### PR TITLE
proto: LogicalField as resolution output (design prototype)

### DIFF
--- a/pkg/modules/rulestatehistory/implrulestatehistory/condition_builder.go
+++ b/pkg/modules/rulestatehistory/implrulestatehistory/condition_builder.go
@@ -40,7 +40,8 @@ func (c *conditionBuilder) ConditionFor(
 		return nil, nil, err
 	}
 
-	keys, warning := querybuilder.ResolveKeys(key, querybuilder.MatchingFieldKeys(key, fieldKeys))
+	logicalFields, warning := querybuilder.ResolveLogicalFields(key, querybuilder.MatchingLogicalFields(key, fieldKeys))
+	keys := querybuilder.SingleKeys(logicalFields)
 	var warnings []string
 	if warning != "" {
 		warnings = append(warnings, warning)

--- a/pkg/querybuilder/exists_expr.go
+++ b/pkg/querybuilder/exists_expr.go
@@ -2,32 +2,12 @@ package querybuilder
 
 import (
 	"fmt"
-	"strings"
 
 	schema "github.com/SigNoz/signoz-otel-collector/cmd/signozschemamigrator/schema_migrator"
 	"github.com/SigNoz/signoz/pkg/errors"
 	qbtypes "github.com/SigNoz/signoz/pkg/types/querybuildertypes/querybuildertypesv5"
 	"github.com/SigNoz/signoz/pkg/types/telemetrytypes"
 )
-
-func physicalSemconvMembers(key *telemetrytypes.TelemetryFieldKey) []string {
-	if len(key.SemconvMembers) > 0 {
-		return key.SemconvMembers
-	}
-	return []string{key.Name}
-}
-
-func mapMemberExistenceExpression(column string, key *telemetrytypes.TelemetryFieldKey, member string) string {
-	if materializedColumn, ok := key.SemconvMaterializedColumns[member]; ok {
-		return ClickHouseIdentifier(materializedColumn + "_exists")
-	}
-	if key.Materialized && key.Name == member {
-		physicalKey := key.Copy()
-		physicalKey.Name = member
-		return telemetrytypes.FieldKeyToMaterializedColumnNameForExists(physicalKey)
-	}
-	return fmt.Sprintf("mapContains(%s, %s)", column, ClickHouseStringLiteral(member))
-}
 
 // ExistsExpression renders the existence predicate for a key resolved to the given
 // columns (negated when exists is false). Comparisons are against constants rendered
@@ -63,26 +43,11 @@ func ExistsExpression(columns []*schema.Column, key *telemetrytypes.TelemetryFie
 		if len(evolutionsEntries) > 0 && evolutionsEntries[0] != nil {
 			columnName = evolutionsEntries[0].ColumnName
 		}
-		members := physicalSemconvMembers(key)
-		paths := make([]string, 0, len(members))
-		for _, member := range members {
-			paths = append(paths, fmt.Sprintf("%s.%s", columnName, ClickHouseIdentifier(member)))
-		}
-		if len(paths) == 1 {
-			if exists {
-				return paths[0] + " IS NOT NULL", nil
-			}
-			return paths[0] + " IS NULL", nil
-		}
-		guards := make([]string, 0, len(paths))
-		for _, path := range paths {
-			guards = append(guards, path+" IS NOT NULL")
-		}
-		rawPath := "(" + strings.Join(guards, " OR ") + ")"
+		rawPath := fmt.Sprintf("%s.%s", columnName, ClickHouseIdentifier(key.Name))
 		if exists {
-			return rawPath, nil
+			return rawPath + " IS NOT NULL", nil
 		}
-		return "NOT " + rawPath, nil
+		return rawPath + " IS NULL", nil
 	case schema.ColumnTypeEnumString,
 		schema.ColumnTypeEnumFixedString:
 		if exists {
@@ -123,14 +88,9 @@ func ExistsExpression(columns []*schema.Column, key *telemetrytypes.TelemetryFie
 
 		switch valueType := column.Type.(schema.MapColumnType).ValueType; valueType.GetType() {
 		case schema.ColumnTypeEnumString, schema.ColumnTypeEnumBool, schema.ColumnTypeEnumFloat64:
-			members := physicalSemconvMembers(key)
-			operands := make([]string, 0, len(members))
-			for _, member := range members {
-				operands = append(operands, mapMemberExistenceExpression(column.Name, key, member))
-			}
-			leftOperand := strings.Join(operands, " OR ")
-			if len(operands) > 1 {
-				leftOperand = "(" + leftOperand + ")"
+			leftOperand := fmt.Sprintf("mapContains(%s, %s)", column.Name, ClickHouseStringLiteral(key.Name))
+			if key.Materialized {
+				leftOperand = telemetrytypes.FieldKeyToMaterializedColumnNameForExists(key)
 			}
 			if exists {
 				return leftOperand, nil

--- a/pkg/querybuilder/exists_expr_test.go
+++ b/pkg/querybuilder/exists_expr_test.go
@@ -9,19 +9,9 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestExistsExpressionUsesEveryPhysicalSemconvMember(t *testing.T) {
-	key := &telemetrytypes.TelemetryFieldKey{
-		Name:          "deployment.environment.name",
-		FieldContext:  telemetrytypes.FieldContextAttribute,
-		FieldDataType: telemetrytypes.FieldDataTypeString,
-		SemconvMembers: []string{
-			"deployment.environment.name",
-			"deployment.environment",
-		},
-		SemconvMaterializedColumns: map[string]string{
-			"deployment.environment": "attribute_string_deployment$$environment",
-		},
-	}
+// ExistsExpression is a per-physical-key primitive: family composition happens
+// at the logical-field layer, so this only ever sees one spelling.
+func TestExistsExpressionIsPerKey(t *testing.T) {
 	columns := []*schema.Column{{
 		Name: "attributes_string",
 		Type: schema.MapColumnType{
@@ -30,12 +20,22 @@ func TestExistsExpressionUsesEveryPhysicalSemconvMember(t *testing.T) {
 		},
 	}}
 
-	expression, err := ExistsExpression(columns, key, 0, 0, "unused", true)
+	plain := &telemetrytypes.TelemetryFieldKey{
+		Name:          "deployment.environment",
+		FieldContext:  telemetrytypes.FieldContextAttribute,
+		FieldDataType: telemetrytypes.FieldDataTypeString,
+	}
+	expression, err := ExistsExpression(columns, plain, 0, 0, "unused", true)
 	require.NoError(t, err)
+	assert.Equal(t, "mapContains(attributes_string, 'deployment.environment')", expression)
 
-	assert.Equal(
-		t,
-		"(mapContains(attributes_string, 'deployment.environment.name') OR `attribute_string_deployment$$environment_exists`)",
-		expression,
-	)
+	materialized := &telemetrytypes.TelemetryFieldKey{
+		Name:          "deployment.environment",
+		FieldContext:  telemetrytypes.FieldContextAttribute,
+		FieldDataType: telemetrytypes.FieldDataTypeString,
+		Materialized:  true,
+	}
+	expression, err = ExistsExpression(columns, materialized, 0, 0, "unused", false)
+	require.NoError(t, err)
+	assert.Equal(t, "NOT `attribute_string_deployment$$environment_exists`", expression)
 }

--- a/pkg/querybuilder/key_resolution.go
+++ b/pkg/querybuilder/key_resolution.go
@@ -21,24 +21,25 @@ const (
 	hasTokenFunctionDocURL       = "https://signoz.io/docs/userguide/functions-reference/#hastoken-function"
 )
 
-// ResolveKeys picks which matching field keys a filter term builds conditions for.
-// With 0 or 1 match it returns the input unchanged and no warning. When a name is
-// ambiguous it returns a warning; a resource+attribute mix defaults to the resource
-// keys (the common intent), noted in the warning.
-func ResolveKeys(field *telemetrytypes.TelemetryFieldKey, fieldKeysForName []*telemetrytypes.TelemetryFieldKey) ([]*telemetrytypes.TelemetryFieldKey, string) {
-	if len(fieldKeysForName) <= 1 {
-		return fieldKeysForName, ""
+// ResolveLogicalFields picks which logical fields a filter term builds conditions
+// for. With 0 or 1 field it returns the input unchanged and no warning. When a
+// name is ambiguous (several logical fields — a family is one field and never
+// ambiguous with itself) it returns a warning; a resource+attribute mix defaults
+// to the resource fields (the common intent), noted in the warning.
+func ResolveLogicalFields(field *telemetrytypes.TelemetryFieldKey, logicalFields []*telemetrytypes.LogicalField) ([]*telemetrytypes.LogicalField, string) {
+	if len(logicalFields) <= 1 {
+		return logicalFields, ""
 	}
 
 	warning := fmt.Sprintf(
 		"Key `%s` is ambiguous, found %d different combinations of field context / data type: %v.",
 		field.Name,
-		len(fieldKeysForName),
-		fieldKeysForName,
+		len(logicalFields),
+		logicalFields,
 	)
 
 	hasResource, hasAttribute := false, false
-	for _, item := range fieldKeysForName {
+	for _, item := range logicalFields {
 		switch item.FieldContext {
 		case telemetrytypes.FieldContextResource:
 			hasResource = true
@@ -49,18 +50,28 @@ func ResolveKeys(field *telemetrytypes.TelemetryFieldKey, fieldKeysForName []*te
 
 	// when there is both resource and attribute context, default to resource only
 	if hasResource && hasAttribute {
-		filteredKeys := make([]*telemetrytypes.TelemetryFieldKey, 0, len(fieldKeysForName))
-		for _, item := range fieldKeysForName {
+		filtered := make([]*telemetrytypes.LogicalField, 0, len(logicalFields))
+		for _, item := range logicalFields {
 			if item.FieldContext == telemetrytypes.FieldContextResource {
-				filteredKeys = append(filteredKeys, item)
+				filtered = append(filtered, item)
 			}
 		}
-		fieldKeysForName = filteredKeys
+		logicalFields = filtered
 		warning += " " + "Using `resource` context by default. To query attributes explicitly, " +
 			fmt.Sprintf("use the fully qualified name (e.g., 'attribute.%s')", field.Name)
 	}
 
-	return fieldKeysForName, warning
+	return logicalFields, warning
+}
+
+// WrapAsLogicalFields wraps physical keys (candidate or synthesized) as
+// single-member logical fields addressed by the requested spelling.
+func WrapAsLogicalFields(requestedName string, keys []*telemetrytypes.TelemetryFieldKey) []*telemetrytypes.LogicalField {
+	fields := make([]*telemetrytypes.LogicalField, 0, len(keys))
+	for _, key := range keys {
+		fields = append(fields, telemetrytypes.SingleLogicalField(requestedName, key))
+	}
+	return fields
 }
 
 // NewKeyNotFoundError builds the error a condition builder returns when a filter term
@@ -174,4 +185,16 @@ func NewFunctionUnsupportedError(operator qbtypes.FilterOperator) error {
 	default:
 		return nil
 	}
+}
+
+// SingleKeys flattens single-member logical fields to their member keys. It is
+// the adapter for signals whose fields are never families (everything except
+// traces today); a family in the input would be silently narrowed, so callers
+// must be gated signals.
+func SingleKeys(fields []*telemetrytypes.LogicalField) []*telemetrytypes.TelemetryFieldKey {
+	keys := make([]*telemetrytypes.TelemetryFieldKey, 0, len(fields))
+	for _, logical := range fields {
+		keys = append(keys, logical.Single())
+	}
+	return keys
 }

--- a/pkg/querybuilder/semconv_materialization_test.go
+++ b/pkg/querybuilder/semconv_materialization_test.go
@@ -12,6 +12,9 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+// A promoted historical member keeps its materialized column inside the family
+// expression: the member key carries its own Materialized state, so the
+// logical-field merge needs no sibling bookkeeping.
 func TestTraceFamilyUsesMaterializedHistoricalMember(t *testing.T) {
 	current := &telemetrytypes.TelemetryFieldKey{
 		Name:          "deployment.environment.name",
@@ -32,12 +35,13 @@ func TestTraceFamilyUsesMaterializedHistoricalMember(t *testing.T) {
 		telemetrytypes.FieldDataTypeString,
 	)
 
-	matches := querybuilder.MatchingFieldKeys(requested, map[string][]*telemetrytypes.TelemetryFieldKey{
+	matches := querybuilder.MatchingLogicalFields(requested, map[string][]*telemetrytypes.TelemetryFieldKey{
 		current.Name:    {current},
 		historical.Name: {historical},
 	})
 	require.Len(t, matches, 1, "family metadata should resolve to one logical field")
-	expression, err := tracestelemetryschema.NewFieldMapper().FieldFor(context.Background(), valuer.UUID{}, 0, 0, matches[0])
+
+	expression, err := tracestelemetryschema.NewFieldMapper().FieldForLogical(context.Background(), valuer.UUID{}, 0, 0, matches[0])
 	require.NoError(t, err, "resolved trace family should map to a value expression")
 
 	assert.Equal(

--- a/pkg/querybuilder/where_clause_visitor.go
+++ b/pkg/querybuilder/where_clause_visitor.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
-	"maps"
 	"slices"
 	"strconv"
 	"strings"
@@ -362,7 +361,7 @@ func (v *filterExpressionVisitor) VisitPrimary(ctx *grammar.PrimaryContext) any 
 				return ErrorConditionLiteral
 			}
 		}
-		conds, ok := v.buildConditions(v.fullTextColumn, []*telemetrytypes.TelemetryFieldKey{v.fullTextColumn}, qbtypes.FilterOperatorRegexp, FormatFullTextSearch(searchText))
+		conds, ok := v.buildConditions(v.fullTextColumn, []*telemetrytypes.LogicalField{telemetrytypes.SingleLogicalField(v.fullTextColumn.Name, v.fullTextColumn)}, qbtypes.FilterOperatorRegexp, FormatFullTextSearch(searchText))
 		if !ok {
 			return ErrorConditionLiteral
 		}
@@ -381,7 +380,7 @@ func (v *filterExpressionVisitor) VisitPrimary(ctx *grammar.PrimaryContext) any 
 // VisitComparison handles all comparison operators.
 func (v *filterExpressionVisitor) VisitComparison(ctx *grammar.ComparisonContext) any {
 	key := v.Visit(ctx.Key()).(*telemetrytypes.TelemetryFieldKey)
-	matching := MatchingFieldKeys(key, v.fieldKeys)
+	matching := MatchingLogicalFields(key, v.fieldKeys)
 
 	// Handle EXISTS specially
 	if ctx.EXISTS() != nil {
@@ -677,7 +676,7 @@ func (v *filterExpressionVisitor) VisitFullText(ctx *grammar.FullTextContext) an
 		v.errors = append(v.errors, "full text search is not supported")
 		return ErrorConditionLiteral
 	}
-	conds, ok := v.buildConditions(v.fullTextColumn, []*telemetrytypes.TelemetryFieldKey{v.fullTextColumn}, qbtypes.FilterOperatorRegexp, FormatFullTextSearch(text))
+	conds, ok := v.buildConditions(v.fullTextColumn, []*telemetrytypes.LogicalField{telemetrytypes.SingleLogicalField(v.fullTextColumn.Name, v.fullTextColumn)}, qbtypes.FilterOperatorRegexp, FormatFullTextSearch(text))
 	if !ok {
 		return ErrorConditionLiteral
 	}
@@ -732,7 +731,7 @@ func (v *filterExpressionVisitor) VisitFunctionCall(ctx *grammar.FunctionCallCon
 		return ErrorConditionLiteral
 	}
 
-	conds, ok := v.buildConditions(key, MatchingFieldKeys(key, v.fieldKeys), operator, value)
+	conds, ok := v.buildConditions(key, MatchingLogicalFields(key, v.fieldKeys), operator, value)
 	if !ok {
 		return ErrorConditionLiteral
 	}
@@ -924,7 +923,7 @@ func (v *filterExpressionVisitor) VisitKey(ctx *grammar.KeyContext) any {
 
 // buildConditions invokes the condition builder for a filter term, folding its
 // warnings/errors into visitor state; returns false if an error was recorded.
-func (v *filterExpressionVisitor) buildConditions(key *telemetrytypes.TelemetryFieldKey, matching []*telemetrytypes.TelemetryFieldKey, op qbtypes.FilterOperator, value any) ([]string, bool) {
+func (v *filterExpressionVisitor) buildConditions(key *telemetrytypes.TelemetryFieldKey, matching []*telemetrytypes.LogicalField, op qbtypes.FilterOperator, value any) ([]string, bool) {
 	conds, warns, err := v.conditionBuilder.ConditionFor(v.context, v.orgID, v.startNs, v.endNs, key, v.fieldKeys, qbtypes.ConditionBuilderOptions{SkipResourceFilter: v.skipResourceFilter}, op, value, v.builder)
 	if err != nil {
 		_, _, _, _, errURL, _ := errors.Unwrapb(err)
@@ -981,23 +980,43 @@ func assignIfEmpty(s *string, value string) {
 	}
 }
 
-// MatchingFieldKeys returns the field keys from the map that match the given key,
-// honoring any context/data type the user specified.
-func MatchingFieldKeys(field *telemetrytypes.TelemetryFieldKey, fieldKeys map[string][]*telemetrytypes.TelemetryFieldKey) []*telemetrytypes.TelemetryFieldKey {
-	selector := telemetrytypes.FieldKeySelector{
+// familyMemberNames returns the physical spellings to look up for the
+// referenced key: the semantic-convention family members (current-first) when
+// the key can resolve to traces, else just the requested name. Only trace
+// field mappers understand families today; logs and metrics keep the
+// requested spelling until theirs land.
+func familyMemberNames(field *telemetrytypes.TelemetryFieldKey) []string {
+	if field.Signal != telemetrytypes.SignalUnspecified && field.Signal != telemetrytypes.SignalTraces {
+		return []string{field.Name}
+	}
+	return semconv.Members(semconv.KindAttribute, telemetrytypes.FieldKeySelector{
 		Name:         field.Name,
 		Signal:       telemetrytypes.SignalTraces,
 		FieldContext: field.FieldContext,
+	})
+}
+
+// MatchingLogicalFields resolves the referenced key against the metadata map
+// into logical fields, honoring any context/data type the user specified.
+//
+// Physical keys that are members of one semantic-convention family (traces
+// only today) group into a single logical field per (signal, context, data
+// type) identity, members ordered current-first. Every other matching key
+// becomes its own single-member logical field. Ambiguity is therefore the
+// length of the returned slice, and a family is never ambiguous with itself.
+// Members alias the metadata map entries; nothing is copied or mutated.
+func MatchingLogicalFields(field *telemetrytypes.TelemetryFieldKey, fieldKeys map[string][]*telemetrytypes.TelemetryFieldKey) []*telemetrytypes.LogicalField {
+	members := familyMemberNames(field)
+	memberRank := make(map[string]int, len(members))
+	for i, member := range members {
+		memberRank[member] = i
 	}
-	members := []string{field.Name}
-	// Only trace field mappers understand semantic-convention families today.
-	// Logs and metrics must keep using the requested spelling until theirs land.
-	if field.Signal == telemetrytypes.SignalUnspecified || field.Signal == telemetrytypes.SignalTraces {
-		members = semconv.Members(semconv.KindAttribute, selector)
-	}
-	isFamily := len(members) > 1
-	fieldKeysForName := make([]*telemetrytypes.TelemetryFieldKey, 0)
+
+	fields := make([]*telemetrytypes.LogicalField, 0)
 	indexByIdentity := make(map[string]int)
+	// rank of the family member each physical key matched under; the stored
+	// name of a context-prefixed match differs from the member name.
+	ranks := make(map[*telemetrytypes.TelemetryFieldKey]int)
 
 	appendMatches := func(lookupName string, memberName string, contextAlreadyMatched bool) {
 		for _, item := range fieldKeys[lookupName] {
@@ -1011,7 +1030,7 @@ func MatchingFieldKeys(field *telemetrytypes.TelemetryFieldKey, fieldKeys map[st
 			// A wildcard lookup may have found a same-named field in a scope where
 			// this family does not apply. Keep exact names, but reject cross-member
 			// matches outside the generated family scope.
-			traceFamilyMatch := isFamily && item.Signal == telemetrytypes.SignalTraces
+			traceFamilyMatch := len(members) > 1 && item.Signal == telemetrytypes.SignalTraces
 			if memberName != field.Name {
 				if !traceFamilyMatch {
 					continue
@@ -1026,53 +1045,38 @@ func MatchingFieldKeys(field *telemetrytypes.TelemetryFieldKey, fieldKeys map[st
 				}
 			}
 
-			physicalMembers := item.SemconvMembers
-			if len(physicalMembers) == 0 {
-				physicalMembers = []string{memberName}
+			if !traceFamilyMatch {
+				fields = append(fields, telemetrytypes.SingleLogicalField(field.Name, item))
+				continue
 			}
-			materializedColumns := maps.Clone(item.SemconvMaterializedColumns)
-			if item.Materialized {
-				if materializedColumns == nil {
-					materializedColumns = make(map[string]string)
-				}
-				physicalKey := item.Copy()
-				physicalKey.Name = memberName
-				materializedColumns[memberName] = strings.Trim(telemetrytypes.FieldKeyToMaterializedColumnName(physicalKey), "`")
-			}
+
 			identity := item.Signal.StringValue() + ";" + item.FieldContext.StringValue() + ";" + item.FieldDataType.StringValue()
-			if traceFamilyMatch {
-				if index, found := indexByIdentity[identity]; found {
-					for _, physicalMember := range physicalMembers {
-						if !slices.Contains(fieldKeysForName[index].SemconvMembers, physicalMember) {
-							fieldKeysForName[index].SemconvMembers = append(fieldKeysForName[index].SemconvMembers, physicalMember)
-						}
-					}
-					if len(materializedColumns) > 0 {
-						if fieldKeysForName[index].SemconvMaterializedColumns == nil {
-							fieldKeysForName[index].SemconvMaterializedColumns = make(map[string]string)
-						}
-						maps.Copy(fieldKeysForName[index].SemconvMaterializedColumns, materializedColumns)
-					}
-					continue
+			index, found := indexByIdentity[identity]
+			if !found {
+				index = len(fields)
+				indexByIdentity[identity] = index
+				fields = append(fields, &telemetrytypes.LogicalField{
+					Name:          field.Name,
+					Signal:        item.Signal,
+					FieldContext:  item.FieldContext,
+					FieldDataType: item.FieldDataType,
+				})
+			}
+			logical := fields[index]
+			duplicate := false
+			for _, existing := range logical.Members {
+				if existing.Name == item.Name {
+					duplicate = true
+					break
 				}
-				indexByIdentity[identity] = len(fieldKeysForName)
 			}
-			resolved := item.Copy()
-			// The requested spelling is the response identity. Field mappers use
-			// it to resolve the available family members current-first.
-			if traceFamilyMatch {
-				resolved.Name = field.Name
-				resolved.SemconvMembers = slices.Clone(physicalMembers)
-				resolved.SemconvMaterializedColumns = materializedColumns
-				// Materialization is member-specific after family keys are merged.
-				resolved.Materialized = false
+			if !duplicate {
+				ranks[item] = memberRank[memberName]
+				logical.Members = append(logical.Members, item)
 			}
-			fieldKeysForName = append(fieldKeysForName, resolved)
 		}
 	}
 
-	// Members are current-first, so metadata from the current key wins when
-	// both spellings describe the same signal/context/type.
 	for _, member := range members {
 		appendMatches(member, member, false)
 	}
@@ -1086,5 +1090,13 @@ func MatchingFieldKeys(field *telemetrytypes.TelemetryFieldKey, fieldKeys map[st
 		}
 	}
 
-	return fieldKeysForName
+	// Precedence is a property of the family, not of arrival order: members
+	// sort current-first no matter which lookup pass found them.
+	for _, logical := range fields {
+		slices.SortStableFunc(logical.Members, func(a, b *telemetrytypes.TelemetryFieldKey) int {
+			return ranks[a] - ranks[b]
+		})
+	}
+
+	return fields
 }

--- a/pkg/querybuilder/where_clause_visitor_test.go
+++ b/pkg/querybuilder/where_clause_visitor_test.go
@@ -590,8 +590,8 @@ func TestVisitKey(t *testing.T) {
 			// VisitKey only parses; the condition builder matches, resolves ambiguity
 			// and decides not-found handling. Replay that here against the generic
 			// builder behavior (error unless the key is ignored).
-			matching := MatchingFieldKeys(key, tt.fieldKeys)
-			keys, warning := ResolveKeys(key, matching)
+			matching := MatchingLogicalFields(key, tt.fieldKeys)
+			keys, warning := ResolveLogicalFields(key, matching)
 
 			var gotErrors []string
 			var gotMainErrURL, gotMainWrnURL string
@@ -613,15 +613,19 @@ func TestVisitKey(t *testing.T) {
 				t.Errorf("expected %d keys, got %d", len(tt.expectedKeys), len(keys))
 			}
 
-			// Check each expected key matches name, field context, and data type
+			// Check each expected key matches a member's stored name plus the
+			// logical field's context and data type (the logical Name is the
+			// requested spelling, members keep the stored spellings).
 			for _, expectedKey := range tt.expectedKeys {
 				found := false
-				for _, key := range keys {
-					if key.Name == expectedKey.Name &&
-						key.FieldContext == expectedKey.FieldContext &&
-						key.FieldDataType == expectedKey.FieldDataType {
-						found = true
-						break
+				for _, logical := range keys {
+					for _, member := range logical.Members {
+						if member.Name == expectedKey.Name &&
+							logical.FieldContext == expectedKey.FieldContext &&
+							logical.FieldDataType == expectedKey.FieldDataType {
+							found = true
+							break
+						}
 					}
 				}
 				if !found {
@@ -686,7 +690,15 @@ func TestVisitKey(t *testing.T) {
 	}
 }
 
-func TestMatchingFieldKeysResolvesCurrentTraceNameFromOldMetadata(t *testing.T) {
+func memberNames(logical *telemetrytypes.LogicalField) []string {
+	names := make([]string, 0, len(logical.Members))
+	for _, member := range logical.Members {
+		names = append(names, member.Name)
+	}
+	return names
+}
+
+func TestMatchingLogicalFieldsResolvesCurrentTraceNameFromOldMetadata(t *testing.T) {
 	old := &telemetrytypes.TelemetryFieldKey{
 		Name:          "deployment.environment",
 		Description:   "old metadata",
@@ -700,25 +712,23 @@ func TestMatchingFieldKeysResolvesCurrentTraceNameFromOldMetadata(t *testing.T) 
 		telemetrytypes.FieldDataTypeString,
 	)
 
-	matches := MatchingFieldKeys(requested, map[string][]*telemetrytypes.TelemetryFieldKey{old.Name: {old}})
+	matches := MatchingLogicalFields(requested, map[string][]*telemetrytypes.TelemetryFieldKey{old.Name: {old}})
 
-	require.Len(t, matches, 1, "trace family lookup must resolve before inspecting metadata")
-	assert.Equal(t, "deployment.environment.name", matches[0].Name)
-	assert.Equal(t, "old metadata", matches[0].Description)
-	assert.Equal(t, []string{"deployment.environment"}, matches[0].SemconvMembers)
+	require.Len(t, matches, 1, "a family is one logical field, not an ambiguity")
+	assert.Equal(t, "deployment.environment.name", matches[0].Name, "the requested spelling is the response identity")
+	assert.Equal(t, []string{"deployment.environment"}, memberNames(matches[0]))
+	assert.Same(t, old, matches[0].Members[0], "members alias metadata entries; nothing is copied")
 }
 
-func TestMatchingFieldKeysUsesCurrentTraceMetadataForOldName(t *testing.T) {
+func TestMatchingLogicalFieldsGroupsFamilyMembersCurrentFirst(t *testing.T) {
 	current := &telemetrytypes.TelemetryFieldKey{
 		Name:          "deployment.environment.name",
-		Description:   "current metadata",
 		Signal:        telemetrytypes.SignalTraces,
 		FieldContext:  telemetrytypes.FieldContextResource,
 		FieldDataType: telemetrytypes.FieldDataTypeString,
 	}
 	old := &telemetrytypes.TelemetryFieldKey{
 		Name:          "deployment.environment",
-		Description:   "old metadata",
 		Signal:        telemetrytypes.SignalTraces,
 		FieldContext:  telemetrytypes.FieldContextResource,
 		FieldDataType: telemetrytypes.FieldDataTypeString,
@@ -729,18 +739,50 @@ func TestMatchingFieldKeysUsesCurrentTraceMetadataForOldName(t *testing.T) {
 		telemetrytypes.FieldDataTypeString,
 	)
 
-	matches := MatchingFieldKeys(requested, map[string][]*telemetrytypes.TelemetryFieldKey{
+	matches := MatchingLogicalFields(requested, map[string][]*telemetrytypes.TelemetryFieldKey{
 		current.Name: {current},
 		old.Name:     {old},
 	})
 
-	require.Len(t, matches, 1, "trace family lookup must resolve before inspecting metadata")
-	assert.Equal(t, old.Name, matches[0].Name)
-	assert.Equal(t, "current metadata", matches[0].Description)
-	assert.Equal(t, []string{current.Name, old.Name}, matches[0].SemconvMembers)
+	require.Len(t, matches, 1, "a family is one logical field, not an ambiguity")
+	assert.Equal(t, old.Name, matches[0].Name, "the requested spelling is the response identity")
+	assert.True(t, matches[0].IsFamily())
+	assert.Equal(t, []string{current.Name, old.Name}, memberNames(matches[0]), "members order current-first")
 }
 
-func TestMatchingFieldKeysKeepsLogSemconvNamesLiteral(t *testing.T) {
+// Precedence is a property of the family, not of arrival order: a member that
+// only exists under its context-prefixed stored spelling still sorts by its
+// family rank.
+func TestMatchingLogicalFieldsOrdersMembersByFamilyRank(t *testing.T) {
+	old := &telemetrytypes.TelemetryFieldKey{
+		Name:          "deployment.environment",
+		Signal:        telemetrytypes.SignalTraces,
+		FieldContext:  telemetrytypes.FieldContextResource,
+		FieldDataType: telemetrytypes.FieldDataTypeString,
+	}
+	prefixedCurrent := &telemetrytypes.TelemetryFieldKey{
+		Name:          "resource.deployment.environment.name",
+		Signal:        telemetrytypes.SignalTraces,
+		FieldContext:  telemetrytypes.FieldContextResource,
+		FieldDataType: telemetrytypes.FieldDataTypeString,
+	}
+	requested := telemetrytypes.NewTelemetryFieldKey(
+		"deployment.environment.name",
+		telemetrytypes.FieldContextResource,
+		telemetrytypes.FieldDataTypeString,
+	)
+
+	matches := MatchingLogicalFields(requested, map[string][]*telemetrytypes.TelemetryFieldKey{
+		old.Name:             {old},
+		prefixedCurrent.Name: {prefixedCurrent},
+	})
+
+	require.Len(t, matches, 1)
+	assert.Equal(t, []string{prefixedCurrent.Name, old.Name}, memberNames(matches[0]),
+		"the current-spelling member must coalesce before the old one")
+}
+
+func TestMatchingLogicalFieldsKeepsLogSemconvNamesLiteral(t *testing.T) {
 	current := &telemetrytypes.TelemetryFieldKey{
 		Name:          "deployment.environment.name",
 		Signal:        telemetrytypes.SignalLogs,
@@ -759,17 +801,17 @@ func TestMatchingFieldKeysKeepsLogSemconvNamesLiteral(t *testing.T) {
 		telemetrytypes.FieldDataTypeString,
 	)
 
-	matches := MatchingFieldKeys(requested, map[string][]*telemetrytypes.TelemetryFieldKey{
+	matches := MatchingLogicalFields(requested, map[string][]*telemetrytypes.TelemetryFieldKey{
 		current.Name: {current},
 		old.Name:     {old},
 	})
 
 	require.Len(t, matches, 1, "log lookup must keep the requested spelling literal")
-	assert.Equal(t, current.Name, matches[0].Name)
-	assert.Empty(t, matches[0].SemconvMembers)
+	assert.False(t, matches[0].IsFamily())
+	assert.Equal(t, current.Name, matches[0].Single().Name)
 }
 
-func TestMatchingFieldKeysKeepsMetricSemconvNamesLiteral(t *testing.T) {
+func TestMatchingLogicalFieldsKeepsMetricSemconvNamesLiteral(t *testing.T) {
 	current := &telemetrytypes.TelemetryFieldKey{
 		Name:          "deployment.environment.name",
 		Signal:        telemetrytypes.SignalMetrics,
@@ -788,14 +830,14 @@ func TestMatchingFieldKeysKeepsMetricSemconvNamesLiteral(t *testing.T) {
 		telemetrytypes.FieldDataTypeString,
 	)
 
-	matches := MatchingFieldKeys(requested, map[string][]*telemetrytypes.TelemetryFieldKey{
+	matches := MatchingLogicalFields(requested, map[string][]*telemetrytypes.TelemetryFieldKey{
 		current.Name: {current},
 		old.Name:     {old},
 	})
 
 	require.Len(t, matches, 1, "metric lookup must keep the requested spelling literal")
-	assert.Equal(t, current.Name, matches[0].Name)
-	assert.Empty(t, matches[0].SemconvMembers)
+	assert.False(t, matches[0].IsFamily())
+	assert.Equal(t, current.Name, matches[0].Single().Name)
 }
 
 // ---------------------------------------------------------------------------
@@ -879,7 +921,7 @@ func (b *resourceConditionBuilder) ConditionFor(
 		return nil, nil, nil
 	}
 
-	keys, warning := ResolveKeys(key, MatchingFieldKeys(key, fieldKeys))
+	keys, warning := ResolveLogicalFields(key, MatchingLogicalFields(key, fieldKeys))
 	var warnings []string
 	if warning != "" {
 		warnings = append(warnings, warning)
@@ -887,11 +929,11 @@ func (b *resourceConditionBuilder) ConditionFor(
 
 	var conds []string
 	for _, k := range keys {
-		// only resource keys contribute; others (and unknown keys) are ignored
+		// only resource fields contribute; others (and unknown keys) are ignored
 		if k.FieldContext != telemetrytypes.FieldContextResource {
 			continue
 		}
-		conds = append(conds, fmt.Sprintf("%s_cond", k.Name))
+		conds = append(conds, fmt.Sprintf("%s_cond", k.Single().Name))
 	}
 	return conds, warnings, nil
 }
@@ -921,7 +963,7 @@ func (b *conditionBuilder) ConditionFor(
 		return []string{fmt.Sprintf("%s_cond", key.Name)}, nil, nil
 	}
 
-	keys, warning := ResolveKeys(key, MatchingFieldKeys(key, fieldKeys))
+	keys, warning := ResolveLogicalFields(key, MatchingLogicalFields(key, fieldKeys))
 	var warnings []string
 	if warning != "" {
 		warnings = append(warnings, warning)
@@ -933,7 +975,7 @@ func (b *conditionBuilder) ConditionFor(
 
 	// A resource sub-query already covers the term; drop resource keys from the main query.
 	if options.SkipResourceFilter {
-		filtered := make([]*telemetrytypes.TelemetryFieldKey, 0, len(keys))
+		filtered := make([]*telemetrytypes.LogicalField, 0, len(keys))
 		for _, k := range keys {
 			if k.FieldContext != telemetrytypes.FieldContextResource {
 				filtered = append(filtered, k)

--- a/pkg/statementbuilder/resourcefilter/condition_builder.go
+++ b/pkg/statementbuilder/resourcefilter/condition_builder.go
@@ -13,12 +13,14 @@ import (
 )
 
 type defaultConditionBuilder struct {
-	fm qbtypes.FieldMapper
+	// The builder composes family expressions, so it needs this package's
+	// mapper, not the narrower qbtypes.FieldMapper.
+	fm *defaultFieldMapper
 }
 
 var _ qbtypes.ConditionBuilder = (*defaultConditionBuilder)(nil)
 
-func NewConditionBuilder(fm qbtypes.FieldMapper) *defaultConditionBuilder {
+func NewConditionBuilder(fm *defaultFieldMapper) *defaultConditionBuilder {
 	return &defaultConditionBuilder{fm: fm}
 }
 
@@ -44,16 +46,10 @@ func keyIndexFilter(key *telemetrytypes.TelemetryFieldKey) any {
 	return fmt.Sprintf(`%%%s%%`, key.Name)
 }
 
-func memberKey(key *telemetrytypes.TelemetryFieldKey, name string) *telemetrytypes.TelemetryFieldKey {
-	member := key.Copy()
-	member.Name = name
-	return member
-}
-
-func keyIndexCondition(sb *sqlbuilder.SelectBuilder, column string, key *telemetrytypes.TelemetryFieldKey, members []string) string {
+func keyIndexCondition(sb *sqlbuilder.SelectBuilder, column string, members []*telemetrytypes.TelemetryFieldKey) string {
 	conditions := make([]string, 0, len(members))
 	for _, member := range members {
-		conditions = append(conditions, sb.Like(column, keyIndexFilter(memberKey(key, member))))
+		conditions = append(conditions, sb.Like(column, keyIndexFilter(member)))
 	}
 	if len(conditions) == 1 {
 		return conditions[0]
@@ -64,15 +60,14 @@ func keyIndexCondition(sb *sqlbuilder.SelectBuilder, column string, key *telemet
 func valueIndexCondition(
 	sb *sqlbuilder.SelectBuilder,
 	column string,
-	key *telemetrytypes.TelemetryFieldKey,
-	members []string,
+	members []*telemetrytypes.TelemetryFieldKey,
 	op qbtypes.FilterOperator,
 	value any,
 	caseInsensitive bool,
 ) string {
 	conditions := make([]string, 0, len(members))
 	for _, member := range members {
-		patterns := valueForIndexFilter(op, memberKey(key, member), value)
+		patterns := valueForIndexFilter(op, member, value)
 		switch values := patterns.(type) {
 		case []string:
 			for _, pattern := range values {
@@ -92,10 +87,10 @@ func valueIndexCondition(
 	return sb.Or(conditions...)
 }
 
-func memberPresenceCondition(sb *sqlbuilder.SelectBuilder, column string, members []string, exists bool) string {
+func memberPresenceCondition(sb *sqlbuilder.SelectBuilder, column string, members []*telemetrytypes.TelemetryFieldKey, exists bool) string {
 	conditions := make([]string, 0, len(members))
 	for _, member := range members {
-		field := fmt.Sprintf("simpleJSONHas(%s, %s)", column, querybuilder.ClickHouseStringLiteral(member))
+		field := fmt.Sprintf("simpleJSONHas(%s, %s)", column, querybuilder.ClickHouseStringLiteral(member.Name))
 		if exists {
 			conditions = append(conditions, sb.E(field, true))
 		} else {
@@ -124,7 +119,7 @@ func (b *defaultConditionBuilder) ConditionFor(
 	value any,
 	sb *sqlbuilder.SelectBuilder,
 ) ([]string, []string, error) {
-	matches := querybuilder.MatchingFieldKeys(key, fieldKeys)
+	matches := querybuilder.MatchingLogicalFields(key, fieldKeys)
 
 	// has/hasAny/hasAll/hasToken are logs-body-only functions; they never apply to the
 	// resource fingerprint table, so skip them (the main query still evaluates them).
@@ -132,21 +127,21 @@ func (b *defaultConditionBuilder) ConditionFor(
 		return nil, nil, nil
 	}
 
-	keys, warning := querybuilder.ResolveKeys(key, matches)
+	logicalFields, warning := querybuilder.ResolveLogicalFields(key, matches)
 	var warnings []string
 	if warning != "" {
 		warnings = append(warnings, warning)
 	}
 
-	conds := make([]string, 0, len(keys))
-	for _, k := range keys {
-		// the resource fingerprint table only stores resource attributes; keys from
+	conds := make([]string, 0, len(logicalFields))
+	for _, logical := range logicalFields {
+		// the resource fingerprint table only stores resource attributes; fields from
 		// any other context contribute no condition and are omitted. An empty result
 		// (including an unknown key) lets the caller skip this filter entirely.
-		if k.FieldContext != telemetrytypes.FieldContextResource {
+		if logical.FieldContext != telemetrytypes.FieldContextResource {
 			continue
 		}
-		cond, err := b.conditionForKey(ctx, startNs, endNs, k, op, value, sb)
+		cond, err := b.conditionForLogicalField(ctx, startNs, endNs, logical, op, value, sb)
 		if err != nil {
 			return nil, nil, err
 		}
@@ -155,11 +150,11 @@ func (b *defaultConditionBuilder) ConditionFor(
 	return conds, warnings, nil
 }
 
-func (b *defaultConditionBuilder) conditionForKey(
+func (b *defaultConditionBuilder) conditionForLogicalField(
 	ctx context.Context,
 	startNs uint64,
 	endNs uint64,
-	key *telemetrytypes.TelemetryFieldKey,
+	logical *telemetrytypes.LogicalField,
 	op qbtypes.FilterOperator,
 	value any,
 	sb *sqlbuilder.SelectBuilder,
@@ -169,7 +164,7 @@ func (b *defaultConditionBuilder) conditionForKey(
 	// as we store resource values as string
 	formattedValue := querybuilder.FormatValueForContains(value)
 
-	columns, err := b.fm.ColumnFor(ctx, valuer.UUID{}, startNs, endNs, key)
+	columns, err := b.fm.ColumnFor(ctx, valuer.UUID{}, startNs, endNs, logical.Single())
 	if err != nil {
 		return "", err
 	}
@@ -182,12 +177,12 @@ func (b *defaultConditionBuilder) conditionForKey(
 	// as we have not changed the resource column in the resource fingerprint table.
 	column := columns[0]
 
-	members := resourceSemconvMembers(key)
-	isFamily := len(members) > 1
-	keyIdxFilter := keyIndexCondition(sb, column.Name, key, members)
-	singleValueIndexFilter := valueForIndexFilter(op, memberKey(key, members[0]), value)
+	members := logical.Members
+	isFamily := logical.IsFamily()
+	keyIdxFilter := keyIndexCondition(sb, column.Name, members)
+	singleValueIndexFilter := valueForIndexFilter(op, members[0], value)
 
-	fieldName, err := b.fm.FieldFor(ctx, valuer.UUID{}, startNs, endNs, key)
+	fieldName, err := b.fm.FieldForLogical(ctx, valuer.UUID{}, startNs, endNs, logical)
 	if err != nil {
 		return "", err
 	}
@@ -197,7 +192,7 @@ func (b *defaultConditionBuilder) conditionForKey(
 		return sb.And(
 			sb.E(fieldName, formattedValue),
 			keyIdxFilter,
-			valueIndexCondition(sb, column.Name, key, members, op, value, false),
+			valueIndexCondition(sb, column.Name, members, op, value, false),
 		), nil
 	case qbtypes.FilterOperatorNotEqual:
 		if isFamily {
@@ -220,7 +215,7 @@ func (b *defaultConditionBuilder) conditionForKey(
 		return sb.And(
 			sb.ILike(fieldName, formattedValue),
 			keyIdxFilter,
-			valueIndexCondition(sb, column.Name, key, members, op, value, true),
+			valueIndexCondition(sb, column.Name, members, op, value, true),
 		), nil
 	case qbtypes.FilterOperatorNotLike, qbtypes.FilterOperatorNotILike:
 		// no index filter: as cannot apply `not contains x%y` as y can be somewhere else
@@ -260,7 +255,7 @@ func (b *defaultConditionBuilder) conditionForKey(
 		mainCondition = sb.And(
 			mainCondition,
 			keyIdxFilter,
-			valueIndexCondition(sb, column.Name, key, members, op, value, false),
+			valueIndexCondition(sb, column.Name, members, op, value, false),
 		)
 
 		return mainCondition, nil
@@ -308,7 +303,7 @@ func (b *defaultConditionBuilder) conditionForKey(
 		return sb.And(
 			sb.ILike(fieldName, fmt.Sprintf(`%%%s%%`, formattedValue)),
 			keyIdxFilter,
-			valueIndexCondition(sb, column.Name, key, members, op, value, true),
+			valueIndexCondition(sb, column.Name, members, op, value, true),
 		), nil
 	case qbtypes.FilterOperatorNotContains:
 		// no index filter: as cannot apply `not contains x%y` as y can be somewhere else

--- a/pkg/statementbuilder/resourcefilter/condition_builder_test.go
+++ b/pkg/statementbuilder/resourcefilter/condition_builder_test.go
@@ -221,24 +221,40 @@ func TestConditionBuilder(t *testing.T) {
 	}
 }
 
-func TestFamilyPositiveFilterExcludesKeylessRows(t *testing.T) {
-	key := &telemetrytypes.TelemetryFieldKey{
-		Name:           "deployment.environment.name",
-		Signal:         telemetrytypes.SignalTraces,
-		FieldContext:   telemetrytypes.FieldContextResource,
-		FieldDataType:  telemetrytypes.FieldDataTypeString,
-		SemconvMembers: []string{"deployment.environment.name", "deployment.environment"},
+// The family tests drive resolution through the metadata map, exactly as
+// production does: two plain member keys in the map, one requested spelling.
+// The keys carry no family bookkeeping — grouping is the resolver's job.
+func familyConditionSQL(t *testing.T, requestedName string, memberNames []string, op qbtypes.FilterOperator, value any) (string, []any) {
+	t.Helper()
+	fieldKeys := map[string][]*telemetrytypes.TelemetryFieldKey{}
+	for _, name := range memberNames {
+		fieldKeys[name] = []*telemetrytypes.TelemetryFieldKey{{
+			Name:          name,
+			Signal:        telemetrytypes.SignalTraces,
+			FieldContext:  telemetrytypes.FieldContextResource,
+			FieldDataType: telemetrytypes.FieldDataTypeString,
+		}}
 	}
+	requested := telemetrytypes.NewTelemetryFieldKey(
+		requestedName,
+		telemetrytypes.FieldContextResource,
+		telemetrytypes.FieldDataTypeString,
+	)
 	sb := sqlbuilder.NewSelectBuilder()
-
 	conditions, _, err := NewConditionBuilder(NewFieldMapper()).ConditionFor(
-		context.Background(), valuer.UUID{}, 0, 0, key,
-		map[string][]*telemetrytypes.TelemetryFieldKey{key.Name: {key}},
-		qbtypes.ConditionBuilderOptions{}, qbtypes.FilterOperatorEqual, "production", sb,
+		context.Background(), valuer.UUID{}, 0, 0, requested,
+		fieldKeys,
+		qbtypes.ConditionBuilderOptions{}, op, value, sb,
 	)
 	require.NoError(t, err)
 	sb.Where(conditions...)
-	sql, args := sb.BuildWithFlavor(sqlbuilder.ClickHouse)
+	return sb.BuildWithFlavor(sqlbuilder.ClickHouse)
+}
+
+var deploymentFamilyMembers = []string{"deployment.environment.name", "deployment.environment"}
+
+func TestFamilyPositiveFilterExcludesKeylessRows(t *testing.T) {
+	sql, args := familyConditionSQL(t, "deployment.environment.name", deploymentFamilyMembers, qbtypes.FilterOperatorEqual, "production")
 
 	assert.Contains(t, sql, "COALESCE(NULLIF(simpleJSONExtractString(labels, 'deployment.environment.name'), ''), NULLIF(simpleJSONExtractString(labels, 'deployment.environment'), ''), '') = ? AND (labels LIKE ? OR labels LIKE ?) AND (labels LIKE ? OR labels LIKE ?)")
 	assert.Equal(t, []any{
@@ -251,164 +267,61 @@ func TestFamilyPositiveFilterExcludesKeylessRows(t *testing.T) {
 }
 
 func TestFamilyNotEqualIncludesKeylessRows(t *testing.T) {
-	key := &telemetrytypes.TelemetryFieldKey{
-		Name:           "deployment.environment.name",
-		Signal:         telemetrytypes.SignalTraces,
-		FieldContext:   telemetrytypes.FieldContextResource,
-		FieldDataType:  telemetrytypes.FieldDataTypeString,
-		SemconvMembers: []string{"deployment.environment.name", "deployment.environment"},
-	}
-	sb := sqlbuilder.NewSelectBuilder()
-
-	conditions, _, err := NewConditionBuilder(NewFieldMapper()).ConditionFor(
-		context.Background(), valuer.UUID{}, 0, 0, key,
-		map[string][]*telemetrytypes.TelemetryFieldKey{key.Name: {key}},
-		qbtypes.ConditionBuilderOptions{}, qbtypes.FilterOperatorNotEqual, "staging", sb,
-	)
-	require.NoError(t, err)
-	sb.Where(conditions...)
-	sql, args := sb.BuildWithFlavor(sqlbuilder.ClickHouse)
+	sql, args := familyConditionSQL(t, "deployment.environment.name", deploymentFamilyMembers, qbtypes.FilterOperatorNotEqual, "staging")
 
 	assert.Contains(t, sql, "COALESCE(NULLIF(simpleJSONExtractString(labels, 'deployment.environment.name'), ''), NULLIF(simpleJSONExtractString(labels, 'deployment.environment'), ''), '') <> ?")
 	assert.Equal(t, []any{"staging"}, args)
 }
 
 func TestFamilyNotInIncludesKeylessRows(t *testing.T) {
-	key := &telemetrytypes.TelemetryFieldKey{
-		Name:           "deployment.environment.name",
-		Signal:         telemetrytypes.SignalTraces,
-		FieldContext:   telemetrytypes.FieldContextResource,
-		FieldDataType:  telemetrytypes.FieldDataTypeString,
-		SemconvMembers: []string{"deployment.environment.name", "deployment.environment"},
-	}
-	sb := sqlbuilder.NewSelectBuilder()
-
-	conditions, _, err := NewConditionBuilder(NewFieldMapper()).ConditionFor(
-		context.Background(), valuer.UUID{}, 0, 0, key,
-		map[string][]*telemetrytypes.TelemetryFieldKey{key.Name: {key}},
-		qbtypes.ConditionBuilderOptions{}, qbtypes.FilterOperatorNotIn, []any{"staging", "dev"}, sb,
-	)
-	require.NoError(t, err)
-	sb.Where(conditions...)
-	sql, args := sb.BuildWithFlavor(sqlbuilder.ClickHouse)
+	sql, args := familyConditionSQL(t, "deployment.environment.name", deploymentFamilyMembers, qbtypes.FilterOperatorNotIn, []any{"staging", "dev"})
 
 	assert.Contains(t, sql, "(COALESCE(NULLIF(simpleJSONExtractString(labels, 'deployment.environment.name'), ''), NULLIF(simpleJSONExtractString(labels, 'deployment.environment'), ''), '') <> ? AND COALESCE(NULLIF(simpleJSONExtractString(labels, 'deployment.environment.name'), ''), NULLIF(simpleJSONExtractString(labels, 'deployment.environment'), ''), '') <> ?)")
 	assert.Equal(t, []any{"staging", "dev"}, args)
 }
 
 func TestFamilyNotLikeIncludesKeylessRows(t *testing.T) {
-	key := &telemetrytypes.TelemetryFieldKey{
-		Name:           "deployment.environment.name",
-		Signal:         telemetrytypes.SignalTraces,
-		FieldContext:   telemetrytypes.FieldContextResource,
-		FieldDataType:  telemetrytypes.FieldDataTypeString,
-		SemconvMembers: []string{"deployment.environment.name", "deployment.environment"},
-	}
-	sb := sqlbuilder.NewSelectBuilder()
-
-	conditions, _, err := NewConditionBuilder(NewFieldMapper()).ConditionFor(
-		context.Background(), valuer.UUID{}, 0, 0, key,
-		map[string][]*telemetrytypes.TelemetryFieldKey{key.Name: {key}},
-		qbtypes.ConditionBuilderOptions{}, qbtypes.FilterOperatorNotLike, "%stag%", sb,
-	)
-	require.NoError(t, err)
-	sb.Where(conditions...)
-	sql, args := sb.BuildWithFlavor(sqlbuilder.ClickHouse)
+	sql, args := familyConditionSQL(t, "deployment.environment.name", deploymentFamilyMembers, qbtypes.FilterOperatorNotLike, "%stag%")
 
 	assert.Contains(t, sql, "LOWER(COALESCE(NULLIF(simpleJSONExtractString(labels, 'deployment.environment.name'), ''), NULLIF(simpleJSONExtractString(labels, 'deployment.environment'), ''), '')) NOT LIKE LOWER(?)")
 	assert.Equal(t, []any{"%stag%"}, args)
 }
 
 func TestFamilyNotContainsIncludesKeylessRows(t *testing.T) {
-	key := &telemetrytypes.TelemetryFieldKey{
-		Name:           "deployment.environment.name",
-		Signal:         telemetrytypes.SignalTraces,
-		FieldContext:   telemetrytypes.FieldContextResource,
-		FieldDataType:  telemetrytypes.FieldDataTypeString,
-		SemconvMembers: []string{"deployment.environment.name", "deployment.environment"},
-	}
-	sb := sqlbuilder.NewSelectBuilder()
-
-	conditions, _, err := NewConditionBuilder(NewFieldMapper()).ConditionFor(
-		context.Background(), valuer.UUID{}, 0, 0, key,
-		map[string][]*telemetrytypes.TelemetryFieldKey{key.Name: {key}},
-		qbtypes.ConditionBuilderOptions{}, qbtypes.FilterOperatorNotContains, "stag", sb,
-	)
-	require.NoError(t, err)
-	sb.Where(conditions...)
-	sql, args := sb.BuildWithFlavor(sqlbuilder.ClickHouse)
+	sql, args := familyConditionSQL(t, "deployment.environment.name", deploymentFamilyMembers, qbtypes.FilterOperatorNotContains, "stag")
 
 	assert.Contains(t, sql, "LOWER(COALESCE(NULLIF(simpleJSONExtractString(labels, 'deployment.environment.name'), ''), NULLIF(simpleJSONExtractString(labels, 'deployment.environment'), ''), '')) NOT LIKE LOWER(?)")
 	assert.Equal(t, []any{"%stag%"}, args)
 }
 
 func TestFamilyNotRegexpIncludesKeylessRows(t *testing.T) {
-	key := &telemetrytypes.TelemetryFieldKey{
-		Name:           "deployment.environment.name",
-		Signal:         telemetrytypes.SignalTraces,
-		FieldContext:   telemetrytypes.FieldContextResource,
-		FieldDataType:  telemetrytypes.FieldDataTypeString,
-		SemconvMembers: []string{"deployment.environment.name", "deployment.environment"},
-	}
-	sb := sqlbuilder.NewSelectBuilder()
-
-	conditions, _, err := NewConditionBuilder(NewFieldMapper()).ConditionFor(
-		context.Background(), valuer.UUID{}, 0, 0, key,
-		map[string][]*telemetrytypes.TelemetryFieldKey{key.Name: {key}},
-		qbtypes.ConditionBuilderOptions{}, qbtypes.FilterOperatorNotRegexp, "stag.*", sb,
-	)
-	require.NoError(t, err)
-	sb.Where(conditions...)
-	sql, args := sb.BuildWithFlavor(sqlbuilder.ClickHouse)
+	sql, args := familyConditionSQL(t, "deployment.environment.name", deploymentFamilyMembers, qbtypes.FilterOperatorNotRegexp, "stag.*")
 
 	assert.Contains(t, sql, "NOT match(COALESCE(NULLIF(simpleJSONExtractString(labels, 'deployment.environment.name'), ''), NULLIF(simpleJSONExtractString(labels, 'deployment.environment'), ''), ''), ?)")
 	assert.Equal(t, []any{"stag.*"}, args)
 }
 
 func TestFamilyExistsChecksEveryMember(t *testing.T) {
-	key := &telemetrytypes.TelemetryFieldKey{
-		Name:           "deployment.environment.name",
-		Signal:         telemetrytypes.SignalTraces,
-		FieldContext:   telemetrytypes.FieldContextResource,
-		FieldDataType:  telemetrytypes.FieldDataTypeString,
-		SemconvMembers: []string{"deployment.environment.name", "deployment.environment"},
-	}
-	sb := sqlbuilder.NewSelectBuilder()
-
-	conditions, _, err := NewConditionBuilder(NewFieldMapper()).ConditionFor(
-		context.Background(), valuer.UUID{}, 0, 0, key,
-		map[string][]*telemetrytypes.TelemetryFieldKey{key.Name: {key}},
-		qbtypes.ConditionBuilderOptions{}, qbtypes.FilterOperatorExists, nil, sb,
-	)
-	require.NoError(t, err)
-	sb.Where(conditions...)
-	sql, args := sb.BuildWithFlavor(sqlbuilder.ClickHouse)
+	sql, args := familyConditionSQL(t, "deployment.environment.name", deploymentFamilyMembers, qbtypes.FilterOperatorExists, nil)
 
 	assert.Contains(t, sql, "(simpleJSONHas(labels, 'deployment.environment.name') = ? OR simpleJSONHas(labels, 'deployment.environment') = ?) AND (labels LIKE ? OR labels LIKE ?)")
 	assert.Equal(t, []any{true, true, "%deployment.environment.name%", "%deployment.environment%"}, args)
 }
 
 func TestFamilyNotExistsChecksEveryMember(t *testing.T) {
-	key := &telemetrytypes.TelemetryFieldKey{
-		Name:           "deployment.environment.name",
-		Signal:         telemetrytypes.SignalTraces,
-		FieldContext:   telemetrytypes.FieldContextResource,
-		FieldDataType:  telemetrytypes.FieldDataTypeString,
-		SemconvMembers: []string{"deployment.environment.name", "deployment.environment"},
-	}
-	sb := sqlbuilder.NewSelectBuilder()
-
-	conditions, _, err := NewConditionBuilder(NewFieldMapper()).ConditionFor(
-		context.Background(), valuer.UUID{}, 0, 0, key,
-		map[string][]*telemetrytypes.TelemetryFieldKey{key.Name: {key}},
-		qbtypes.ConditionBuilderOptions{}, qbtypes.FilterOperatorNotExists, nil, sb,
-	)
-	require.NoError(t, err)
-	sb.Where(conditions...)
-	sql, args := sb.BuildWithFlavor(sqlbuilder.ClickHouse)
+	sql, args := familyConditionSQL(t, "deployment.environment.name", deploymentFamilyMembers, qbtypes.FilterOperatorNotExists, nil)
 
 	assert.Contains(t, sql, "simpleJSONHas(labels, 'deployment.environment.name') <> ? AND simpleJSONHas(labels, 'deployment.environment') <> ?")
 	assert.Equal(t, []any{true, true}, args)
+}
+
+// The old-name request with only the current spelling in metadata prunes to a
+// single member: plain single-key SQL, no coalesce.
+func TestFamilyPrunesToPresentMembers(t *testing.T) {
+	sql, args := familyConditionSQL(t, "deployment.environment", []string{"deployment.environment.name"}, qbtypes.FilterOperatorEqual, "production")
+
+	assert.Contains(t, sql, "simpleJSONExtractString(labels, 'deployment.environment.name') = ? AND labels LIKE ? AND labels LIKE ?")
+	assert.Equal(t, []any{"production", "%deployment.environment.name%", `%deployment.environment.name":"production%`}, args)
 }
 
 func TestLogSemconvNameStaysLiteral(t *testing.T) {

--- a/pkg/statementbuilder/resourcefilter/field_mapper.go
+++ b/pkg/statementbuilder/resourcefilter/field_mapper.go
@@ -7,7 +7,6 @@ import (
 
 	schema "github.com/SigNoz/signoz-otel-collector/cmd/signozschemamigrator/schema_migrator"
 	"github.com/SigNoz/signoz/pkg/querybuilder"
-	"github.com/SigNoz/signoz/pkg/semconv"
 	qbtypes "github.com/SigNoz/signoz/pkg/types/querybuildertypes/querybuildertypesv5"
 	"github.com/SigNoz/signoz/pkg/types/telemetrytypes"
 	"github.com/SigNoz/signoz/pkg/valuer"
@@ -35,18 +34,29 @@ func NewFieldMapper() *defaultFieldMapper {
 	return &defaultFieldMapper{}
 }
 
-func resourceSemconvMembers(key *telemetrytypes.TelemetryFieldKey) []string {
-	if key.Signal != telemetrytypes.SignalTraces || key.FieldContext != telemetrytypes.FieldContextResource {
-		return []string{key.Name}
+// FieldForLogical returns the value expression for a resolved logical field:
+// the member's own expression for a single-member field, and a current-first
+// merge for a family. Resource label values are strings, so the merge is a
+// coalesce with a trailing '' that keeps single-key semantics for rows
+// without any member (see AddDefaultExistsFilter).
+func (m *defaultFieldMapper) FieldForLogical(
+	ctx context.Context,
+	orgID valuer.UUID,
+	tsStart, tsEnd uint64,
+	logical *telemetrytypes.LogicalField,
+) (string, error) {
+	if !logical.IsFamily() {
+		return m.FieldFor(ctx, orgID, tsStart, tsEnd, logical.Single())
 	}
-	if len(key.SemconvMembers) > 0 {
-		return key.SemconvMembers
+	values := make([]string, 0, len(logical.Members))
+	for _, member := range logical.Members {
+		expr, err := m.FieldFor(ctx, orgID, tsStart, tsEnd, member)
+		if err != nil {
+			return "", err
+		}
+		values = append(values, fmt.Sprintf("NULLIF(%s, '')", expr))
 	}
-	return semconv.Members(semconv.KindAttribute, telemetrytypes.FieldKeySelector{
-		Name:         key.Name,
-		Signal:       telemetrytypes.SignalTraces,
-		FieldContext: telemetrytypes.FieldContextResource,
-	})
+	return "COALESCE(" + strings.Join(values, ", ") + ", '')", nil
 }
 
 func (m *defaultFieldMapper) getColumn(
@@ -83,15 +93,7 @@ func (m *defaultFieldMapper) FieldFor(
 		return "", err
 	}
 	if key.FieldContext == telemetrytypes.FieldContextResource {
-		members := resourceSemconvMembers(key)
-		if len(members) > 1 {
-			values := make([]string, 0, len(members))
-			for _, member := range members {
-				values = append(values, fmt.Sprintf("NULLIF(simpleJSONExtractString(%s, %s), '')", columns[0].Name, querybuilder.ClickHouseStringLiteral(member)))
-			}
-			return "COALESCE(" + strings.Join(values, ", ") + ", '')", nil
-		}
-		return fmt.Sprintf("simpleJSONExtractString(%s, %s)", columns[0].Name, querybuilder.ClickHouseStringLiteral(members[0])), nil
+		return fmt.Sprintf("simpleJSONExtractString(%s, %s)", columns[0].Name, querybuilder.ClickHouseStringLiteral(key.Name)), nil
 	}
 	return columns[0].Name, nil
 }

--- a/pkg/telemetrymetadata/condition_builder.go
+++ b/pkg/telemetrymetadata/condition_builder.go
@@ -39,7 +39,8 @@ func (c *conditionBuilder) ConditionFor(
 	}
 
 	// an unknown key simply yields no condition rather than an error.
-	keys, warning := querybuilder.ResolveKeys(key, querybuilder.MatchingFieldKeys(key, fieldKeys))
+	logicalFields, warning := querybuilder.ResolveLogicalFields(key, querybuilder.MatchingLogicalFields(key, fieldKeys))
+	keys := querybuilder.SingleKeys(logicalFields)
 	var warnings []string
 	if warning != "" {
 		warnings = append(warnings, warning)

--- a/pkg/telemetryschema/audittelemetryschema/condition_builder.go
+++ b/pkg/telemetryschema/audittelemetryschema/condition_builder.go
@@ -139,7 +139,8 @@ func (c *conditionBuilder) ConditionFor(
 		return nil, nil, err
 	}
 
-	keys, warning := querybuilder.ResolveKeys(key, querybuilder.MatchingFieldKeys(key, fieldKeys))
+	logicalFields, warning := querybuilder.ResolveLogicalFields(key, querybuilder.MatchingLogicalFields(key, fieldKeys))
+	keys := querybuilder.SingleKeys(logicalFields)
 	var warnings []string
 	if warning != "" {
 		warnings = append(warnings, warning)

--- a/pkg/telemetryschema/logstelemetryschema/condition_builder.go
+++ b/pkg/telemetryschema/logstelemetryschema/condition_builder.go
@@ -452,7 +452,7 @@ func (c *conditionBuilder) ConditionFor(
 	value any,
 	sb *sqlbuilder.SelectBuilder,
 ) ([]string, []string, error) {
-	matches := querybuilder.MatchingFieldKeys(key, fieldKeys)
+	matches := querybuilder.MatchingLogicalFields(key, fieldKeys)
 	skipResourceFilter := options.SkipResourceFilter
 
 	// search() resolves its own (optional) scope; handle it before key resolution.
@@ -460,7 +460,8 @@ func (c *conditionBuilder) ConditionFor(
 		return c.conditionForSearch(ctx, orgID, key, value, sb)
 	}
 
-	keys, warning := querybuilder.ResolveKeys(key, matches)
+	logicalFields, warning := querybuilder.ResolveLogicalFields(key, matches)
+	keys := querybuilder.SingleKeys(logicalFields)
 	var warnings []string
 	if warning != "" {
 		warnings = append(warnings, warning)

--- a/pkg/telemetryschema/metricstelemetryschema/condition_builder.go
+++ b/pkg/telemetryschema/metricstelemetryschema/condition_builder.go
@@ -162,7 +162,7 @@ func (c *conditionBuilder) ConditionFor(
 		return nil, nil, err
 	}
 
-	keys := querybuilder.MatchingFieldKeys(key, fieldKeys)
+	keys := querybuilder.SingleKeys(querybuilder.MatchingLogicalFields(key, fieldKeys))
 	var warnings []string
 	if len(keys) == 0 {
 		if _, isColumn := timeSeriesV4Columns[key.Name]; isColumn {

--- a/pkg/telemetryschema/tracestelemetryschema/condition_builder.go
+++ b/pkg/telemetryschema/tracestelemetryschema/condition_builder.go
@@ -18,12 +18,14 @@ import (
 )
 
 type conditionBuilder struct {
-	fm qbtypes.FieldMapper
+	// The builder composes family expressions, so it needs this package's
+	// mapper, not the narrower qbtypes.FieldMapper.
+	fm *fieldMapper
 }
 
 var _ qbtypes.ConditionBuilder = (*conditionBuilder)(nil)
 
-func NewConditionBuilder(fm qbtypes.FieldMapper) *conditionBuilder {
+func NewConditionBuilder(fm *fieldMapper) *conditionBuilder {
 	return &conditionBuilder{fm: fm}
 }
 
@@ -32,7 +34,7 @@ func (c *conditionBuilder) conditionFor(
 	orgID valuer.UUID,
 	startNs uint64,
 	endNs uint64,
-	key *telemetrytypes.TelemetryFieldKey,
+	logical *telemetrytypes.LogicalField,
 	operator qbtypes.FilterOperator,
 	value any,
 	sb *sqlbuilder.SelectBuilder,
@@ -42,13 +44,13 @@ func (c *conditionBuilder) conditionFor(
 		value = querybuilder.FormatValueForContains(value)
 	}
 
-	fieldExpression, err := c.fm.FieldFor(ctx, orgID, startNs, endNs, key)
+	fieldExpression, err := c.fm.FieldForLogical(ctx, orgID, startNs, endNs, logical)
 	if err != nil {
 		return "", err
 	}
 
 	// TODO(srikanthccv): maybe extend this to every possible attribute
-	if key.Name == "duration_nano" || key.Name == "durationNano" { // QoL improvement
+	if logical.Name == "duration_nano" || logical.Name == "durationNano" { // QoL improvement
 		switch v := value.(type) {
 		case string:
 			if duration, err := time.ParseDuration(v); err == nil {
@@ -65,7 +67,7 @@ func (c *conditionBuilder) conditionFor(
 		}
 	}
 
-	fieldExpression, value = querybuilder.DataTypeCollisionHandledFieldName(key, value, fieldExpression, operator)
+	fieldExpression, value = querybuilder.DataTypeCollisionHandledFieldName(logical.Single(), value, fieldExpression, operator)
 
 	// regular operators
 	switch operator {
@@ -154,11 +156,7 @@ func (c *conditionBuilder) conditionFor(
 	// in the query builder, `exists` and `not exists` are used for
 	// key membership checks, so depending on the column type, the condition changes
 	case qbtypes.FilterOperatorExists, qbtypes.FilterOperatorNotExists:
-		columns, err := c.fm.ColumnFor(ctx, orgID, startNs, endNs, key)
-		if err != nil {
-			return "", err
-		}
-		pred, err := querybuilder.ExistsExpression(columns, key, startNs, endNs, fieldExpression, operator == qbtypes.FilterOperatorExists)
+		pred, err := c.fm.ExistsForLogical(ctx, orgID, startNs, endNs, logical, operator == qbtypes.FilterOperatorExists)
 		if err != nil {
 			return "", err
 		}
@@ -210,10 +208,10 @@ func (c *conditionBuilder) ConditionFor(
 		return nil, nil, err
 	}
 
-	matches := querybuilder.MatchingFieldKeys(key, fieldKeys)
+	matches := querybuilder.MatchingLogicalFields(key, fieldKeys)
 	skipResourceFilter := options.SkipResourceFilter
 
-	keys, warning := querybuilder.ResolveKeys(key, matches)
+	logicalFields, warning := querybuilder.ResolveLogicalFields(key, matches)
 	var warnings []string
 	if warning != "" {
 		warnings = append(warnings, warning)
@@ -221,10 +219,10 @@ func (c *conditionBuilder) ConditionFor(
 	// A bare key that names a real column filters on the column too — first. When metadata
 	// only knows the name under other contexts, prepend the column and keep metadata matches
 	// only where their type is consistent with it (a corrupt entry can't degrade the column).
-	if key.FieldContext == telemetrytypes.FieldContextUnspecified && len(keys) > 0 {
+	if key.FieldContext == telemetrytypes.FieldContextUnspecified && len(logicalFields) > 0 {
 		hasColumn := false
-		for _, k := range keys {
-			if k.FieldContext == telemetrytypes.FieldContextSpan {
+		for _, logical := range logicalFields {
+			if logical.FieldContext == telemetrytypes.FieldContextSpan {
 				hasColumn = true
 				break
 			}
@@ -232,49 +230,49 @@ func (c *conditionBuilder) ConditionFor(
 		if !hasColumn {
 			probe := telemetrytypes.NewTelemetryFieldKey(key.Name, telemetrytypes.FieldContextSpan, key.FieldDataType)
 			if cols, colErr := c.fm.ColumnFor(ctx, orgID, startNs, endNs, probe); colErr == nil && len(cols) > 0 {
-				combined := make([]*telemetrytypes.TelemetryFieldKey, 0, len(keys)+1)
-				combined = append(combined, probe)
-				for _, k := range keys {
-					if columnMatchesDataType(cols[0], k.FieldDataType) {
-						combined = append(combined, k)
+				combined := make([]*telemetrytypes.LogicalField, 0, len(logicalFields)+1)
+				combined = append(combined, telemetrytypes.SingleLogicalField(key.Name, probe))
+				for _, logical := range logicalFields {
+					if columnMatchesDataType(cols[0], logical.FieldDataType) {
+						combined = append(combined, logical)
 					}
 				}
-				keys = combined
+				logicalFields = combined
 			}
 		}
 	}
 
 	synthesized := false
-	if len(keys) == 0 {
+	if len(logicalFields) == 0 {
 		// Not in metadata. CandidateKeys resolves it: fold contexts (span/trace) get the
 		// metadata map so it can honor a real column, correct to a stripped-name metadata
 		// match, or synthesize; strict contexts pass nil and keep their synthesize path.
-		keys = c.fm.CandidateKeys(ctx, orgID, key, value, candidateLookupKeys(key, fieldKeys))
-		if len(keys) == 0 {
+		logicalFields = querybuilder.WrapAsLogicalFields(key.Name, c.fm.CandidateKeys(ctx, orgID, key, value, candidateLookupKeys(key, fieldKeys)))
+		if len(logicalFields) == 0 {
 			return nil, warnings, querybuilder.NewKeyNotFoundError(key.Name)
 		}
 		synthesized = true
 		warnings = append(warnings, querybuilder.NewKeyNotFoundWarning(key.Name))
 	}
 
-	// When a resource sub-query already covers the term, drop resource keys from the main
+	// When a resource sub-query already covers the term, drop resource fields from the main
 	// query. Synthesized keys are exempt: the sub-query skips keys absent from metadata.
 	if skipResourceFilter && !synthesized {
-		filtered := make([]*telemetrytypes.TelemetryFieldKey, 0, len(keys))
-		for _, k := range keys {
-			if k.FieldContext != telemetrytypes.FieldContextResource {
-				filtered = append(filtered, k)
+		filtered := make([]*telemetrytypes.LogicalField, 0, len(logicalFields))
+		for _, logical := range logicalFields {
+			if logical.FieldContext != telemetrytypes.FieldContextResource {
+				filtered = append(filtered, logical)
 			}
 		}
 		if len(filtered) == 0 {
 			return nil, warnings, nil
 		}
-		keys = filtered
+		logicalFields = filtered
 	}
 
-	conds := make([]string, 0, len(keys))
-	for _, k := range keys {
-		cond, err := c.conditionForKey(ctx, orgID, startNs, endNs, k, operator, value, sb)
+	conds := make([]string, 0, len(logicalFields))
+	for _, logical := range logicalFields {
+		cond, err := c.conditionForLogicalField(ctx, orgID, startNs, endNs, logical, operator, value, sb)
 		if err != nil {
 			return nil, nil, err
 		}
@@ -283,28 +281,28 @@ func (c *conditionBuilder) ConditionFor(
 	return conds, warnings, nil
 }
 
-func (c *conditionBuilder) conditionForKey(
+func (c *conditionBuilder) conditionForLogicalField(
 	ctx context.Context,
 	orgID valuer.UUID,
 	startNs uint64,
 	endNs uint64,
-	key *telemetrytypes.TelemetryFieldKey,
+	logical *telemetrytypes.LogicalField,
 	operator qbtypes.FilterOperator,
 	value any,
 	sb *sqlbuilder.SelectBuilder,
 ) (string, error) {
-	if c.isSpanScopeField(key.Name) {
-		return c.buildSpanScopeCondition(key, operator, value, startNs)
+	if c.isSpanScopeField(logical.Name) {
+		return c.buildSpanScopeCondition(logical.Single(), operator, value, startNs)
 	}
 
-	condition, err := c.conditionFor(ctx, orgID, startNs, endNs, key, operator, value, sb)
+	condition, err := c.conditionFor(ctx, orgID, startNs, endNs, logical, operator, value, sb)
 	if err != nil {
 		return "", err
 	}
 
 	if operator.AddDefaultExistsFilter() {
 		// skip adding exists filter for intrinsic fields
-		field, _ := c.fm.FieldFor(ctx, orgID, startNs, endNs, key)
+		field, _ := c.fm.FieldFor(ctx, orgID, startNs, endNs, logical.Single())
 		if slices.Contains(maps.Keys(IntrinsicFields), field) ||
 			slices.Contains(maps.Keys(IntrinsicFieldsDeprecated), field) ||
 			slices.Contains(maps.Keys(CalculatedFields), field) ||
@@ -312,7 +310,7 @@ func (c *conditionBuilder) conditionForKey(
 			return condition, nil
 		}
 
-		existsCondition, err := c.conditionFor(ctx, orgID, startNs, endNs, key, qbtypes.FilterOperatorExists, nil, sb)
+		existsCondition, err := c.conditionFor(ctx, orgID, startNs, endNs, logical, qbtypes.FilterOperatorExists, nil, sb)
 		if err != nil {
 			return "", err
 		}

--- a/pkg/telemetryschema/tracestelemetryschema/condition_builder_test.go
+++ b/pkg/telemetryschema/tracestelemetryschema/condition_builder_test.go
@@ -308,57 +308,72 @@ func TestConditionFor(t *testing.T) {
 	}
 }
 
-func TestConditionForSemconvFamilyPositiveFilterChecksPresence(t *testing.T) {
-	key := &telemetrytypes.TelemetryFieldKey{
-		Name:           "deployment.environment.name",
-		Signal:         telemetrytypes.SignalTraces,
-		FieldContext:   telemetrytypes.FieldContextAttribute,
-		FieldDataType:  telemetrytypes.FieldDataTypeString,
-		SemconvMembers: []string{"deployment.environment.name", "deployment.environment"},
+// The family tests drive resolution through the metadata map, exactly as
+// production does: plain member keys in, the resolver groups them, and the
+// builder composes one condition per logical field.
+func traceFamilyConditionSQL(t *testing.T, requestedName string, members []*telemetrytypes.TelemetryFieldKey, op qbtypes.FilterOperator, value any) (string, []any, []string) {
+	t.Helper()
+	fieldKeys := map[string][]*telemetrytypes.TelemetryFieldKey{}
+	for _, member := range members {
+		fieldKeys[member.Name] = []*telemetrytypes.TelemetryFieldKey{member}
 	}
+	requested := telemetrytypes.NewTelemetryFieldKey(
+		requestedName,
+		telemetrytypes.FieldContextAttribute,
+		telemetrytypes.FieldDataTypeString,
+	)
 	sb := sqlbuilder.NewSelectBuilder()
-
 	conditions, warnings, err := NewConditionBuilder(NewFieldMapper()).ConditionFor(
-		context.Background(), valuer.UUID{}, 0, 0, key,
-		map[string][]*telemetrytypes.TelemetryFieldKey{key.Name: {key}},
-		qbtypes.ConditionBuilderOptions{}, qbtypes.FilterOperatorEqual, "production", sb,
+		context.Background(), valuer.UUID{}, 0, 0, requested,
+		fieldKeys,
+		qbtypes.ConditionBuilderOptions{}, op, value, sb,
 	)
 	require.NoError(t, err)
 	sb.Where(conditions...)
 	sql, args := sb.BuildWithFlavor(sqlbuilder.ClickHouse)
+	return sql, args, warnings
+}
 
-	assert.Empty(t, warnings)
-	assert.Contains(t, sql, "(COALESCE(NULLIF(attributes_string['deployment.environment.name'], ''), NULLIF(attributes_string['deployment.environment'], ''), '') = ? AND (mapContains(attributes_string, 'deployment.environment.name') OR mapContains(attributes_string, 'deployment.environment')))")
+func traceAttrMember(name string, materialized bool) *telemetrytypes.TelemetryFieldKey {
+	return &telemetrytypes.TelemetryFieldKey{
+		Name:          name,
+		Signal:        telemetrytypes.SignalTraces,
+		FieldContext:  telemetrytypes.FieldContextAttribute,
+		FieldDataType: telemetrytypes.FieldDataTypeString,
+		Materialized:  materialized,
+	}
+}
+
+func TestConditionForSemconvFamilyPositiveFilterChecksPresence(t *testing.T) {
+	sql, args, warnings := traceFamilyConditionSQL(t,
+		"deployment.environment.name",
+		[]*telemetrytypes.TelemetryFieldKey{
+			traceAttrMember("deployment.environment.name", false),
+			traceAttrMember("deployment.environment", false),
+		},
+		qbtypes.FilterOperatorEqual, "production",
+	)
+
+	assert.Empty(t, warnings, "a family is one logical field, never an ambiguity warning")
+	assert.Contains(t, sql, "COALESCE(NULLIF(attributes_string['deployment.environment.name'], ''), NULLIF(attributes_string['deployment.environment'], ''), '') = ? AND (mapContains(attributes_string, 'deployment.environment.name') OR mapContains(attributes_string, 'deployment.environment'))")
 	assert.Equal(t, []any{"production"}, args)
 }
 
-func TestNewConditionBuilderAcceptsFieldMapperInterface(t *testing.T) {
-	var mapper qbtypes.FieldMapper = NewFieldMapper()
-
-	require.NotNil(t, NewConditionBuilder(mapper))
+func TestNewConditionBuilderTakesThisPackagesMapper(t *testing.T) {
+	// The builder composes family expressions, so it is deliberately coupled
+	// to this package's mapper rather than the narrower qbtypes.FieldMapper.
+	require.NotNil(t, NewConditionBuilder(NewFieldMapper()))
 }
 
 func TestConditionForSemconvFamilyPreservesMaterializedMemberExistsColumn(t *testing.T) {
-	key := &telemetrytypes.TelemetryFieldKey{
-		Name:           "deployment.environment.name",
-		Signal:         telemetrytypes.SignalTraces,
-		FieldContext:   telemetrytypes.FieldContextAttribute,
-		FieldDataType:  telemetrytypes.FieldDataTypeString,
-		SemconvMembers: []string{"deployment.environment.name", "deployment.environment"},
-		SemconvMaterializedColumns: map[string]string{
-			"deployment.environment": "attribute_string_deployment$$environment",
+	sql, args, warnings := traceFamilyConditionSQL(t,
+		"deployment.environment.name",
+		[]*telemetrytypes.TelemetryFieldKey{
+			traceAttrMember("deployment.environment.name", false),
+			traceAttrMember("deployment.environment", true),
 		},
-	}
-	sb := sqlbuilder.NewSelectBuilder()
-
-	conditions, warnings, err := NewConditionBuilder(NewFieldMapper()).ConditionFor(
-		context.Background(), valuer.UUID{}, 0, 0, key,
-		map[string][]*telemetrytypes.TelemetryFieldKey{key.Name: {key}},
-		qbtypes.ConditionBuilderOptions{}, qbtypes.FilterOperatorEqual, "production", sb,
+		qbtypes.FilterOperatorEqual, "production",
 	)
-	require.NoError(t, err)
-	sb.Where(conditions...)
-	sql, args := sb.BuildWithFlavor(sqlbuilder.ClickHouse)
 
 	assert.Empty(t, warnings)
 	assert.Contains(t, sql, "`attribute_string_deployment$$environment_exists`")
@@ -367,27 +382,17 @@ func TestConditionForSemconvFamilyPreservesMaterializedMemberExistsColumn(t *tes
 }
 
 func TestConditionForSemconvFamilyNotExistsChecksEveryMember(t *testing.T) {
-	key := &telemetrytypes.TelemetryFieldKey{
-		Name:           "deployment.environment.name",
-		Signal:         telemetrytypes.SignalTraces,
-		FieldContext:   telemetrytypes.FieldContextAttribute,
-		FieldDataType:  telemetrytypes.FieldDataTypeString,
-		SemconvMembers: []string{"deployment.environment.name", "deployment.environment"},
-	}
-	sb := sqlbuilder.NewSelectBuilder()
-
-	conditions, warnings, err := NewConditionBuilder(NewFieldMapper()).ConditionFor(
-		context.Background(), valuer.UUID{}, 0, 0, key,
-		map[string][]*telemetrytypes.TelemetryFieldKey{key.Name: {key}},
-		qbtypes.ConditionBuilderOptions{}, qbtypes.FilterOperatorNotExists, nil, sb,
+	sql, _, warnings := traceFamilyConditionSQL(t,
+		"deployment.environment",
+		[]*telemetrytypes.TelemetryFieldKey{
+			traceAttrMember("deployment.environment.name", false),
+			traceAttrMember("deployment.environment", false),
+		},
+		qbtypes.FilterOperatorNotExists, nil,
 	)
-	require.NoError(t, err)
-	sb.Where(conditions...)
-	sql, args := sb.BuildWithFlavor(sqlbuilder.ClickHouse)
 
 	assert.Empty(t, warnings)
 	assert.Contains(t, sql, "NOT (mapContains(attributes_string, 'deployment.environment.name') OR mapContains(attributes_string, 'deployment.environment'))")
-	assert.Empty(t, args)
 }
 
 func TestConditionForResourceWithEvolution(t *testing.T) {

--- a/pkg/telemetryschema/tracestelemetryschema/field_mapper.go
+++ b/pkg/telemetryschema/tracestelemetryschema/field_mapper.go
@@ -8,7 +8,6 @@ import (
 	schema "github.com/SigNoz/signoz-otel-collector/cmd/signozschemamigrator/schema_migrator"
 	"github.com/SigNoz/signoz/pkg/errors"
 	"github.com/SigNoz/signoz/pkg/querybuilder"
-	"github.com/SigNoz/signoz/pkg/semconv"
 	qbtypes "github.com/SigNoz/signoz/pkg/types/querybuildertypes/querybuildertypesv5"
 	"github.com/SigNoz/signoz/pkg/types/telemetrytypes"
 	"github.com/SigNoz/signoz/pkg/valuer"
@@ -168,30 +167,143 @@ func NewFieldMapper() *fieldMapper {
 	return &fieldMapper{}
 }
 
-func traceSemconvMembers(key *telemetrytypes.TelemetryFieldKey) []string {
-	if key.FieldContext != telemetrytypes.FieldContextResource && key.FieldContext != telemetrytypes.FieldContextAttribute {
-		return []string{key.Name}
+// FieldForLogical returns the value expression for a resolved logical field:
+// the member's own expression for a single-member field, and a current-first
+// merge across the members' expressions for a family. Each member expression
+// comes from FieldFor and therefore honors that member's own materialization
+// and evolution state — a family never needs sibling information on a key.
+func (m *fieldMapper) FieldForLogical(
+	ctx context.Context,
+	orgID valuer.UUID,
+	tsStart, tsEnd uint64,
+	logical *telemetrytypes.LogicalField,
+) (string, error) {
+	if !logical.IsFamily() {
+		return m.FieldFor(ctx, orgID, tsStart, tsEnd, logical.Single())
 	}
-	if len(key.SemconvMembers) > 0 {
-		return key.SemconvMembers
+
+	memberExprs := make([]string, 0, len(logical.Members))
+	for _, member := range logical.Members {
+		expr, err := m.FieldFor(ctx, orgID, tsStart, tsEnd, member)
+		if err != nil {
+			return "", err
+		}
+		memberExprs = append(memberExprs, expr)
 	}
-	return semconv.Members(semconv.KindAttribute, telemetrytypes.FieldKeySelector{
-		Name:         key.Name,
-		Signal:       telemetrytypes.SignalTraces,
-		FieldContext: key.FieldContext,
-	})
+
+	if logical.FieldDataType == telemetrytypes.FieldDataTypeString {
+		// The trailing '' keeps single-key semantics for rows without any
+		// member: string maps read '' for an absent key, and negative
+		// operators must keep including such rows (see AddDefaultExistsFilter).
+		values := make([]string, 0, len(memberExprs))
+		for _, expr := range memberExprs {
+			values = append(values, fmt.Sprintf("NULLIF(%s, '')", expr))
+		}
+		return "COALESCE(" + strings.Join(values, ", ") + ", '')", nil
+	}
+
+	// Numeric and boolean maps return zero for an absent key. If a family of
+	// either type is enabled, this tail must become zero too.
+	branches := make([]string, 0, len(logical.Members)*2)
+	for i, member := range logical.Members {
+		guard, err := m.existsExpressionFor(ctx, orgID, tsStart, tsEnd, member, true)
+		if err != nil {
+			return "", err
+		}
+		branches = append(branches, guard, memberExprs[i])
+	}
+	return "multiIf(" + strings.Join(branches, ", ") + ", NULL)", nil
 }
 
-func traceSemconvMapMemberExpressions(columnName string, key *telemetrytypes.TelemetryFieldKey, member string) (string, string) {
-	if materializedColumn, ok := key.SemconvMaterializedColumns[member]; ok {
-		return querybuilder.ClickHouseIdentifier(materializedColumn), querybuilder.ClickHouseIdentifier(materializedColumn + "_exists")
+// ExistsForLogical renders the existence predicate for a resolved logical
+// field: a member's own predicate for a single-member field, presence of any
+// member for a family.
+func (m *fieldMapper) ExistsForLogical(
+	ctx context.Context,
+	orgID valuer.UUID,
+	tsStart, tsEnd uint64,
+	logical *telemetrytypes.LogicalField,
+	exists bool,
+) (string, error) {
+	if !logical.IsFamily() {
+		return m.existsExpressionFor(ctx, orgID, tsStart, tsEnd, logical.Single(), exists)
 	}
-	if key.Materialized && key.Name == member {
-		physicalKey := key.Copy()
-		physicalKey.Name = member
-		return telemetrytypes.FieldKeyToMaterializedColumnName(physicalKey), telemetrytypes.FieldKeyToMaterializedColumnNameForExists(physicalKey)
+
+	guards := make([]string, 0, len(logical.Members))
+	for _, member := range logical.Members {
+		guard, err := m.existsExpressionFor(ctx, orgID, tsStart, tsEnd, member, true)
+		if err != nil {
+			return "", err
+		}
+		guards = append(guards, guard)
 	}
-	return fmt.Sprintf("%s[%s]", columnName, querybuilder.ClickHouseStringLiteral(member)), fmt.Sprintf("mapContains(%s, %s)", columnName, querybuilder.ClickHouseStringLiteral(member))
+	combined := "(" + strings.Join(guards, " OR ") + ")"
+	if exists {
+		return combined, nil
+	}
+	return "NOT " + combined, nil
+}
+
+// logicalForResolvedColumn upgrades a directly-resolvable key (the FieldFor
+// probe succeeded) to its family when the metadata map proves membership;
+// otherwise the key stays a single-member logical field.
+func logicalForResolvedColumn(field *telemetrytypes.TelemetryFieldKey, keys map[string][]*telemetrytypes.TelemetryFieldKey) *telemetrytypes.LogicalField {
+	for _, logical := range querybuilder.MatchingLogicalFields(field, keys) {
+		if logical.IsFamily() &&
+			logical.FieldContext == field.FieldContext &&
+			(field.FieldDataType == telemetrytypes.FieldDataTypeUnspecified || logical.FieldDataType == field.FieldDataType) {
+			return logical
+		}
+	}
+	return telemetrytypes.SingleLogicalField(field.Name, field)
+}
+
+// upgradeToFamilies swaps single-member candidates for their family when the
+// metadata map proves membership. Candidate order and every non-family
+// candidate stay exactly as the legacy flow produced them; sibling candidates
+// of an already-emitted family are dropped rather than duplicated.
+func upgradeToFamilies(field *telemetrytypes.TelemetryFieldKey, candidates []*telemetrytypes.LogicalField, keys map[string][]*telemetrytypes.TelemetryFieldKey) []*telemetrytypes.LogicalField {
+	var families []*telemetrytypes.LogicalField
+	for _, logical := range querybuilder.MatchingLogicalFields(field, keys) {
+		if logical.IsFamily() {
+			families = append(families, logical)
+		}
+	}
+	if len(families) == 0 {
+		return candidates
+	}
+
+	out := make([]*telemetrytypes.LogicalField, 0, len(candidates))
+	emitted := make(map[*telemetrytypes.LogicalField]bool)
+	for _, candidate := range candidates {
+		var family *telemetrytypes.LogicalField
+		for _, fam := range families {
+			if fam.FieldContext != candidate.FieldContext || fam.FieldDataType != candidate.FieldDataType {
+				continue
+			}
+			memberOfFamily := candidate.Single().Name == field.Name
+			for _, member := range fam.Members {
+				if member.Name == candidate.Single().Name {
+					memberOfFamily = true
+					break
+				}
+			}
+			if memberOfFamily {
+				family = fam
+				break
+			}
+		}
+		if family == nil {
+			out = append(out, candidate)
+			continue
+		}
+		if emitted[family] {
+			continue
+		}
+		emitted[family] = true
+		out = append(out, family)
+	}
+	return out
 }
 
 func (m *fieldMapper) getColumn(
@@ -318,27 +430,10 @@ func (m *fieldMapper) resolveColumnExprs(
 			if key.FieldContext != telemetrytypes.FieldContextResource {
 				return nil, nil, nil, errors.Newf(errors.TypeInvalidInput, errors.CodeInvalidInput, "only resource context fields are supported for json columns, got %s", key.FieldContext.String)
 			}
-			members := traceSemconvMembers(key)
-			if len(members) > 1 {
-				values := make([]string, 0, len(members))
-				guards := make([]string, 0, len(members))
-				for _, member := range members {
-					// The String cast is required because ClickHouse does not allow
-					// Variant/Dynamic values in GROUP BY.
-					value := fmt.Sprintf("%s.%s::String", columnName, querybuilder.ClickHouseIdentifier(member))
-					values = append(values, fmt.Sprintf("NULLIF(%s, '')", value))
-					guards = append(guards, fmt.Sprintf("%s.%s IS NOT NULL", columnName, querybuilder.ClickHouseIdentifier(member)))
-				}
-				// Missing Dynamic paths are NULL, so this family expression must
-				// retain the same NULL result as a single JSON-path lookup.
-				exprs = append(exprs, "COALESCE("+strings.Join(values, ", ")+")")
-				existExprs = append(existExprs, "("+strings.Join(guards, " OR ")+")")
-			} else {
-				// have to add ::string as clickHouse throws an error :- data types Variant/Dynamic are not allowed in GROUP BY
-				// once ClickHouse is updated, check whether this cast can be removed.
-				exprs = append(exprs, fmt.Sprintf("%s.%s::String", columnName, querybuilder.ClickHouseIdentifier(members[0])))
-				existExprs = append(existExprs, fmt.Sprintf("%s.%s IS NOT NULL", columnName, querybuilder.ClickHouseIdentifier(members[0])))
-			}
+			// have to add ::string as clickHouse throws an error :- data types Variant/Dynamic are not allowed in GROUP BY
+			// once ClickHouse is updated, check whether this cast can be removed.
+			exprs = append(exprs, fmt.Sprintf("%s.%s::String", columnName, querybuilder.ClickHouseIdentifier(key.Name)))
+			existExprs = append(existExprs, fmt.Sprintf("%s.%s IS NOT NULL", columnName, querybuilder.ClickHouseIdentifier(key.Name)))
 		case schema.ColumnTypeEnumString,
 			schema.ColumnTypeEnumUInt64,
 			schema.ColumnTypeEnumUInt32,
@@ -363,40 +458,13 @@ func (m *fieldMapper) resolveColumnExprs(
 
 			switch valueType := column.Type.(schema.MapColumnType).ValueType; valueType.GetType() {
 			case schema.ColumnTypeEnumString, schema.ColumnTypeEnumFloat64, schema.ColumnTypeEnumBool:
-				members := traceSemconvMembers(key)
-				if len(members) > 1 {
-					guards := make([]string, 0, len(members))
-					memberValues := make([]string, 0, len(members))
-					for _, member := range members {
-						valueExpression, existsExpression := traceSemconvMapMemberExpressions(columnName, key, member)
-						memberValues = append(memberValues, valueExpression)
-						guards = append(guards, existsExpression)
-					}
-					if valueType.GetType() == schema.ColumnTypeEnumString {
-						values := make([]string, 0, len(members))
-						for _, memberValue := range memberValues {
-							values = append(values, fmt.Sprintf("NULLIF(%s, '')", memberValue))
-						}
-						exprs = append(exprs, "COALESCE("+strings.Join(values, ", ")+", '')")
-					} else {
-						branches := make([]string, 0, len(members)*2)
-						for i, memberValue := range memberValues {
-							branches = append(branches, guards[i], memberValue)
-						}
-						// Numeric and boolean maps return zero for an absent key. If a
-						// family of either type is enabled, this tail must become zero too.
-						exprs = append(exprs, "multiIf("+strings.Join(branches, ", ")+", NULL)")
-					}
-					existExprs = append(existExprs, "("+strings.Join(guards, " OR ")+")")
-				} else if key.Materialized {
+				if key.Materialized {
 					// a key could have been materialized, if so return the materialized column name
-					physicalKey := key.Copy()
-					physicalKey.Name = members[0]
-					exprs = append(exprs, telemetrytypes.FieldKeyToMaterializedColumnName(physicalKey))
-					existExprs = append(existExprs, telemetrytypes.FieldKeyToMaterializedColumnNameForExists(physicalKey))
+					exprs = append(exprs, telemetrytypes.FieldKeyToMaterializedColumnName(key))
+					existExprs = append(existExprs, telemetrytypes.FieldKeyToMaterializedColumnNameForExists(key))
 				} else {
-					exprs = append(exprs, fmt.Sprintf("%s[%s]", columnName, querybuilder.ClickHouseStringLiteral(members[0])))
-					existExprs = append(existExprs, fmt.Sprintf("mapContains(%s, %s)", columnName, querybuilder.ClickHouseStringLiteral(members[0])))
+					exprs = append(exprs, fmt.Sprintf("%s[%s]", columnName, querybuilder.ClickHouseStringLiteral(key.Name)))
+					existExprs = append(existExprs, fmt.Sprintf("mapContains(%s, %s)", columnName, querybuilder.ClickHouseStringLiteral(key.Name)))
 				}
 			default:
 				return nil, nil, nil, errors.NewInvalidInputf(errors.CodeInvalidInput, "value type %s is not supported for map column type %s", valueType, column.Type)
@@ -419,18 +487,23 @@ func (m *fieldMapper) ColumnExpressionFor(
 	keys map[string][]*telemetrytypes.TelemetryFieldKey,
 ) (string, error) {
 
-	// Resolve the candidate column(s).
-	var candidates []*telemetrytypes.TelemetryFieldKey
+	// Resolve the candidate logical field(s).
+	var candidates []*telemetrytypes.LogicalField
 	switch _, err := m.FieldFor(ctx, orgID, startNs, endNs, field); {
 	case err == nil:
-		candidates = []*telemetrytypes.TelemetryFieldKey{field}
+		// A directly-resolvable key upgrades to its family when the metadata
+		// map proves membership; otherwise it stays single-member.
+		candidates = []*telemetrytypes.LogicalField{logicalForResolvedColumn(field, keys)}
 	case errors.Is(err, qbtypes.ErrColumnNotFound):
-		// column (when the bare name is one) plus metadata matches, else synthesized
-		// type-variant keys.
-		candidates = m.CandidateKeys(ctx, orgID, field, nil, keys)
-		if len(candidates) == 0 {
+		// The legacy candidate flow, unchanged: column (when the bare name is
+		// one) plus metadata matches, else synthesized type-variant keys. The
+		// family step below only swaps candidates for their family; it never
+		// changes candidate order or non-family behavior.
+		raw := m.CandidateKeys(ctx, orgID, field, nil, keys)
+		if len(raw) == 0 {
 			return "", errors.Wrapf(err, errors.TypeInvalidInput, errors.CodeInvalidInput, "field `%s` not found", field.Name).WithSuggestions(errors.NewSuggestionsOnLevenshteinDistance(field.Name, errors.NounKeys, maps.Keys(keys))...)
 		}
+		candidates = upgradeToFamilies(field, querybuilder.WrapAsLogicalFields(field.Name, raw), keys)
 	default:
 		return "", err
 	}
@@ -444,21 +517,21 @@ func (m *fieldMapper) ColumnExpressionFor(
 			dummyValue = 0.0
 		}
 		stmts := make([]string, 0, len(candidates)*2)
-		for _, key := range candidates {
-			value, err := m.FieldFor(ctx, orgID, startNs, endNs, key)
+		for _, logical := range candidates {
+			value, err := m.FieldForLogical(ctx, orgID, startNs, endNs, logical)
 			if err != nil {
 				return "", err
 			}
-			guard, err := m.existsExpressionFor(ctx, orgID, startNs, endNs, key, true)
+			guard, err := m.ExistsForLogical(ctx, orgID, startNs, endNs, logical, true)
 			if err != nil {
 				return "", err
 			}
 			coerced := value
 			// a time column keeps its native type; coercing it would yield seconds
-			if temporal, err := m.columnIsTemporal(ctx, startNs, endNs, key); err != nil {
+			if temporal, err := m.logicalIsTemporal(ctx, startNs, endNs, logical); err != nil {
 				return "", err
 			} else if !temporal {
-				coerced, _ = querybuilder.DataTypeCollisionHandledFieldName(key, dummyValue, value, qbtypes.FilterOperatorUnknown)
+				coerced, _ = querybuilder.DataTypeCollisionHandledFieldName(logical.Single(), dummyValue, value, qbtypes.FilterOperatorUnknown)
 			}
 			stmts = append(stmts, guard, coerced)
 		}
@@ -466,13 +539,14 @@ func (m *fieldMapper) ColumnExpressionFor(
 	}
 
 	if len(candidates) == 1 {
-		value, err := m.FieldFor(ctx, orgID, startNs, endNs, candidates[0])
+		logical := candidates[0]
+		value, err := m.FieldForLogical(ctx, orgID, startNs, endNs, logical)
 		if err != nil {
 			return "", err
 		}
-		exprs, existExprs, _, _ := m.resolveColumnExprs(ctx, startNs, endNs, candidates[0])
-		if len(exprs) == 1 && len(existExprs) == 1 {
-			guard, err := m.existsExpressionFor(ctx, orgID, startNs, endNs, candidates[0], true)
+		exprs, existExprs, _, _ := m.resolveColumnExprs(ctx, startNs, endNs, logical.Single())
+		if !logical.IsFamily() && len(exprs) == 1 && len(existExprs) == 1 {
+			guard, err := m.ExistsForLogical(ctx, orgID, startNs, endNs, logical, true)
 			if err != nil {
 				return "", err
 			}
@@ -484,18 +558,27 @@ func (m *fieldMapper) ColumnExpressionFor(
 	// Multiple candidates (collision / synth): multiIf picks the first that exists,
 	// stringified so branches share a type.
 	args := make([]string, 0, len(candidates))
-	for _, key := range candidates {
-		value, err := m.FieldFor(ctx, orgID, startNs, endNs, key)
+	for _, logical := range candidates {
+		value, err := m.FieldForLogical(ctx, orgID, startNs, endNs, logical)
 		if err != nil {
 			return "", err
 		}
-		guard, err := m.existsExpressionFor(ctx, orgID, startNs, endNs, key, true)
+		guard, err := m.ExistsForLogical(ctx, orgID, startNs, endNs, logical, true)
 		if err != nil {
 			return "", err
 		}
 		args = append(args, fmt.Sprintf("%s, toString(%s)", guard, value))
 	}
 	return fmt.Sprintf("multiIf(%s, NULL)", strings.Join(args, ", ")), nil
+}
+
+// logicalIsTemporal reports whether the logical field resolves to a single time
+// column. A family is attribute-backed and never temporal.
+func (m *fieldMapper) logicalIsTemporal(ctx context.Context, startNs, endNs uint64, logical *telemetrytypes.LogicalField) (bool, error) {
+	if logical.IsFamily() {
+		return false, nil
+	}
+	return m.columnIsTemporal(ctx, startNs, endNs, logical.Single())
 }
 
 // columnIsTemporal reports whether key resolves to a single time column, after evolution

--- a/pkg/telemetryschema/tracestelemetryschema/field_mapper_test.go
+++ b/pkg/telemetryschema/tracestelemetryschema/field_mapper_test.go
@@ -95,7 +95,7 @@ func TestGetFieldKeyName(t *testing.T) {
 				Materialized:  true,
 				Evolutions:    mockEvolution,
 			},
-			expectedResult: "multiIf((resource.`deployment.environment.name` IS NOT NULL OR resource.`deployment.environment` IS NOT NULL), COALESCE(NULLIF(resource.`deployment.environment.name`::String, ''), NULLIF(resource.`deployment.environment`::String, '')), (mapContains(resources_string, 'deployment.environment.name') OR `resource_string_deployment$$environment_exists`), COALESCE(NULLIF(resources_string['deployment.environment.name'], ''), NULLIF(`resource_string_deployment$$environment`, ''), ''), NULL)",
+			expectedResult: "multiIf(resource.`deployment.environment` IS NOT NULL, resource.`deployment.environment`::String, `resource_string_deployment$$environment_exists`, `resource_string_deployment$$environment`, NULL)",
 			expectedError:  nil,
 		},
 		{
@@ -135,61 +135,116 @@ func TestGetFieldKeyName(t *testing.T) {
 	}
 }
 
-func TestFieldForResolvesCurrentTraceSemconvAttributeName(t *testing.T) {
+// FieldFor is a per-physical-key primitive: it never consults the family
+// table. Family composition is FieldForLogical's job.
+func TestFieldForIsPerKey(t *testing.T) {
 	key := telemetrytypes.TelemetryFieldKey{
 		Name:          "deployment.environment.name",
 		FieldContext:  telemetrytypes.FieldContextAttribute,
 		FieldDataType: telemetrytypes.FieldDataTypeString,
-	}
-
-	expression, err := NewFieldMapper().FieldFor(context.Background(), valuer.UUID{}, 0, 0, &key)
-
-	require.NoError(t, err)
-	assert.Equal(t, "COALESCE(NULLIF(attributes_string['deployment.environment.name'], ''), NULLIF(attributes_string['deployment.environment'], ''), '')", expression)
-}
-
-func TestFieldForResolvesOldTraceSemconvAttributeName(t *testing.T) {
-	key := telemetrytypes.TelemetryFieldKey{
-		Name:          "deployment.environment",
-		FieldContext:  telemetrytypes.FieldContextAttribute,
-		FieldDataType: telemetrytypes.FieldDataTypeString,
-	}
-
-	expression, err := NewFieldMapper().FieldFor(context.Background(), valuer.UUID{}, 0, 0, &key)
-
-	require.NoError(t, err)
-	assert.Equal(t, "COALESCE(NULLIF(attributes_string['deployment.environment.name'], ''), NULLIF(attributes_string['deployment.environment'], ''), '')", expression)
-}
-
-func TestFieldForPreservesResourceStorageDefaultsForSemconvFamily(t *testing.T) {
-	key := telemetrytypes.TelemetryFieldKey{
-		Name:          "deployment.environment.name",
-		FieldContext:  telemetrytypes.FieldContextResource,
-		FieldDataType: telemetrytypes.FieldDataTypeString,
-		Materialized:  true,
-		Evolutions:    MockEvolutionData(time.Date(2024, 6, 2, 0, 0, 0, 0, time.UTC)),
-	}
-	start := uint64(time.Date(2024, 6, 1, 0, 0, 0, 0, time.UTC).UnixNano())
-	end := uint64(time.Date(2024, 6, 5, 0, 0, 0, 0, time.UTC).UnixNano())
-
-	expression, err := NewFieldMapper().FieldFor(context.Background(), valuer.UUID{}, start, end, &key)
-
-	require.NoError(t, err)
-	assert.Equal(t, "multiIf((resource.`deployment.environment.name` IS NOT NULL OR resource.`deployment.environment` IS NOT NULL), COALESCE(NULLIF(resource.`deployment.environment.name`::String, ''), NULLIF(resource.`deployment.environment`::String, '')), (`resource_string_deployment$$environment$$name_exists` OR mapContains(resources_string, 'deployment.environment')), COALESCE(NULLIF(`resource_string_deployment$$environment$$name`, ''), NULLIF(resources_string['deployment.environment'], ''), ''), NULL)", expression)
-}
-
-func TestFieldForUsesAvailableTraceSemconvMember(t *testing.T) {
-	key := telemetrytypes.TelemetryFieldKey{
-		Name:           "deployment.environment",
-		FieldContext:   telemetrytypes.FieldContextAttribute,
-		FieldDataType:  telemetrytypes.FieldDataTypeString,
-		SemconvMembers: []string{"deployment.environment.name"},
 	}
 
 	expression, err := NewFieldMapper().FieldFor(context.Background(), valuer.UUID{}, 0, 0, &key)
 
 	require.NoError(t, err)
 	assert.Equal(t, "attributes_string['deployment.environment.name']", expression)
+}
+
+func traceFamilyLogicalField(t *testing.T, requestedName string, members ...*telemetrytypes.TelemetryFieldKey) *telemetrytypes.LogicalField {
+	t.Helper()
+	fieldKeys := map[string][]*telemetrytypes.TelemetryFieldKey{}
+	for _, member := range members {
+		fieldKeys[member.Name] = []*telemetrytypes.TelemetryFieldKey{member}
+	}
+	requested := telemetrytypes.NewTelemetryFieldKey(requestedName, members[0].FieldContext, members[0].FieldDataType)
+	matches := querybuilder.MatchingLogicalFields(requested, fieldKeys)
+	require.Len(t, matches, 1)
+	return matches[0]
+}
+
+func TestFieldForLogicalMergesFamilyMembersCurrentFirst(t *testing.T) {
+	current := &telemetrytypes.TelemetryFieldKey{
+		Name:          "deployment.environment.name",
+		Signal:        telemetrytypes.SignalTraces,
+		FieldContext:  telemetrytypes.FieldContextAttribute,
+		FieldDataType: telemetrytypes.FieldDataTypeString,
+	}
+	old := &telemetrytypes.TelemetryFieldKey{
+		Name:          "deployment.environment",
+		Signal:        telemetrytypes.SignalTraces,
+		FieldContext:  telemetrytypes.FieldContextAttribute,
+		FieldDataType: telemetrytypes.FieldDataTypeString,
+	}
+
+	for _, requestedName := range []string{current.Name, old.Name} {
+		logical := traceFamilyLogicalField(t, requestedName, current, old)
+		expression, err := NewFieldMapper().FieldForLogical(context.Background(), valuer.UUID{}, 0, 0, logical)
+		require.NoError(t, err)
+		assert.Equal(t,
+			"COALESCE(NULLIF(attributes_string['deployment.environment.name'], ''), NULLIF(attributes_string['deployment.environment'], ''), '')",
+			expression,
+			"both request spellings address one logical field",
+		)
+	}
+}
+
+// The old-name request with only the current spelling in metadata prunes to a
+// single member: plain single-key SQL, no coalesce.
+func TestFieldForLogicalPrunesToPresentMembers(t *testing.T) {
+	current := &telemetrytypes.TelemetryFieldKey{
+		Name:          "deployment.environment.name",
+		Signal:        telemetrytypes.SignalTraces,
+		FieldContext:  telemetrytypes.FieldContextAttribute,
+		FieldDataType: telemetrytypes.FieldDataTypeString,
+	}
+
+	logical := traceFamilyLogicalField(t, "deployment.environment", current)
+	expression, err := NewFieldMapper().FieldForLogical(context.Background(), valuer.UUID{}, 0, 0, logical)
+
+	require.NoError(t, err)
+	assert.Equal(t, "attributes_string['deployment.environment.name']", expression)
+}
+
+// Every member brings its own storage state: the merge composes each member's
+// FieldFor output, so a materialized-with-evolutions member keeps its column
+// history inside the family expression with no sibling bookkeeping anywhere.
+func TestFieldForLogicalComposesResourceMembersFromTheirOwnStorage(t *testing.T) {
+	ctx := context.Background()
+	fm := NewFieldMapper()
+	start := uint64(time.Date(2024, 6, 1, 0, 0, 0, 0, time.UTC).UnixNano())
+	end := uint64(time.Date(2024, 6, 5, 0, 0, 0, 0, time.UTC).UnixNano())
+
+	current := &telemetrytypes.TelemetryFieldKey{
+		Name:          "deployment.environment.name",
+		Signal:        telemetrytypes.SignalTraces,
+		FieldContext:  telemetrytypes.FieldContextResource,
+		FieldDataType: telemetrytypes.FieldDataTypeString,
+	}
+	old := &telemetrytypes.TelemetryFieldKey{
+		Name:          "deployment.environment",
+		Signal:        telemetrytypes.SignalTraces,
+		FieldContext:  telemetrytypes.FieldContextResource,
+		FieldDataType: telemetrytypes.FieldDataTypeString,
+		Materialized:  true,
+		Evolutions:    MockEvolutionData(time.Date(2024, 6, 2, 0, 0, 0, 0, time.UTC)),
+	}
+
+	currentExpr, err := fm.FieldFor(ctx, valuer.UUID{}, start, end, current)
+	require.NoError(t, err)
+	oldExpr, err := fm.FieldFor(ctx, valuer.UUID{}, start, end, old)
+	require.NoError(t, err)
+
+	logical := traceFamilyLogicalField(t, current.Name, current, old)
+	expression, err := fm.FieldForLogical(ctx, valuer.UUID{}, start, end, logical)
+	require.NoError(t, err)
+
+	assert.Equal(t,
+		"COALESCE(NULLIF("+currentExpr+", ''), NULLIF("+oldExpr+", ''), '')",
+		expression,
+		"the family merge is exactly the members' own expressions, current-first, with the keyless tail",
+	)
+	assert.Contains(t, expression, "`resource_string_deployment$$environment`",
+		"the promoted member keeps its materialized column")
 }
 
 func TestFieldForResourceWithEvolution(t *testing.T) {
@@ -248,7 +303,7 @@ func TestFieldForResourceWithEvolution(t *testing.T) {
 			},
 			tsStart:        uint64(time.Date(2025, 6, 1, 0, 0, 0, 0, time.UTC).UnixNano()),
 			tsEnd:          uint64(time.Date(2025, 7, 1, 0, 0, 0, 0, time.UTC).UnixNano()),
-			expectedResult: "COALESCE(NULLIF(resource.`deployment.environment.name`::String, ''), NULLIF(resource.`deployment.environment`::String, ''))",
+			expectedResult: "resource.`deployment.environment`::String",
 		},
 		{
 			name: "Window straddles release - materialized resource",
@@ -261,7 +316,7 @@ func TestFieldForResourceWithEvolution(t *testing.T) {
 			},
 			tsStart:        uint64(time.Date(2024, 6, 1, 0, 0, 0, 0, time.UTC).UnixNano()),
 			tsEnd:          uint64(time.Date(2025, 6, 1, 0, 0, 0, 0, time.UTC).UnixNano()),
-			expectedResult: "multiIf((resource.`deployment.environment.name` IS NOT NULL OR resource.`deployment.environment` IS NOT NULL), COALESCE(NULLIF(resource.`deployment.environment.name`::String, ''), NULLIF(resource.`deployment.environment`::String, '')), (mapContains(resources_string, 'deployment.environment.name') OR `resource_string_deployment$$environment_exists`), COALESCE(NULLIF(resources_string['deployment.environment.name'], ''), NULLIF(`resource_string_deployment$$environment`, ''), ''), NULL)",
+			expectedResult: "multiIf(resource.`deployment.environment` IS NOT NULL, resource.`deployment.environment`::String, `resource_string_deployment$$environment_exists`, `resource_string_deployment$$environment`, NULL)",
 		},
 	}
 

--- a/pkg/types/telemetrytypes/field.go
+++ b/pkg/types/telemetrytypes/field.go
@@ -2,7 +2,6 @@ package telemetrytypes
 
 import (
 	"fmt"
-	"maps"
 	"slices"
 	"strings"
 
@@ -49,11 +48,7 @@ type TelemetryFieldKey struct {
 	Indexes      []TelemetryFieldKeySkipIndex `json:"-"`
 	Materialized bool                         `json:"-"` // refers to promoted in case of body.... fields
 
-	Evolutions     []*EvolutionEntry `json:"-"`
-	SemconvMembers []string          `json:"-"`
-	// SemconvMaterializedColumns maps a physical family spelling to its
-	// materialized column name. It is populated only on resolved query keys.
-	SemconvMaterializedColumns map[string]string `json:"-"`
+	Evolutions []*EvolutionEntry `json:"-"`
 }
 
 // Copy returns an independent copy of f.
@@ -73,8 +68,6 @@ func (f *TelemetryFieldKey) Copy() *TelemetryFieldKey {
 			}
 		}
 	}
-	copied.SemconvMembers = slices.Clone(f.SemconvMembers)
-	copied.SemconvMaterializedColumns = maps.Clone(f.SemconvMaterializedColumns)
 	copied.JSONPlan = copyJSONAccessPlan(f.JSONPlan, f, &copied)
 
 	return &copied
@@ -204,8 +197,6 @@ func (f *TelemetryFieldKey) OverrideMetadataFrom(src *TelemetryFieldKey) {
 	f.Materialized = src.Materialized
 	f.JSONPlan = src.JSONPlan
 	f.Evolutions = src.Evolutions
-	f.SemconvMembers = src.SemconvMembers
-	f.SemconvMaterializedColumns = src.SemconvMaterializedColumns
 }
 
 func (f *TelemetryFieldKey) Equal(key *TelemetryFieldKey) bool {

--- a/pkg/types/telemetrytypes/field_copy_test.go
+++ b/pkg/types/telemetrytypes/field_copy_test.go
@@ -18,10 +18,6 @@ func TestTelemetryFieldKeyCopyOwnsMutableState(t *testing.T) {
 		Evolutions: []*EvolutionEntry{
 			{FieldName: "items.name"},
 		},
-		SemconvMembers: []string{"items.name", "item.name"},
-		SemconvMaterializedColumns: map[string]string{
-			"item.name": "body_string_item$$name",
-		},
 	}
 	require.NoError(t, original.SetJSONAccessPlan(JSONColumnMetadata{BaseColumn: "body_v2"}, nil))
 	require.Len(t, original.JSONPlan, 1)
@@ -41,16 +37,12 @@ func TestTelemetryFieldKeyCopyOwnsMutableState(t *testing.T) {
 	copied.Name = "changed"
 	copied.Indexes[0].Name = "changed"
 	copied.Evolutions[0].FieldName = "changed"
-	copied.SemconvMembers[0] = "changed"
-	copied.SemconvMaterializedColumns["item.name"] = "changed"
 	copied.JSONPlan[0].Name = "changed"
 	copied.JSONPlan[0].Parent.Name = "changed"
 
 	assert.Equal(t, "items.name", original.Name)
 	assert.Equal(t, "items.name", original.Indexes[0].Name)
 	assert.Equal(t, "items.name", original.Evolutions[0].FieldName)
-	assert.Equal(t, "items.name", original.SemconvMembers[0])
-	assert.Equal(t, "body_string_item$$name", original.SemconvMaterializedColumns["item.name"])
 	assert.Equal(t, "items.name", original.JSONPlan[0].Name)
 	assert.Equal(t, "body_v2", original.JSONPlan[0].Parent.Name)
 }

--- a/pkg/types/telemetrytypes/logical_field.go
+++ b/pkg/types/telemetrytypes/logical_field.go
@@ -1,0 +1,78 @@
+package telemetrytypes
+
+// LogicalField is resolution output: one queryable field, addressed by the
+// spelling the request used, backed by the physical member keys that store it.
+//
+// The resolver expresses ambiguity ("possibly different fields sharing a
+// name") as a []*LogicalField — never inside one LogicalField. Within one
+// LogicalField, members are alternate physical spellings of the same field
+// (a semantic-convention family), ordered current-first; compilers merge
+// them into one expression with current-wins precedence. Across the slice,
+// compilers build one condition per LogicalField and combine per the
+// operator, exactly as they previously combined ambiguous keys.
+//
+// Members always has at least one entry. A non-family field has exactly
+// one. Members alias the metadata map entries and must not be mutated.
+type LogicalField struct {
+	// Name is the requested spelling. It is the response identity: aliases,
+	// series labels, and warnings use it, so responses echo the request.
+	Name string
+
+	// The physical identity every member shares. Members with a different
+	// signal, field context, or data type belong to different logical
+	// fields by definition.
+	Signal        Signal
+	FieldContext  FieldContext
+	FieldDataType FieldDataType
+
+	// Members are the physical keys that store this field, ordered
+	// current-first. Each member carries its own physical facts
+	// (Materialized, Evolutions, JSONPlan, ...), so per-member accessors
+	// need no sibling information.
+	Members []*TelemetryFieldKey
+}
+
+// SingleLogicalField wraps one physical key as its own logical field.
+func SingleLogicalField(name string, key *TelemetryFieldKey) *LogicalField {
+	return &LogicalField{
+		Name:          name,
+		Signal:        key.Signal,
+		FieldContext:  key.FieldContext,
+		FieldDataType: key.FieldDataType,
+		Members:       []*TelemetryFieldKey{key},
+	}
+}
+
+// Single returns the only member. It is the accessor for signals whose
+// logical fields are always single-member (everything except traces today).
+func (l *LogicalField) Single() *TelemetryFieldKey {
+	return l.Members[0]
+}
+
+// IsFamily reports whether the field has more than one physical member.
+func (l *LogicalField) IsFamily() bool {
+	return len(l.Members) > 1
+}
+
+// String implements fmt.Stringer for warning messages.
+func (l *LogicalField) String() string {
+	if len(l.Members) == 1 {
+		return l.Members[0].String()
+	}
+	names := make([]string, 0, len(l.Members))
+	for _, member := range l.Members {
+		names = append(names, member.Name)
+	}
+	return l.Name + "(" + l.FieldContext.StringValue() + ", " + l.FieldDataType.StringValue() + ", members: " + joinNames(names) + ")"
+}
+
+func joinNames(names []string) string {
+	out := ""
+	for i, name := range names {
+		if i > 0 {
+			out += ", "
+		}
+		out += name
+	}
+	return out
+}


### PR DESCRIPTION
## What this is

A working prototype of the `LogicalField` representation discussed in review — resolution output as an explicit group type instead of annotations flattened onto `TelemetryFieldKey`. Based on #12442's head so the diff is exactly the representation change for identical functionality: same generated SQL, same semantics, every `./pkg/...` and `./ee/...` test green.

**Not for merge as-is** — it exists to judge the shape end to end.

## The model

```
resolve(request, metadata) -> []*LogicalField
        the slice = ambiguity   (union across, warn)
        the group = family      (merge within, current-first precedence)
```

A `LogicalField` is the requested spelling + the shared identity triple + member keys ordered current-first. Members alias metadata entries untouched; each member carries its own physical facts (`Materialized`, `Evolutions`, …), so family expressions compose from the members' own `FieldFor` outputs and no key ever smuggles sibling state.

## What it deletes

- `SemconvMembers` and `SemconvMaterializedColumns` from `TelemetryFieldKey`
- resolution-time deep copying (members are never mutated)
- `resourcefilter.memberKey()` fabrication and the per-mapper member-derivation helpers with their static fallbacks
- the family branches inside `resolveColumnExprs` — `FieldFor` is a strict per-physical-key primitive again, byte-identical to main

## What to look at, in order

1. `pkg/types/telemetrytypes/logical_field.go` — the type and its contract
2. `pkg/querybuilder/where_clause_visitor.go` — `MatchingLogicalFields`: grouping, the per-item family scope guard, and members sorted by family rank (fixes the context-prefixed precedence inversion, test-pinned)
3. `pkg/telemetryschema/tracestelemetryschema/field_mapper.go` — `FieldForLogical`/`ExistsForLogical`: the family expression as a composition of per-member expressions; `upgradeToFamilies` in `ColumnExpressionFor`, which preserves the legacy candidate flow byte-for-byte and only swaps candidates for their family
4. `pkg/statementbuilder/resourcefilter/` — the same pattern on the fingerprint path; hints and presence checks now read real member keys
5. The non-family signals (logs/metrics/audit/metadata/rulestatehistory) — two-line `SingleKeys()` adapters; their logical fields are single-member by construction, pinned by literalness tests

## Judgment calls worth debating

- Traces and resourcefilter condition builders now take their package's concrete mapper instead of `qbtypes.FieldMapper` (they need the logical methods; the alternative was widening the shared interface for all seven mappers)
- `ColumnExpressionFor` keeps the legacy candidate flow and family-upgrades its output, rather than resolving logically first — that choice is what kept every legacy/corrupt-data golden test byte-identical
- Per-member evolution handling is a small semantic *improvement* over #12442 (each member resolves against its own storage history); the combined family-with-evolutions expression is therefore shaped differently — nested per-member `multiIf`s inside the coalesce instead of one interleaved expression

## Diff stats

21 files, +755 / −598 on top of #12442 — net +157 lines while deleting two struct fields, one fabrication helper, three member-derivation copies, and the deep-copy machinery.

🤖 Generated with [Claude Code](https://claude.com/claude-code)