### PR TITLE
feat(logs-explorer): resolve body json fields in logs table columns

### DIFF
--- a/frontend/src/components/Logs/TableView/__tests__/useLogsTableColumns.test.tsx
+++ b/frontend/src/components/Logs/TableView/__tests__/useLogsTableColumns.test.tsx
@@ -10,6 +10,10 @@ jest.mock('providers/Timezone', () => ({
 	}),
 }));
 
+jest.mock('providers/App/App', () => ({
+	useAppContext: (): { featureFlags: [] } => ({ featureFlags: [] }),
+}));
+
 const field = (name: string, type = ''): IField => ({
 	name,
 	type,

--- a/frontend/src/components/Logs/TableView/useLogsTableColumns.tsx
+++ b/frontend/src/components/Logs/TableView/useLogsTableColumns.tsx
@@ -2,13 +2,15 @@ import type { ReactElement } from 'react';
 import { useMemo } from 'react';
 import TanStackTable from 'components/TanStackTableView';
 import { DATE_TIME_FORMATS } from 'constants/dateTimeFormats';
+import { FeatureKeys } from 'constants/features';
 import {
 	getBodyDisplayString,
 	getSanitizedLogBody,
 } from 'container/LogDetailedView/utils';
 import { FontSize } from 'container/OptionsMenu/types';
 import { buildCompositeKey } from 'container/OptionsMenu/utils';
-import { FlatLogData } from 'lib/logs/flatLogData';
+import { getLogFieldValue } from 'lib/logs/flatLogData';
+import { useAppContext } from 'providers/App/App';
 import { useTimezone } from 'providers/Timezone';
 import { IField } from 'types/api/logs/fields';
 import { ILog } from 'types/api/logs/log';
@@ -26,6 +28,10 @@ export function useLogsTableColumns({
 	fontSize,
 }: UseLogsTableColumnsProps): TableColumnDef<ILog>[] {
 	const { formatTimezoneAdjustedTimestamp } = useTimezone();
+	const { featureFlags } = useAppContext();
+	const isBodyJsonEnabled =
+		featureFlags?.find((flag) => flag.name === FeatureKeys.USE_JSON_BODY)
+			?.active || false;
 
 	return useMemo<TableColumnDef<ILog>[]>(() => {
 		const stateIndicatorCol: TableColumnDef<ILog> = {
@@ -88,7 +94,8 @@ export function useLogsTableColumns({
 		const makeUserFieldCol = (f: IField): TableColumnDef<ILog> => ({
 			id: buildCompositeKey(f.name, f.type),
 			header: f.name,
-			accessorFn: (log): unknown => FlatLogData(log)[f.name],
+			accessorFn: (log): unknown =>
+				getLogFieldValue(log, f.name, isBodyJsonEnabled),
 			enableRemove: true,
 			width: { min: 192 },
 			cell: ({ value }): ReactElement => (
@@ -115,5 +122,5 @@ export function useLogsTableColumns({
 			.filter((c): c is TableColumnDef<ILog> => c !== null);
 
 		return [stateIndicatorCol, ...fieldCols];
-	}, [fields, fontSize, formatTimezoneAdjustedTimestamp]);
+	}, [fields, fontSize, formatTimezoneAdjustedTimestamp, isBodyJsonEnabled]);
 }

--- a/frontend/src/lib/logs/flatLogData.test.ts
+++ b/frontend/src/lib/logs/flatLogData.test.ts
@@ -1,0 +1,55 @@
+import { ILog } from 'types/api/logs/log';
+
+import { getLogFieldValue } from './flatLogData';
+
+const asLog = (partial: Partial<ILog>): ILog => partial as unknown as ILog;
+
+describe('getLogFieldValue', () => {
+	it('resolves a nested body field by dotted key when use_json_body is on', () => {
+		const log = asLog({ body: { a: { b: { c: 'deep' } } } });
+		expect(getLogFieldValue(log, 'a.b.c', true)).toBe('deep');
+	});
+
+	it('ignores body when use_json_body is off', () => {
+		const log = asLog({ body: { a: { b: { c: 'deep' } } } });
+		expect(getLogFieldValue(log, 'a.b.c', false)).toBeUndefined();
+	});
+
+	it('ignores a stringified body even when use_json_body is on', () => {
+		const log = asLog({ body: '{"a":{"b":1}}' });
+		expect(getLogFieldValue(log, 'a.b', true)).toBeUndefined();
+	});
+
+	it('prefers the body value over attributes when the key exists in both (body first)', () => {
+		const log = asLog({
+			attributes_string: { 'a.b': 'attr' } as never,
+			body: { a: { b: 'bodyval' } },
+		});
+		expect(getLogFieldValue(log, 'a.b', true)).toBe('bodyval');
+	});
+
+	it('falls back to attributes when the key is not in the body', () => {
+		const log = asLog({
+			attributes_string: { 'x.y': 'attr' } as never,
+			body: { other: 1 },
+		});
+		expect(getLogFieldValue(log, 'x.y', true)).toBe('attr');
+	});
+
+	it('preserves falsy body values (0, false, empty string)', () => {
+		const log = asLog({ body: { n: 0, flag: false, s: '' } });
+		expect(getLogFieldValue(log, 'n', true)).toBe(0);
+		expect(getLogFieldValue(log, 'flag', true)).toBe(false);
+		expect(getLogFieldValue(log, 's', true)).toBe('');
+	});
+
+	it('returns undefined when the body path is missing', () => {
+		const log = asLog({ body: { x: 1 } });
+		expect(getLogFieldValue(log, 'nope', true)).toBeUndefined();
+	});
+
+	it('returns undefined when a mid path segment is not an object', () => {
+		const log = asLog({ body: { a: { b: 'leaf' } } });
+		expect(getLogFieldValue(log, 'a.b.c', true)).toBeUndefined();
+	});
+});

--- a/frontend/src/lib/logs/flatLogData.ts
+++ b/frontend/src/lib/logs/flatLogData.ts
@@ -1,5 +1,5 @@
 import { defaultTo } from 'lodash-es';
-import { ILog } from 'types/api/logs/log';
+import { ILog, ILogBody } from 'types/api/logs/log';
 
 export function FlatLogData(log: ILog): Record<string, string> {
 	const flattenLogObject: Record<string, string> = {};
@@ -14,4 +14,30 @@ export function FlatLogData(log: ILog): Record<string, string> {
 		}
 	});
 	return flattenLogObject;
+}
+
+function getBodyFieldValue(body: ILogBody, key: string): unknown {
+	return key.split('.').reduce<unknown>((acc, segment) => {
+		if (acc && typeof acc === 'object' && !Array.isArray(acc)) {
+			return (acc as Record<string, unknown>)[segment];
+		}
+		return undefined;
+	}, body);
+}
+
+// Resolve one field for the logs table. A JSON body is checked first (use_json_body
+// only), splitting the key on `.`; otherwise fall back to FlatLogData
+// (attributes/resources/scope/top-level).
+export function getLogFieldValue(
+	log: ILog,
+	fieldName: string,
+	isBodyJsonEnabled: boolean,
+): unknown {
+	if (isBodyJsonEnabled && log.body && typeof log.body === 'object') {
+		const bodyValue = getBodyFieldValue(log.body, fieldName);
+		if (bodyValue !== undefined) {
+			return bodyValue;
+		}
+	}
+	return FlatLogData(log)[fieldName];
 }


### PR DESCRIPTION
<!--A few plain bullets saying what changed and why, for a reviewer skimming it - not a wall of text, not a restatement of the diff, not generated boilerplate.-->
#### Description
In the logs explorer **table view**, a column for a field that lives inside a JSON body now shows its value instead of coming up empty. Scoped to `use_json_body` tenants.

- Added a wrapper util which sits on top of existing util which provides the col values(FlatLogData).
- This searches for the attribute in body json. If its not present there we will get it from attribute/resources as its happening currently.
- Only does this if `use_json_body` is true.

<!--Reference issues using `Closes #issue-number` to enable automatic closure on merge. -->
#### Issues closed by this PR
Closes https://github.com/SigNoz/engineering-pod/issues/4610
<!--If applicable, include screenshots or screen recordings that clearly show the behavior before the change and the result after the change. -->
#### Screenshots / Screen Recordings

Before:
DB Operation col is empty
<img width="3402" height="1850" alt="image" src="https://github.com/user-attachments/assets/7f8c6945-2c43-4ea6-9b82-5fd07b36c52f" />


After:
DB Operation col is populated from body

<img width="3346" height="1778" alt="image" src="https://github.com/user-attachments/assets/c1ae2953-986e-42d5-bef3-9bc10e932fc2" />

