### PR TITLE
fix(user): return 400 instead of 501 for protected user states

### DIFF
--- a/docs/api/openapi.yml
+++ b/docs/api/openapi.yml
@@ -23421,6 +23421,12 @@ paths:
       responses:
         "204":
           description: No Content
+        "400":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/RenderErrorResponse'
+          description: Bad Request
         "401":
           content:
             application/json:
@@ -23767,6 +23773,12 @@ paths:
       responses:
         "200":
           description: OK
+        "400":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/RenderErrorResponse'
+          description: Bad Request
         "401":
           content:
             application/json:
@@ -23819,6 +23831,12 @@ paths:
       responses:
         "204":
           description: No Content
+        "400":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/RenderErrorResponse'
+          description: Bad Request
         "401":
           content:
             application/json:
@@ -23906,6 +23924,12 @@ paths:
       responses:
         "204":
           description: No Content
+        "400":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/RenderErrorResponse'
+          description: Bad Request
         "401":
           content:
             application/json:

--- a/pkg/apiserver/signozapiserver/user.go
+++ b/pkg/apiserver/signozapiserver/user.go
@@ -122,7 +122,7 @@ func (provider *provider) addUserRoutes(router *mux.Router) error {
 		Response:            nil,
 		ResponseContentType: "",
 		SuccessStatusCode:   http.StatusNoContent,
-		ErrorStatusCodes:    []int{},
+		ErrorStatusCodes:    []int{http.StatusBadRequest},
 		Deprecated:          false,
 		SecuritySchemes:     []handler.OpenAPISecurityScheme{{Name: authtypes.IdentNProviderTokenizer.StringValue()}},
 	})).Methods(http.MethodPut).GetError(); err != nil {
@@ -173,7 +173,7 @@ func (provider *provider) addUserRoutes(router *mux.Router) error {
 		Response:            nil,
 		ResponseContentType: "",
 		SuccessStatusCode:   http.StatusNoContent,
-		ErrorStatusCodes:    []int{http.StatusNotFound},
+		ErrorStatusCodes:    []int{http.StatusBadRequest, http.StatusNotFound},
 		Deprecated:          false,
 		SecuritySchemes:     newSecuritySchemes(types.RoleAdmin),
 	})).Methods(http.MethodDelete).GetError(); err != nil {
@@ -343,7 +343,7 @@ func (provider *provider) addUserRoutes(router *mux.Router) error {
 		Response:            nil,
 		ResponseContentType: "",
 		SuccessStatusCode:   http.StatusOK,
-		ErrorStatusCodes:    []int{http.StatusNotFound},
+		ErrorStatusCodes:    []int{http.StatusBadRequest, http.StatusNotFound},
 		Deprecated:          true,
 		SecuritySchemes:     newSecuritySchemes(types.RoleAdmin),
 	})).Methods(http.MethodPost).GetError(); err != nil {
@@ -360,7 +360,7 @@ func (provider *provider) addUserRoutes(router *mux.Router) error {
 		Response:            nil,
 		ResponseContentType: "",
 		SuccessStatusCode:   http.StatusNoContent,
-		ErrorStatusCodes:    []int{http.StatusNotFound},
+		ErrorStatusCodes:    []int{http.StatusBadRequest, http.StatusNotFound},
 		Deprecated:          true,
 		SecuritySchemes:     newSecuritySchemes(types.RoleAdmin),
 	})).Methods(http.MethodDelete).GetError(); err != nil {

--- a/pkg/types/user.go
+++ b/pkg/types/user.go
@@ -170,7 +170,7 @@ func (u *User) UpdateEmail(email valuer.Email) {
 // enrich the error with the specific operation using errors.WithAdditionalf.
 func (u *User) ErrIfRoot() error {
 	if u.IsRoot {
-		return errors.New(errors.TypeUnsupported, ErrCodeRootUserOperationUnsupported, "this operation is not supported for the root user")
+		return errors.New(errors.TypeInvalidInput, ErrCodeRootUserOperationUnsupported, "this operation is not supported for the root user")
 	}
 	return nil
 }
@@ -179,7 +179,7 @@ func (u *User) ErrIfRoot() error {
 // This error can be enriched with specific operation by the called using errors.WithAdditionalf.
 func (u *User) ErrIfDeleted() error {
 	if u.Status == UserStatusDeleted {
-		return errors.New(errors.TypeUnsupported, ErrCodeUserStatusDeleted, "unsupported operation for deleted user")
+		return errors.New(errors.TypeInvalidInput, ErrCodeUserStatusDeleted, "unsupported operation for deleted user")
 	}
 	return nil
 }
@@ -188,7 +188,7 @@ func (u *User) ErrIfDeleted() error {
 // This error can be enriched with specific operation by the called using errors.WithAdditionalf.
 func (u *User) ErrIfPending() error {
 	if u.Status == UserStatusPendingInvite {
-		return errors.New(errors.TypeUnsupported, ErrCodeUserStatusPendingInvite, "unsupported operation for pending user")
+		return errors.New(errors.TypeInvalidInput, ErrCodeUserStatusPendingInvite, "unsupported operation for pending user")
 	}
 	return nil
 }

--- a/tests/integration/tests/rootuser/02_impersonation.py
+++ b/tests/integration/tests/rootuser/02_impersonation.py
@@ -55,3 +55,33 @@ def test_impersonated_user_is_admin(signoz: types.SigNoz) -> None:
     )
     assert root_detail.status_code == HTTPStatus.OK
     assert_user_has_role(root_detail.json()["data"], "signoz-admin")
+
+
+def test_mutating_root_user_is_rejected(signoz: types.SigNoz) -> None:
+    """
+    The root user is permanently protected, so mutating it is rejected with
+    400 and a machine readable code. ErrIfRoot runs before the self-delete
+    guard, so this holds even when the caller is the impersonated root
+    identity itself.
+    """
+    response = requests.get(
+        signoz.self.host_configs["8080"].get("/api/v2/users"),
+        timeout=2,
+    )
+    assert response.status_code == HTTPStatus.OK
+
+    root_user = next(
+        (u for u in response.json()["data"] if u.get("isRoot") is True),
+        None,
+    )
+    assert root_user is not None
+
+    response = requests.delete(
+        signoz.self.host_configs["8080"].get(f"/api/v2/users/{root_user['id']}"),
+        timeout=2,
+    )
+
+    assert response.status_code == HTTPStatus.BAD_REQUEST, response.text
+    error = response.json()["error"]
+    assert error["type"] == "invalid-input"
+    assert error["code"] == "root_user_operation_unsupported"


### PR DESCRIPTION
#### Description

- `ErrIfRoot`, `ErrIfDeleted` and `ErrIfPending` returned **501**, which means the server lacks the functionality — that is how the noop providers signal edition gating. These three are business rules that ship in every build.
- They now return **400**, matching `ErrIfNotPending` which already did.
- Adds an integration test; nothing asserted this status before.

#### Additional Information

- No status expresses "rejected permanently, for every caller, and not for permissions", so the meaning stays in the error code each guard already returns.
- `TypeUnsupported` and its 501 mapping are untouched, so licensing and gateway edition gating are unaffected.