### PR TITLE
fix: allow deletion of legacy dashboards via delete api

### DIFF
--- a/pkg/modules/dashboard/impldashboard/v2_module.go
+++ b/pkg/modules/dashboard/impldashboard/v2_module.go
@@ -245,11 +245,13 @@ func (module *module) PatchV2(ctx context.Context, orgID valuer.UUID, id valuer.
 }
 
 func (module *module) DeleteV2(ctx context.Context, orgID valuer.UUID, id valuer.UUID) error {
-	existing, err := module.GetV2(ctx, orgID, id)
+	// Read the storable, not the decoded v2 dashboard: deleting must work even
+	// when the stored data is corrupt or never migrated off the v1 schema.
+	storable, err := module.store.Get(ctx, orgID, id)
 	if err != nil {
 		return err
 	}
-	if err := existing.ErrIfNotDeletable(); err != nil {
+	if err := storable.ErrIfNotDeletable(); err != nil {
 		return err
 	}
 

--- a/pkg/types/dashboardtypes/dashboard.go
+++ b/pkg/types/dashboardtypes/dashboard.go
@@ -201,6 +201,18 @@ func (storableDashboardData *StorableDashboardData) GetWidgetIds() []string {
 	return widgetIds
 }
 
+// ErrIfNotDeletable gates deletion on the columns alone, never on Data, so a
+// dashboard whose data is corrupt or stuck on the v1 schema stays deletable.
+func (storable StorableDashboard) ErrIfNotDeletable() error {
+	if storable.Locked {
+		return errors.Newf(errors.TypeInvalidInput, errors.CodeInvalidInput, "cannot delete a locked dashboard, please unlock the dashboard to delete")
+	}
+	if !storable.Source.isUserDeletable() {
+		return errors.Newf(errors.TypeInvalidInput, ErrCodeDashboardImmutable, "%s dashboards cannot be deleted", storable.Source)
+	}
+	return nil
+}
+
 func (dashboard *Dashboard) ErrIfNotMutable() error {
 	if dashboard.Source == SourceIntegration {
 		return errors.Newf(errors.TypeInvalidInput, ErrCodeDashboardImmutable, "integration dashboards cannot be modified")

--- a/pkg/types/dashboardtypes/dashboard_test.go
+++ b/pkg/types/dashboardtypes/dashboard_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"testing"
 
+	"github.com/SigNoz/signoz/pkg/types"
 	"github.com/SigNoz/signoz/pkg/valuer"
 	"github.com/stretchr/testify/assert"
 )
@@ -78,6 +79,67 @@ func TestCanUpdate_MultipleDeletions_ByDiff(t *testing.T) {
 			} else {
 				assert.NoError(t, err)
 			}
+		})
+	}
+}
+
+func TestStorableDashboardErrIfNotDeletable(t *testing.T) {
+	testCases := []struct {
+		subtestName     string
+		locked          bool
+		source          Source
+		data            StorableDashboardData
+		expectDeletable bool
+	}{
+		{
+			subtestName:     "user dashboard on the v2 schema",
+			source:          SourceUser,
+			data:            StorableDashboardData{"metadata": map[string]any{"schemaVersion": SchemaVersion}},
+			expectDeletable: true,
+		},
+		{
+			subtestName:     "user dashboard still on the v1 schema",
+			source:          SourceUser,
+			data:            StorableDashboardData{"widgets": makeTestWidgets("a")},
+			expectDeletable: true,
+		},
+		{
+			subtestName:     "user dashboard with unreadable data",
+			source:          SourceUser,
+			data:            StorableDashboardData{"metadata": "not-an-object"},
+			expectDeletable: true,
+		},
+		{
+			subtestName:     "locked user dashboard",
+			locked:          true,
+			source:          SourceUser,
+			data:            StorableDashboardData{"widgets": makeTestWidgets("a")},
+			expectDeletable: false,
+		},
+		{
+			subtestName:     "system dashboard",
+			source:          SourceSystem,
+			data:            StorableDashboardData{"widgets": makeTestWidgets("a")},
+			expectDeletable: false,
+		},
+		{
+			subtestName:     "integration dashboard",
+			source:          SourceIntegration,
+			data:            StorableDashboardData{"widgets": makeTestWidgets("a")},
+			expectDeletable: false,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.subtestName, func(t *testing.T) {
+			storable := StorableDashboard{
+				Identifiable: types.Identifiable{ID: valuer.GenerateUUID()},
+				OrgID:        valuer.GenerateUUID(),
+				Locked:       tc.locked,
+				Source:       tc.source,
+				Data:         tc.data,
+			}
+			assert.Equal(t, tc.expectDeletable, storable.ErrIfNotDeletable() == nil)
 		})
 	}
 }

--- a/pkg/types/dashboardtypes/perses_dashboard.go
+++ b/pkg/types/dashboardtypes/perses_dashboard.go
@@ -129,16 +129,6 @@ func (d *DashboardV2) LockUnlock(lock bool, isAdmin bool, updatedBy string) erro
 	return nil
 }
 
-func (d *DashboardV2) ErrIfNotDeletable() error {
-	if d.Locked {
-		return errors.Newf(errors.TypeInvalidInput, errors.CodeInvalidInput, "cannot delete a locked dashboard, please unlock the dashboard to delete")
-	}
-	if !d.Source.isUserDeletable() {
-		return errors.Newf(errors.TypeInvalidInput, ErrCodeDashboardImmutable, "%s dashboards cannot be deleted", d.Source)
-	}
-	return nil
-}
-
 func (d *DashboardV2) ErrIfNotClonable() error {
 	if !d.Source.isClonable() {
 		return errors.Newf(errors.TypeInvalidInput, ErrCodeDashboardImmutable, "%s dashboards cannot be cloned", d.Source)


### PR DESCRIPTION
#### Description

If a dashboard failed to migrate to the new schema, currently the delete API does not delete them. This PR changes it to be able to delete those un-migrated dashboards as well.

#### Issues closed by this PR

Closes https://github.com/SigNoz/signoz/issues/12390
