### PR TITLE
chore(telemetrytypes): introduce LogicalField

### DIFF
--- a/pkg/types/telemetrytypes/logical_field.go
+++ b/pkg/types/telemetrytypes/logical_field.go
@@ -1,0 +1,78 @@
+package telemetrytypes
+
+import "strings"
+
+// LogicalField is one queryable field. Its Name is the spelling that the
+// request used. Its Members are the physical keys that store the field.
+// LogicalField is the output type of name resolution: resolution changes a
+// referenced name into logical fields, and compilers make SQL from them.
+//
+// A []*LogicalField shows ambiguity. Ambiguity means that possibly different
+// fields have the same name. Each logical field in the slice gets its own
+// condition. The operator tells the compiler how to connect the conditions.
+//
+// One LogicalField with more than one member shows a semantic-convention
+// family. A family is one field that has more than one spelling. The members
+// are in current-first order. The compiler merges the members into one
+// expression, and the current name wins.
+//
+// Members always has one entry or more. A field that is not a family has
+// exactly one member. The members point to the metadata map entries. Do not
+// change the members.
+type LogicalField struct {
+	// Name is the spelling that the request used. Aliases, series labels,
+	// and warnings use this spelling. Because of this, the response shows
+	// the same spelling as the request.
+	Name string
+
+	// Signal, FieldContext, and FieldDataType are the identity that all
+	// members share. Members with a different signal, field context, or
+	// data type are parts of different logical fields.
+	Signal        Signal
+	FieldContext  FieldContext
+	FieldDataType FieldDataType
+
+	// Members are the physical keys that store this field, in current-first
+	// order. Each member has its own physical data (Materialized,
+	// Evolutions, JSONPlan, ...). A per-member accessor does not need data
+	// from the other members.
+	Members []*TelemetryFieldKey
+}
+
+// SingleLogicalField makes a logical field that has one physical key.
+func SingleLogicalField(name string, key *TelemetryFieldKey) *LogicalField {
+	return &LogicalField{
+		Name:          name,
+		Signal:        key.Signal,
+		FieldContext:  key.FieldContext,
+		FieldDataType: key.FieldDataType,
+		Members:       []*TelemetryFieldKey{key},
+	}
+}
+
+// Single returns the only member of a single-member field. A decision that
+// uses only the shared identity can also use Single on a family. This is
+// safe because all members have the same signal, context, and data type.
+func (l *LogicalField) Single() *TelemetryFieldKey {
+	return l.Members[0]
+}
+
+// IsFamily returns true when the field has more than one physical member.
+func (l *LogicalField) IsFamily() bool {
+	return len(l.Members) > 1
+}
+
+// String implements fmt.Stringer. A single-member field prints as its
+// member. Because of this, a message made from the field and a message made
+// from the key are the same. A family prints its shared identity and its
+// member spellings.
+func (l *LogicalField) String() string {
+	if len(l.Members) == 1 {
+		return l.Members[0].String()
+	}
+	names := make([]string, 0, len(l.Members))
+	for _, member := range l.Members {
+		names = append(names, member.Name)
+	}
+	return l.Name + "(" + l.FieldContext.StringValue() + ", " + l.FieldDataType.StringValue() + ", members: " + strings.Join(names, ", ") + ")"
+}

--- a/pkg/types/telemetrytypes/logical_field_test.go
+++ b/pkg/types/telemetrytypes/logical_field_test.go
@@ -1,0 +1,50 @@
+package telemetrytypes
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestSingleLogicalFieldSharesIdentityAndAliasesKey(t *testing.T) {
+	key := &TelemetryFieldKey{
+		Name:          "service.name",
+		Signal:        SignalTraces,
+		FieldContext:  FieldContextResource,
+		FieldDataType: FieldDataTypeString,
+	}
+
+	logical := SingleLogicalField("resource.service.name", key)
+
+	assert.Equal(t, "resource.service.name", logical.Name, "the identity is the spelling that the request used, not the stored spelling")
+	assert.Equal(t, key.Signal, logical.Signal)
+	assert.Equal(t, key.FieldContext, logical.FieldContext)
+	assert.Equal(t, key.FieldDataType, logical.FieldDataType)
+	assert.False(t, logical.IsFamily())
+	assert.Same(t, key, logical.Single(), "the member points to the key; there is no copy")
+}
+
+func TestStringDelegatesForSingleMember(t *testing.T) {
+	key := &TelemetryFieldKey{
+		Name:          "service.name",
+		FieldContext:  FieldContextResource,
+		FieldDataType: FieldDataTypeString,
+	}
+	assert.Equal(t, key.String(), SingleLogicalField(key.Name, key).String(),
+		"a message made from a single-member field must be the same as a message made from the key")
+}
+
+func TestStringListsFamilyMembers(t *testing.T) {
+	logical := &LogicalField{
+		Name:          "deployment.environment.name",
+		Signal:        SignalTraces,
+		FieldContext:  FieldContextResource,
+		FieldDataType: FieldDataTypeString,
+		Members: []*TelemetryFieldKey{
+			{Name: "deployment.environment.name"},
+			{Name: "deployment.environment"},
+		},
+	}
+	assert.True(t, logical.IsFamily())
+	assert.Equal(t, "deployment.environment.name(resource, string, members: deployment.environment.name, deployment.environment)", logical.String())
+}


### PR DESCRIPTION
Possible options

1. The compatibility keys maps (the approach already in the code).

`backward_compat_keys.go` makes an alias key at metadata time. We rejected this option because of evidence. The alias key resolves, but it reads the wrong data. It prepares to `attributes_string['<alias>']`, and that physical key does not hold the data.

2. The flat multi-key.

`GetKeys` returns multiple keys in order, and the downstream code uses the list. The option fails on semantics. It removes one piece of information that the downstream must have. The downstream must know the difference between two cases:

- Two keys are the same field with two spellings so we can merge them into one expression.
- Two keys are different fields with the same name. The condition builder must make one condition for each key. The operator connects the conditions.

Three failures show the problem:

- Negative operators connect with OR across the keys. A row that has only one spelling then always matches. Example: `env != 'prod'` matches each row that does not have one of the two keys.
- A row that has both spellings with different values gets no clear result.
- A value position (group-by, select) needs exactly one expression for one field. A flat list cannot point to that expression.

The information must live somewhere.

3. Annotations on `TelemetryFieldKey`

Maintain the `SemconvMembers` and `SemconvMaterializedColumns` fields on the keys. The information is the same as in option 4. But it's awkward because "these N keys are one family, in this order" lives in N copies, one copy on each key. 

4. introduce `LogicalField`

The information is the same as in option 3, but the structure holds it:

- The slice is the ambiguity.
- The group is the family.
- The member order is the precedence. The code sorts the members one time, by family rank, at construction.
- The members point to the metadata entries. The code copies nothing and changes nothing.
- The identity (signal, context, data type) is on the group. A merge across contexts or data types is not possible. The design does not avoid that merge; the design cannot express it.
