### PR TITLE
perf(logs): let body_v2 filters use the body_v2 bloom filters

### DIFF
--- a/pkg/statementbuilder/logsstatementbuilder/json_stmt_builder_test.go
+++ b/pkg/statementbuilder/logsstatementbuilder/json_stmt_builder_test.go
@@ -197,8 +197,8 @@ func TestJSONStmtBuilder_PrimitivePaths(t *testing.T) {
 			name:   "message Contains 'Iron Award'",
 			filter: "message Contains 'Iron Award'",
 			expected: TestExpected{
-				WhereClause: "LOWER(body_v2.message) LIKE LOWER(?)",
-				Args:        []any{"%Iron Award%", "1747947419000000000", uint64(1747945619), "1747983448000000000", uint64(1747983448), 10},
+				WhereClause: "(LOWER(body_v2.message) LIKE LOWER(?) AND LOWER(toString(body_v2)) LIKE " + jsonSubstringNeedle + ")",
+				Args:        []any{"%Iron Award%", "Iron Award", "Iron Award", "1747947419000000000", uint64(1747945619), "1747983448000000000", uint64(1747983448), 10},
 			},
 		},
 

--- a/pkg/statementbuilder/logsstatementbuilder/stmt_builder_test.go
+++ b/pkg/statementbuilder/logsstatementbuilder/stmt_builder_test.go
@@ -945,6 +945,9 @@ func TestAdjustKey(t *testing.T) {
 	}
 }
 
+// The needle ClickHouse builds for the body_v2 index expression.
+const jsonSubstringNeedle = `concat('%', replaceAll(replaceAll(replaceAll(lower(substring(toJSONString(?), 2, length(toJSONString(?)) - 2)), '\\', '\\\\'), '%', '\\%'), '_', '\\_'), '%')`
+
 func TestStmtBuilderBodyField(t *testing.T) {
 	cases := []struct {
 		name              string
@@ -1026,8 +1029,8 @@ func TestStmtBuilderBodyField(t *testing.T) {
 			},
 			enableUseJSONBody: true,
 			expected: qbtypes.Statement{
-				Query:    "SELECT timestamp, id, trace_id, span_id, trace_flags, severity_text, severity_number, scope_name, scope_version, body_v2 as body, attributes_string, attributes_number, attributes_bool, resources_string, scope_string FROM signoz_logs.distributed_logs_v2 WHERE LOWER(body_v2.message) LIKE LOWER(?) AND timestamp >= ? AND ts_bucket_start >= ? AND timestamp < ? AND ts_bucket_start <= ? LIMIT ?",
-				Args:     []any{"%error%", "1747947419000000000", uint64(1747945619), "1747983448000000000", uint64(1747983448), 10},
+				Query:    "SELECT timestamp, id, trace_id, span_id, trace_flags, severity_text, severity_number, scope_name, scope_version, body_v2 as body, attributes_string, attributes_number, attributes_bool, resources_string, scope_string FROM signoz_logs.distributed_logs_v2 WHERE (LOWER(body_v2.message) LIKE LOWER(?) AND LOWER(toString(body_v2)) LIKE " + jsonSubstringNeedle + ") AND timestamp >= ? AND ts_bucket_start >= ? AND timestamp < ? AND ts_bucket_start <= ? LIMIT ?",
+				Args:     []any{"%error%", "error", "error", "1747947419000000000", uint64(1747945619), "1747983448000000000", uint64(1747983448), 10},
 				Warnings: []string{bodySearchDefaultWarning},
 			},
 			expectedErr: nil,

--- a/pkg/telemetryschema/logstelemetryschema/condition_builder.go
+++ b/pkg/telemetryschema/logstelemetryschema/condition_builder.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"regexp"
+	"strings"
 
 	schema "github.com/SigNoz/signoz-otel-collector/cmd/signozschemamigrator/schema_migrator"
 	"github.com/SigNoz/signoz/pkg/errors"
@@ -26,6 +27,83 @@ var _ qbtypes.ConditionBuilder = (*conditionBuilder)(nil)
 
 func NewConditionBuilder(fm qbtypes.FieldMapper, fl flagger.Flagger) *conditionBuilder {
 	return &conditionBuilder{fm: fm, fl: fl}
+}
+
+const (
+	// bodyV2NgramSize is the n of the body_v2 ngrambf_v1 index; a shorter needle yields no
+	// ngram for it to check.
+	bodyV2NgramSize = 4
+	loweredBodyV2   = "LOWER(toString(" + LogsV2BodyV2Column + "))"
+)
+
+// bodyIndexLike renders a LIKE on the body_v2 index expression asserting the serialized JSON
+// contains value. toJSONString escapes the value the same way the column stores it, and
+// replaceAll then escapes the LIKE metacharacters — backslash first, so the ones the later
+// steps add are not doubled again. The expression folds to a constant, which is what keeps
+// the bloom filters usable. anchored keeps toJSONString's quotes, pinning the needle to a
+// complete field value.
+func bodyIndexLike(value string, anchored bool, sb *sqlbuilder.SelectBuilder) string {
+	escaped := fmt.Sprintf("lower(toJSONString(%s))", sb.Var(value))
+	if !anchored {
+		quoted := fmt.Sprintf("toJSONString(%s)", sb.Var(value))
+		escaped = fmt.Sprintf("lower(substring(%s, 2, length(%s) - 2))", quoted, quoted)
+	}
+	return fmt.Sprintf(
+		`%s LIKE concat('%%', replaceAll(replaceAll(replaceAll(%s, '\\', '\\\\'), '%%', '\\%%'), '_', '\\_'), '%%')`,
+		loweredBodyV2, escaped,
+	)
+}
+
+// likePatternLiterals returns the runs of pattern between unescaped wildcards, with `\`
+// escapes resolved. Every value the pattern matches contains each run verbatim. ClickHouse
+// treats `\` as an escape only before `%`, `_` and itself; elsewhere it stands for a literal
+// backslash, so dropping it would yield a run the pattern does not require.
+func likePatternLiterals(pattern string) []string {
+	var (
+		literals []string
+		run      strings.Builder
+	)
+	for i := 0; i < len(pattern); i++ {
+		switch c := pattern[i]; c {
+		case '%', '_':
+			if run.Len() > 0 {
+				literals = append(literals, run.String())
+				run.Reset()
+			}
+		case '\\':
+			if i+1 >= len(pattern) {
+				run.WriteByte('\\')
+				continue
+			}
+			i++
+			if escaped := pattern[i]; escaped != '%' && escaped != '_' && escaped != '\\' {
+				run.WriteByte('\\')
+			}
+			run.WriteByte(pattern[i])
+		default:
+			run.WriteByte(c)
+		}
+	}
+	if run.Len() > 0 {
+		literals = append(literals, run.String())
+	}
+	return literals
+}
+
+// bodyV2SubstringPredicates returns predicates implied by body_v2.message matching pattern,
+// one per literal run long enough for the ngram index. The legacy body needs none: it already
+// queries LOWER(body), which is its own index expression.
+func bodyV2SubstringPredicates(fieldExpression, pattern string, sb *sqlbuilder.SelectBuilder) []string {
+	if fieldExpression != messageSubColumn {
+		return nil
+	}
+	var preds []string
+	for _, literal := range likePatternLiterals(pattern) {
+		if len(literal) >= bodyV2NgramSize {
+			preds = append(preds, bodyIndexLike(literal, false, sb))
+		}
+	}
+	return preds
 }
 
 // conditionForSearch ORs a case-insensitive match of the search term across the key
@@ -315,15 +393,30 @@ func (c *conditionBuilder) conditionForResolvedKey(
 	if fieldExpression == "body" || fieldExpression == messageSubColumn {
 		switch operator {
 		case qbtypes.FilterOperatorEqual:
-			// Bloom filters index lower(body), not the column; `=` still decides the row.
-			if _, ok := value.(string); ok && fieldExpression == LogsV2BodyColumn {
+			// Bloom filters index lower(body) and lower(toString(body_v2)), not the column
+			// being compared; `=` still decides the row.
+			str, isStr := value.(string)
+			if isStr && fieldExpression == LogsV2BodyColumn {
 				return sb.And(
 					sb.E(fieldExpression, value),
 					fmt.Sprintf("LOWER(%s) = LOWER(%s)", fieldExpression, sb.Var(value)),
 				), nil
 			}
-		case qbtypes.FilterOperatorLike:
-			return sb.ILike(fieldExpression, value), nil
+			if isStr && str != "" && fieldExpression == messageSubColumn {
+				return sb.And(sb.E(fieldExpression, value), bodyIndexLike(str, true, sb)), nil
+			}
+		case qbtypes.FilterOperatorLike, qbtypes.FilterOperatorILike, qbtypes.FilterOperatorContains:
+			pattern, isStr := value.(string)
+			if operator == qbtypes.FilterOperatorContains {
+				pattern, isStr = fmt.Sprintf("%%%s%%", value), true
+			}
+			if isStr {
+				cond := sb.ILike(fieldExpression, pattern)
+				if preds := bodyV2SubstringPredicates(fieldExpression, pattern, sb); len(preds) > 0 {
+					return sb.And(append([]string{cond}, preds...)...), nil
+				}
+				return cond, nil
+			}
 		case qbtypes.FilterOperatorNotLike:
 			return sb.NotILike(fieldExpression, value), nil
 		case qbtypes.FilterOperatorRegexp:

--- a/pkg/telemetryschema/logstelemetryschema/condition_builder_test.go
+++ b/pkg/telemetryschema/logstelemetryschema/condition_builder_test.go
@@ -954,3 +954,67 @@ func TestConditionForBodyIn(t *testing.T) {
 		})
 	}
 }
+
+// The escaping is ClickHouse's own toJSONString, verified end-to-end in
+// querier_json_body/07_body_contains.py; what matters here is that the needle stays a
+// constant expression the bloom filters can fold.
+func TestBodyIndexLike(t *testing.T) {
+	testCases := []struct {
+		name         string
+		value        string
+		anchored     bool
+		expected     string
+		expectedArgs []any
+	}{
+		{
+			name:         "anchored keeps the quotes toJSONString adds",
+			value:        "GET /api/v1/users",
+			anchored:     true,
+			expected:     `LOWER(toString(body_v2)) LIKE concat('%', replaceAll(replaceAll(replaceAll(lower(toJSONString(?)), '\\', '\\\\'), '%', '\\%'), '_', '\\_'), '%')`,
+			expectedArgs: []any{"GET /api/v1/users"},
+		},
+		{
+			name:         "substring strips them and binds the value twice",
+			value:        "/api/v1",
+			anchored:     false,
+			expected:     `LOWER(toString(body_v2)) LIKE concat('%', replaceAll(replaceAll(replaceAll(lower(substring(toJSONString(?), 2, length(toJSONString(?)) - 2)), '\\', '\\\\'), '%', '\\%'), '_', '\\_'), '%')`,
+			expectedArgs: []any{"/api/v1", "/api/v1"},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			sb := sqlbuilder.NewSelectBuilder()
+			sb.Select("1").From("t")
+			sb.Where(bodyIndexLike(tc.value, tc.anchored, sb))
+			query, args := sb.BuildWithFlavor(sqlbuilder.ClickHouse)
+			assert.Contains(t, query, tc.expected)
+			assert.Equal(t, tc.expectedArgs, args)
+		})
+	}
+}
+
+// ClickHouse treats `\` as an escape only before `%`, `_` and itself — every expectation
+// here was checked against it, where the pattern matches the run and nothing shorter.
+func TestLikePatternLiterals(t *testing.T) {
+	testCases := []struct {
+		name     string
+		pattern  string
+		expected []string
+	}{
+		{"contains wraps a plain value", "%error%", []string{"error"}},
+		{"wildcards split runs", "%foo%bar%", []string{"foo", "bar"}},
+		{"underscore splits too", "a_b", []string{"a", "b"}},
+		{"escaped wildcards stay literal", `%100\%\_off%`, []string{`100%_off`}},
+		{"escaped backslash collapses", `%C:\\tmp%`, []string{`C:\tmp`}},
+		{"backslash before other chars is literal", `%C:\tmp%`, []string{`C:\tmp`}},
+		{"trailing backslash is literal", `%path\`, []string{`path\`}},
+		{"no literals at all", "%_%", nil},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.expected, likePatternLiterals(tc.pattern))
+		})
+	}
+}

--- a/tests/integration/tests/querier_json_body/07_body_contains.py
+++ b/tests/integration/tests/querier_json_body/07_body_contains.py
@@ -1,0 +1,87 @@
+from collections.abc import Callable
+from datetime import UTC, datetime, timedelta
+from http import HTTPStatus
+
+import pytest
+
+from fixtures import types
+from fixtures.auth import USER_ADMIN_EMAIL, USER_ADMIN_PASSWORD
+from fixtures.logs import Logs
+from fixtures.querier import build_order_by, build_raw_query, get_rows, make_query_request
+
+SLASH = "GET /api/v1/users"
+SUPERSTRING = "GET /api/v1/users/42"
+QUOTE = 'say "hi" now'
+BACKSLASH = "C:\\tmp\\log"
+LIKE_META = "100% _off"
+NON_ASCII = "Mixed CASE Ünïcode"
+TAB = "tab\there"
+CTRL = "ctrl\x01here"
+
+BODIES = [SLASH, SUPERSTRING, QUOTE, BACKSLASH, LIKE_META, NON_ASCII, TAB, CTRL]
+
+
+# CONTAINS and LIKE on body_v2 carry a needle over lower(toString(body_v2)), built by
+# ClickHouse's own toJSONString so it matches the escapes the column stores — a term holding
+# `/` or `"` finds nothing without them. The needle only ever narrows, never widens, so a
+# term that should miss must still miss.
+@pytest.mark.parametrize(
+    "expression,expected_bodies",
+    [
+        pytest.param("body CONTAINS '/api/v1'", {SLASH, SUPERSTRING}, id="contains_slash"),
+        pytest.param("body CONTAINS '\"hi\"'", {QUOTE}, id="contains_quote"),
+        pytest.param(r"body CONTAINS 'C:\\tmp'", {BACKSLASH}, id="contains_backslash"),
+        pytest.param("body CONTAINS 'CASE Ünïcode'", {NON_ASCII}, id="contains_non_ascii"),
+        pytest.param("body CONTAINS 'here'", {TAB, CTRL}, id="contains_beside_control_chars"),
+        pytest.param("body CONTAINS 'nothing here'", set(), id="contains_no_match"),
+        # a run shorter than the ngram size gets no needle, so the match alone decides
+        pytest.param("body CONTAINS 'ab'", {TAB}, id="contains_run_below_ngram_size"),
+        # a `\%` the user wrote has to stay a literal `%` through unescape and re-escape
+        pytest.param(r"body LIKE '%100\% \_off%'", {LIKE_META}, id="like_user_escaped_wildcards"),
+        pytest.param(r"body LIKE '%100\%\_off%'", set(), id="like_escaped_wildcards_are_not_wildcards"),
+        pytest.param("body LIKE 'GET /api/v1/users%'", {SLASH, SUPERSTRING}, id="like_trailing_wildcard"),
+        pytest.param("body LIKE '%CASE Ünïcode'", {NON_ASCII}, id="like_leading_wildcard"),
+    ],
+)
+def test_logs_body_contains_json(
+    signoz: types.SigNoz,
+    create_user_admin: None,  # pylint: disable=unused-argument
+    get_token: Callable[[str, str], str],
+    insert_logs: Callable[[list[Logs]], None],
+    expression: str,
+    expected_bodies: set[str],
+) -> None:
+    now = datetime.now(tz=UTC).replace(second=0, microsecond=0)
+    insert_logs(
+        [
+            Logs(
+                timestamp=now - timedelta(seconds=i + 1),
+                resources={"service.name": "api"},
+                body=body,
+            )
+            for i, body in enumerate(BODIES)
+        ]
+    )
+
+    token = get_token(USER_ADMIN_EMAIL, USER_ADMIN_PASSWORD)
+    response = make_query_request(
+        signoz,
+        token,
+        start_ms=int((now - timedelta(minutes=5)).timestamp() * 1000),
+        end_ms=int(now.timestamp() * 1000),
+        request_type="raw",
+        queries=[
+            build_raw_query(
+                "A",
+                "logs",
+                filter_expression=expression,
+                order=[build_order_by("timestamp", "desc"), build_order_by("id", "desc")],
+                limit=100,
+            )
+        ],
+    )
+
+    assert response.status_code == HTTPStatus.OK, response.text
+    assert response.json()["status"] == "success"
+    # body_v2 comes back parsed; a plain-string body is {"message": <body>}.
+    assert {row["data"]["body"]["message"] for row in get_rows(response)} == expected_bodies


### PR DESCRIPTION
#### Description

- `logs_v2` indexes `lower(toString(body_v2))` — the serialized JSON — while `body` resolves to the `body_v2.message` sub-column. Nothing a body filter compares matches an index expression, so every granule is read. This ANDs in a LIKE over the indexed expression; the original predicate still decides the row, so it only prunes. Measured on 1M rows: **123/123 granules → 1/123**.
- `=` and `IN` anchor on the value with `toJSONString`'s quotes, pinning the needle to a complete field value. `CONTAINS` and `LIKE` take one needle per literal run of the pattern that is at least as long as the ngram size.
- The needle is escaped by ClickHouse's own `toJSONString` — the same function that wrote the column — rather than by mirroring those rules in Go. A term holding `/` or `"` is stored escaped and finds nothing without them. `replaceAll` then escapes the LIKE metacharacters, and the whole expression folds to a constant so the index stays usable.

#### Additional Information

- Stacked on #12502, which is stacked on #12504 — review bottom-up; this PR's diff is the four files on top.
- `likePatternLiterals` follows ClickHouse's escape rules, where `\` is an escape only before `%`, `_` and itself. Reading `\t` as a bare `t` would build a needle the pattern does not require and silently drop matching rows — an earlier draft did exactly that and the integration tests caught it.
- `querier_json_body/07_body_contains.py` covers `/`, `"`, `\`, non-ASCII, control characters, a user-written `\%` that must stay literal, and a run shorter than the ngram size where no needle is emitted at all. Whole suite: 111 passing.
- Not covered here: `search()` still uses `match()` and its body_v2 arm still misses escaped terms — that comes next.
- The cleaner long-term fix is a collector-side index on `lower(body_v2.message)`, which would delete most of this. `message` is a typed `String` path, so the index is accepted and `CONTAINS`/`LIKE` prune with no query-builder code at all; `=` would still need the trivial companion. Worth doing when a schema migration is on the table.
