### PR TITLE
fix(sqlstore): validate Config at load time instead of no-op

### DIFF
--- a/pkg/sqlstore/config.go
+++ b/pkg/sqlstore/config.go
@@ -3,7 +3,20 @@ package sqlstore
 import (
 	"time"
 
+	"github.com/SigNoz/signoz/pkg/errors"
 	"github.com/SigNoz/signoz/pkg/factory"
+)
+
+const (
+	ProviderSQLite   = "sqlite"
+	ProviderPostgres = "postgres"
+
+	SQLiteModeDelete = "delete"
+	SQLiteModeWAL    = "wal"
+
+	SQLiteTransactionModeDeferred  = "deferred"
+	SQLiteTransactionModeImmediate = "immediate"
+	SQLiteTransactionModeExclusive = "exclusive"
 )
 
 type Config struct {
@@ -51,21 +64,54 @@ func NewConfigFactory() factory.ConfigFactory {
 
 func newConfig() factory.Config {
 	return Config{
-		Provider: "sqlite",
+		Provider: ProviderSQLite,
 		Connection: ConnectionConfig{
 			MaxOpenConns:    100,
 			MaxConnLifetime: 0,
 		},
 		Sqlite: SqliteConfig{
 			Path:            "/var/lib/signoz/signoz.db",
-			Mode:            "wal",
+			Mode:            SQLiteModeWAL,
 			BusyTimeout:     10000 * time.Millisecond, // increasing the defaults from https://github.com/mattn/go-sqlite3/blob/master/sqlite3.go#L1098 because of transpilation from C to GO
-			TransactionMode: "immediate",
+			TransactionMode: SQLiteTransactionModeImmediate,
 		},
 	}
 
 }
 
 func (c Config) Validate() error {
+	switch c.Provider {
+	case ProviderSQLite:
+		if c.Sqlite.Path == "" {
+			return errors.NewInvalidInputf(errors.CodeInvalidInput, "sqlstore::sqlite::path cannot be empty")
+		}
+		switch c.Sqlite.Mode {
+		case SQLiteModeDelete, SQLiteModeWAL:
+		default:
+			return errors.NewInvalidInputf(errors.CodeInvalidInput, "sqlstore::sqlite::mode must be one of [%s, %s], got %q", SQLiteModeDelete, SQLiteModeWAL, c.Sqlite.Mode)
+		}
+		if c.Sqlite.BusyTimeout < 0 {
+			return errors.NewInvalidInputf(errors.CodeInvalidInput, "sqlstore::sqlite::busy_timeout cannot be negative, got %v", c.Sqlite.BusyTimeout)
+		}
+		switch c.Sqlite.TransactionMode {
+		case SQLiteTransactionModeDeferred, SQLiteTransactionModeImmediate, SQLiteTransactionModeExclusive:
+		default:
+			return errors.NewInvalidInputf(errors.CodeInvalidInput, "sqlstore::sqlite::transaction_mode must be one of [%s, %s, %s], got %q", SQLiteTransactionModeDeferred, SQLiteTransactionModeImmediate, SQLiteTransactionModeExclusive, c.Sqlite.TransactionMode)
+		}
+	case ProviderPostgres:
+		if c.Postgres.DSN == "" {
+			return errors.NewInvalidInputf(errors.CodeInvalidInput, "sqlstore::postgres::dsn cannot be empty")
+		}
+	default:
+		return errors.NewInvalidInputf(errors.CodeInvalidInput, "sqlstore::provider must be one of [%s, %s], got %q", ProviderSQLite, ProviderPostgres, c.Provider)
+	}
+
+	if c.Connection.MaxOpenConns <= 0 {
+		return errors.NewInvalidInputf(errors.CodeInvalidInput, "sqlstore::max_open_conns must be positive, got %d", c.Connection.MaxOpenConns)
+	}
+	if c.Connection.MaxConnLifetime < 0 {
+		return errors.NewInvalidInputf(errors.CodeInvalidInput, "sqlstore::max_conn_lifetime cannot be negative, got %v", c.Connection.MaxConnLifetime)
+	}
+
 	return nil
 }

--- a/pkg/sqlstore/config_test.go
+++ b/pkg/sqlstore/config_test.go
@@ -56,3 +56,145 @@ func TestNewWithEnvProvider(t *testing.T) {
 	assert.Equal(t, expected, actual)
 	assert.NoError(t, actual.Validate())
 }
+
+func validSQLiteConfig() Config {
+	return Config{
+		Provider: ProviderSQLite,
+		Connection: ConnectionConfig{
+			MaxOpenConns:    100,
+			MaxConnLifetime: 0,
+		},
+		Sqlite: SqliteConfig{
+			Path:            "/var/lib/signoz/signoz.db",
+			Mode:            SQLiteModeWAL,
+			BusyTimeout:     10 * time.Second,
+			TransactionMode: SQLiteTransactionModeImmediate,
+		},
+	}
+}
+
+func validPostgresConfig() Config {
+	return Config{
+		Provider: ProviderPostgres,
+		Connection: ConnectionConfig{
+			MaxOpenConns:    100,
+			MaxConnLifetime: 0,
+		},
+		Postgres: PostgresConfig{
+			DSN: "postgres://user:pass@localhost:5432/signoz?sslmode=disable",
+		},
+	}
+}
+
+func TestValidate(t *testing.T) {
+	testCases := []struct {
+		name    string
+		mutate  func(*Config)
+		wantErr string
+	}{
+		{
+			name: "ValidSQLiteDefaults",
+		},
+		{
+			name: "ValidPostgres",
+			mutate: func(c *Config) {
+				*c = validPostgresConfig()
+			},
+		},
+		{
+			name: "EmptyProvider",
+			mutate: func(c *Config) {
+				c.Provider = ""
+			},
+			wantErr: `sqlstore::provider must be one of [sqlite, postgres], got ""`,
+		},
+		{
+			name: "UnknownProvider",
+			mutate: func(c *Config) {
+				c.Provider = "mysql"
+			},
+			wantErr: `sqlstore::provider must be one of [sqlite, postgres], got "mysql"`,
+		},
+		{
+			name: "EmptySQLitePath",
+			mutate: func(c *Config) {
+				c.Sqlite.Path = ""
+			},
+			wantErr: "sqlstore::sqlite::path cannot be empty",
+		},
+		{
+			name: "InvalidSQLiteMode",
+			mutate: func(c *Config) {
+				c.Sqlite.Mode = "memory"
+			},
+			wantErr: `sqlstore::sqlite::mode must be one of [delete, wal], got "memory"`,
+		},
+		{
+			name: "NegativeSQLiteBusyTimeout",
+			mutate: func(c *Config) {
+				c.Sqlite.BusyTimeout = -time.Second
+			},
+			wantErr: "sqlstore::sqlite::busy_timeout cannot be negative, got -1s",
+		},
+		{
+			name: "InvalidSQLiteTransactionMode",
+			mutate: func(c *Config) {
+				c.Sqlite.TransactionMode = "read_only"
+			},
+			wantErr: `sqlstore::sqlite::transaction_mode must be one of [deferred, immediate, exclusive], got "read_only"`,
+		},
+		{
+			name: "EmptyPostgresDSN",
+			mutate: func(c *Config) {
+				*c = validPostgresConfig()
+				c.Postgres.DSN = ""
+			},
+			wantErr: "sqlstore::postgres::dsn cannot be empty",
+		},
+		{
+			name: "NonPositiveMaxOpenConns",
+			mutate: func(c *Config) {
+				c.Connection.MaxOpenConns = 0
+			},
+			wantErr: "sqlstore::max_open_conns must be positive, got 0",
+		},
+		{
+			name: "NegativeMaxConnLifetime",
+			mutate: func(c *Config) {
+				c.Connection.MaxConnLifetime = -time.Minute
+			},
+			wantErr: "sqlstore::max_conn_lifetime cannot be negative, got -1m0s",
+		},
+		{
+			name: "SQLiteModeDeleteAndDeferredAreValid",
+			mutate: func(c *Config) {
+				c.Sqlite.Mode = SQLiteModeDelete
+				c.Sqlite.TransactionMode = SQLiteTransactionModeDeferred
+			},
+		},
+		{
+			name: "SQLiteTransactionModeExclusiveIsValid",
+			mutate: func(c *Config) {
+				c.Sqlite.TransactionMode = SQLiteTransactionModeExclusive
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			cfg := validSQLiteConfig()
+			if tc.mutate != nil {
+				tc.mutate(&cfg)
+			}
+
+			err := cfg.Validate()
+			if tc.wantErr == "" {
+				assert.NoError(t, err)
+				return
+			}
+
+			require.Error(t, err)
+			assert.EqualError(t, err, tc.wantErr)
+		})
+	}
+}


### PR DESCRIPTION
## Summary
> `sqlstore.Config.Validate()` was a no-op, so invalid provider/sqlite/postgres/connection settings were accepted at load time and only failed later (or silently) when opening the database. This implements the validation rules from #12347 and adds unit coverage for each rule.

#### Issues closed by this PR
> Closes #12347

---

### ✅ Change Type
_Select all that apply_

- [ ] ✨ Feature
- [x] 🐛 Bug fix
- [ ] ♻️ Refactor
- [ ] 🛠️ Infra / Tooling
- [ ] 🧪 Test-only

---

### 🐛 Bug Context

#### Root Cause
> `Config.Validate()` satisfied `factory.Config` with `return nil`, so misconfigurations (empty provider/path/DSN, invalid sqlite mode/transaction mode, non-positive pool settings) were not rejected during config load.

#### Fix Strategy
> Implement field checks aligned with `conf/example.yaml` supported values, returning `errors.NewInvalidInputf` with field-named messages. Keep provider-specific checks scoped (sqlite fields only when `provider=sqlite`, postgres DSN only when `provider=postgres`).

---

### 🧪 Testing Strategy

- Tests added/updated: `TestValidate` covers valid sqlite/postgres configs and each invalid rule (provider, path, mode, busy_timeout, transaction_mode, DSN, max_open_conns, max_conn_lifetime). Existing `TestNewWithEnvProvider` still asserts the env-loaded config validates.
- Manual verification: `go test -race -count=1 ./pkg/sqlstore/`
- Edge cases covered: `max_conn_lifetime=0` remains valid; sqlite `delete`/`deferred`/`exclusive` accepted.

---

### ⚠️ Risk & Impact Assessment

- Blast radius: Config load for sqlstore only. Previously accepted invalid configs will now fail fast at startup.
- Potential regressions: Deployments with unsupported sqlite mode/transaction_mode values that somehow worked via driver fallback will now error at boot (intentional).
- Rollback plan: Revert this commit.

---

### 📝 Changelog

| Field | Value |
|------|-------|
| Deployment Type | Cloud / OSS / Enterprise |
| Change Type | Bug Fix |
| Description | Invalid SQLStore configuration is rejected at load time with clear field errors |

---

### 📋 Checklist
- [x] Tests added or explicitly not required
- [x] Manually tested
- [x] Breaking changes documented
- [x] Backward compatibility considered

---

## 👀 Notes for Reviewers

Validation messages use the `sqlstore::...` field path style used elsewhere in config packages. Supported sqlite values match `conf/example.yaml` (`mode`: delete/wal, `transaction_mode`: deferred/immediate/exclusive).