### PR TITLE
chore(frontend): remove the loginPrecheck mock for a removed endpoint

### DIFF
--- a/frontend/src/mocks-server/handlers.ts
+++ b/frontend/src/mocks-server/handlers.ts
@@ -139,27 +139,6 @@ export const handlers = [
 			return res(ctx.status(500));
 		},
 	),
-	rest.get('http://localhost/api/v1/loginPrecheck', (req, res, ctx) => {
-		const email = req.url.searchParams.get('email');
-		if (email === 'failEmail@signoz.io') {
-			return res(ctx.status(500));
-		}
-
-		return res(
-			ctx.status(200),
-			ctx.json({
-				status: 'success',
-				data: {
-					sso: true,
-					ssoUrl: '',
-					canSelfRegister: false,
-					isUser: true,
-					ssoError: '',
-				},
-			}),
-		);
-	}),
-
 	rest.get('http://localhost/api/v2/licenses', (req, res, ctx) =>
 		res(ctx.status(200), ctx.json(licensesSuccessResponse)),
 	),


### PR DESCRIPTION
#### Description

- Removes the msw mock for `/api/v1/loginPrecheck` — the endpoint no longer exists in the backend and nothing in the frontend calls it anymore; the login flow runs on `/api/v2/sessions/context`.
