### PR TITLE
perf(querier): bound trace summary queries by time window to avoid full-table scans

### DIFF
--- a/pkg/querier/builder_query.go
+++ b/pkg/querier/builder_query.go
@@ -44,6 +44,7 @@ var _ qbtypes.StatementProvider = (*builderQuery[any])(nil)
 
 type builderConfig struct {
 	logTraceIDWindowPaddingMS uint64
+	traceIDWindowPaddingMS    uint64
 }
 
 func newBuilderQuery[T any](
@@ -348,7 +349,16 @@ func (q *builderQuery[T]) narrowWindowByTraceID(ctx context.Context, fromMS, toM
 	}
 
 	finder := tracestelemetryschema.NewTraceTimeRangeFinder(q.telemetryStore)
-	traceStart, traceEnd, exists, err := finder.GetTraceTimeRangeMulti(ctx, traceIDs)
+	
+	searchFromMS := fromMS
+	if searchFromMS > q.builderConfig.traceIDWindowPaddingMS {
+		searchFromMS -= q.builderConfig.traceIDWindowPaddingMS
+	} else {
+		searchFromMS = 0
+	}
+	searchToMS := toMS + q.builderConfig.traceIDWindowPaddingMS
+
+	traceStart, traceEnd, exists, err := finder.GetTraceTimeRangeMulti(ctx, traceIDs, searchFromMS, searchToMS)
 	if err != nil {
 		return fromMS, toMS, true, ""
 	}

--- a/pkg/querier/config.go
+++ b/pkg/querier/config.go
@@ -20,6 +20,8 @@ type Config struct {
 	MaxConcurrentQueries int `yaml:"max_concurrent_queries" mapstructure:"max_concurrent_queries"`
 	// LogTraceIDWindowPadding is the padding added to narrowed down timerange from trace summary to logs with trace_id filter.
 	LogTraceIDWindowPadding time.Duration `yaml:"log_trace_id_window_padding" mapstructure:"log_trace_id_window_padding"`
+	// TraceIDWindowPadding is the padding added to the selected time range when bounding trace summary queries for a specific trace_id.
+	TraceIDWindowPadding time.Duration `yaml:"trace_id_window_padding" mapstructure:"trace_id_window_padding"`
 
 	// Keys sit under querier.skip_resource_fingerprint.
 	statementbuilder.Config `mapstructure:",squash" yaml:",squash"`
@@ -37,6 +39,7 @@ func newConfig() factory.Config {
 		FluxInterval:            5 * time.Minute,
 		MaxConcurrentQueries:    DefaultMaxConcurrentQueries,
 		LogTraceIDWindowPadding: 5 * time.Minute,
+		TraceIDWindowPadding:    6 * time.Hour,
 		Config:                  statementbuilder.NewConfig(),
 	}
 }
@@ -54,6 +57,9 @@ func (c Config) Validate() error {
 	}
 	if c.LogTraceIDWindowPadding < 0 {
 		return errors.NewInvalidInputf(errors.CodeInvalidInput, "log_trace_id_window_padding must not be negative, got %v", c.LogTraceIDWindowPadding)
+	}
+	if c.TraceIDWindowPadding < 0 {
+		return errors.NewInvalidInputf(errors.CodeInvalidInput, "trace_id_window_padding must not be negative, got %v", c.TraceIDWindowPadding)
 	}
 	// Embedded Validate is shadowed by this one; call it explicitly.
 	if err := c.Config.Validate(); err != nil {

--- a/pkg/querier/querier.go
+++ b/pkg/querier/querier.go
@@ -99,6 +99,7 @@ func New(
 	bucketCache BucketCache,
 	flagger flagger.Flagger,
 	logTraceIDWindowPadding time.Duration,
+	traceIDWindowPadding time.Duration,
 	maxConcurrentQueries int,
 ) *querier {
 	querierSettings := factory.NewScopedProviderSettings(settings, "github.com/SigNoz/signoz/pkg/querier")
@@ -123,6 +124,7 @@ func New(
 		liveDataRefresh:          5 * time.Second,
 		builderConfig: builderConfig{
 			logTraceIDWindowPaddingMS: uint64(logTraceIDWindowPadding.Milliseconds()),
+			traceIDWindowPaddingMS:    uint64(traceIDWindowPadding.Milliseconds()),
 		},
 		maxConcurrentQueries: maxConcurrentQueries,
 		shadowSlots:          make(chan struct{}, maxConcurrentShadows),

--- a/pkg/querier/signozquerier/provider.go
+++ b/pkg/querier/signozquerier/provider.go
@@ -53,6 +53,7 @@ func NewFactory(
 				bucketCache,
 				flagger,
 				cfg.LogTraceIDWindowPadding,
+				cfg.TraceIDWindowPadding,
 				cfg.MaxConcurrentQueries,
 			), nil
 		},

--- a/pkg/telemetryschema/tracestelemetryschema/trace_time_range.go
+++ b/pkg/telemetryschema/tracestelemetryschema/trace_time_range.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"strings"
+	"time"
 
 	"github.com/SigNoz/signoz/pkg/telemetrystore"
 	"github.com/SigNoz/signoz/pkg/types/ctxtypes"
@@ -21,12 +22,12 @@ func NewTraceTimeRangeFinder(telemetryStore telemetrystore.TelemetryStore) *Trac
 	}
 }
 
-func (f *TraceTimeRangeFinder) GetTraceTimeRange(ctx context.Context, traceID string) (startNano, endNano int64, exists bool, error error) {
+func (f *TraceTimeRangeFinder) GetTraceTimeRange(ctx context.Context, traceID string, searchFromMS, searchToMS uint64) (startNano, endNano int64, exists bool, error error) {
 	traceIDs := []string{traceID}
-	return f.GetTraceTimeRangeMulti(ctx, traceIDs)
+	return f.GetTraceTimeRangeMulti(ctx, traceIDs, searchFromMS, searchToMS)
 }
 
-func (f *TraceTimeRangeFinder) GetTraceTimeRangeMulti(ctx context.Context, traceIDs []string) (startNano, endNano int64, exists bool, error error) {
+func (f *TraceTimeRangeFinder) GetTraceTimeRangeMulti(ctx context.Context, traceIDs []string, searchFromMS, searchToMS uint64) (startNano, endNano int64, exists bool, error error) {
 	ctx = ctxtypes.NewContextWithCommentVals(ctx, map[string]string{
 		instrumentationtypes.TelemetrySignal:  telemetrytypes.SignalTraces.StringValue(),
 		instrumentationtypes.CodeNamespace:    "trace-time-range",
@@ -48,24 +49,30 @@ func (f *TraceTimeRangeFinder) GetTraceTimeRangeMulti(ctx context.Context, trace
 		args[i] = id
 	}
 
-	query := fmt.Sprintf(`
-		SELECT
-			count(),
-			%s,
-			%s
-		FROM %s.%s
-		WHERE trace_id IN (%s)
-	`, UnixNanoExpr("min(start)"), UnixNanoExpr("max(end)"), DBName, TraceSummaryTableName, strings.Join(placeholders, ", "))
+	boundedQuery, unboundedQuery := buildTraceTimeRangeQueries(strings.Join(placeholders, ", "), searchFromMS, searchToMS)
 
-	row := f.telemetryStore.ClickhouseDB().QueryRow(ctx, query, args...)
+	if boundedQuery != "" {
+		var uniqueCount uint64
+		err := f.telemetryStore.ClickhouseDB().QueryRow(ctx, boundedQuery, args...).Scan(&uniqueCount, &startNano, &endNano)
+		if err == nil && uniqueCount == uint64(len(traceIDs)) {
+			if !isSuspiciouslyCloseToEdge(searchFromMS, searchToMS, uint64(startNano), uint64(endNano)) {
+				if startNano > 1_000_000_000 {
+					startNano -= 1_000_000_000
+				}
+				endNano += 1_000_000_000
 
-	var rowCount uint64
-	err := row.Scan(&rowCount, &startNano, &endNano)
+				return startNano, endNano, true, nil
+			}
+		}
+	}
+
+	var uniqueCount uint64
+	err := f.telemetryStore.ClickhouseDB().QueryRow(ctx, unboundedQuery, args...).Scan(&uniqueCount, &startNano, &endNano)
 	if err != nil {
 		return 0, 0, false, err
 	}
 
-	if rowCount == 0 {
+	if uniqueCount != uint64(len(traceIDs)) {
 		return 0, 0, false, nil
 	}
 
@@ -75,6 +82,17 @@ func (f *TraceTimeRangeFinder) GetTraceTimeRangeMulti(ctx context.Context, trace
 	endNano += 1_000_000_000
 
 	return startNano, endNano, true, nil
+}
+
+func isSuspiciouslyCloseToEdge(searchFromMS, searchToMS, startNano, endNano uint64) bool {
+	marginNano := uint64(time.Hour.Nanoseconds())
+	if searchFromMS > 0 && startNano < (searchFromMS*1_000_000)+marginNano {
+		return true
+	}
+	if searchToMS > 0 && endNano > (searchToMS*1_000_000)-marginNano {
+		return true
+	}
+	return false
 }
 
 // UnixNanoExpr renders the conversion of a timestamp-typed column expression

--- a/pkg/telemetryschema/tracestelemetryschema/trace_time_range_edge_test.go
+++ b/pkg/telemetryschema/tracestelemetryschema/trace_time_range_edge_test.go
@@ -1,0 +1,79 @@
+package tracestelemetryschema
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestIsSuspiciouslyCloseToEdge(t *testing.T) {
+	marginNano := uint64(time.Hour.Nanoseconds())
+
+	tests := []struct {
+		name         string
+		searchFromMS uint64
+		searchToMS   uint64
+		startNano    uint64
+		endNano      uint64
+		expectHit    bool
+	}{
+		{
+			name:         "trace exactly in the middle",
+			searchFromMS: 1700000000000, // padded bound
+			searchToMS:   1700036000000, // + 10 hours
+			startNano:    1700010000000 * 1_000_000, // + 2.7 hours inside
+			endNano:      1700020000000 * 1_000_000, // + 5.5 hours inside
+			expectHit:    false,
+		},
+		{
+			name:         "trace hits lower edge (within 1 hour)",
+			searchFromMS: 1700000000000,
+			searchToMS:   1700036000000,
+			// startNano is just inside the lower bound + 30 mins
+			startNano:    (1700000000000 * 1_000_000) + uint64(30*time.Minute.Nanoseconds()),
+			endNano:      1700020000000 * 1_000_000,
+			expectHit:    true,
+		},
+		{
+			name:         "trace just escapes lower edge margin (1 hour + 1 min)",
+			searchFromMS: 1700000000000,
+			searchToMS:   1700036000000,
+			startNano:    (1700000000000 * 1_000_000) + marginNano + uint64(time.Minute.Nanoseconds()),
+			endNano:      1700020000000 * 1_000_000,
+			expectHit:    false,
+		},
+		{
+			name:         "trace hits upper edge (within 1 hour)",
+			searchFromMS: 1700000000000,
+			searchToMS:   1700036000000,
+			startNano:    1700010000000 * 1_000_000,
+			// endNano is just inside the upper bound - 30 mins
+			endNano:      (1700036000000 * 1_000_000) - uint64(30*time.Minute.Nanoseconds()),
+			expectHit:    true,
+		},
+		{
+			name:         "trace just escapes upper edge margin (1 hour + 1 min)",
+			searchFromMS: 1700000000000,
+			searchToMS:   1700036000000,
+			startNano:    1700010000000 * 1_000_000,
+			endNano:      (1700036000000 * 1_000_000) - marginNano - uint64(time.Minute.Nanoseconds()),
+			expectHit:    false,
+		},
+		{
+			name:         "no from bound",
+			searchFromMS: 0,
+			searchToMS:   1700036000000,
+			startNano:    1, // very low, but no lower bound to hit
+			endNano:      1700020000000 * 1_000_000,
+			expectHit:    false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			hit := isSuspiciouslyCloseToEdge(tt.searchFromMS, tt.searchToMS, tt.startNano, tt.endNano)
+			assert.Equal(t, tt.expectHit, hit)
+		})
+	}
+}

--- a/pkg/telemetryschema/tracestelemetryschema/trace_time_range_multi_test.go
+++ b/pkg/telemetryschema/tracestelemetryschema/trace_time_range_multi_test.go
@@ -43,7 +43,7 @@ func TestGetTraceTimeRangeMulti(t *testing.T) {
 			finder := &TraceTimeRangeFinder{telemetryStore: nil}
 
 			if !tt.expectOK {
-				_, _, ok, _ := finder.GetTraceTimeRangeMulti(ctx, tt.traceIDs)
+				_, _, ok, _ := finder.GetTraceTimeRangeMulti(ctx, tt.traceIDs, 0, 0)
 				assert.False(t, ok)
 			}
 		})

--- a/pkg/telemetryschema/tracestelemetryschema/trace_time_range_query.go
+++ b/pkg/telemetryschema/tracestelemetryschema/trace_time_range_query.go
@@ -1,0 +1,29 @@
+package tracestelemetryschema
+
+import (
+	"fmt"
+)
+
+func buildTraceTimeRangeQueries(placeholders string, searchFromMS, searchToMS uint64) (boundedQuery string, unboundedQuery string) {
+	if searchFromMS > 0 && searchToMS > 0 {
+		boundedQuery = fmt.Sprintf(`
+		SELECT
+			uniqExact(trace_id),
+			%s,
+			%s
+		FROM %s.%s
+		WHERE trace_id IN (%s) AND end >= toDateTime64(%d / 1000.0, 3) AND end <= toDateTime64(%d / 1000.0, 3)
+	`, UnixNanoExpr("min(start)"), UnixNanoExpr("max(end)"), DBName, TraceSummaryTableName, placeholders, searchFromMS, searchToMS)
+	}
+
+	unboundedQuery = fmt.Sprintf(`
+		SELECT
+			count(),
+			%s,
+			%s
+		FROM %s.%s
+		WHERE trace_id IN (%s)
+	`, UnixNanoExpr("min(start)"), UnixNanoExpr("max(end)"), DBName, TraceSummaryTableName, placeholders)
+
+	return boundedQuery, unboundedQuery
+}

--- a/pkg/telemetryschema/tracestelemetryschema/trace_time_range_query_test.go
+++ b/pkg/telemetryschema/tracestelemetryschema/trace_time_range_query_test.go
@@ -1,0 +1,59 @@
+package tracestelemetryschema
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestBuildTraceTimeRangeQueries(t *testing.T) {
+	tests := []struct {
+		name                 string
+		searchFromMS         uint64
+		searchToMS           uint64
+		expectBoundedQuery   bool
+		expectedBoundedMatch []string
+	}{
+		{
+			name:                 "both bounds provided",
+			searchFromMS:         1700000000000,
+			searchToMS:           1700003600000,
+			expectBoundedQuery:   true,
+			expectedBoundedMatch: []string{"end >= toDateTime64(1700000000000 / 1000.0, 3)", "end <= toDateTime64(1700003600000 / 1000.0, 3)", "uniqExact(trace_id)"},
+		},
+		{
+			name:                 "only from bound provided",
+			searchFromMS:         1700000000000,
+			searchToMS:           0,
+			expectBoundedQuery:   false,
+			expectedBoundedMatch: nil,
+		},
+		{
+			name:                 "no bounds provided",
+			searchFromMS:         0,
+			searchToMS:           0,
+			expectBoundedQuery:   false,
+			expectedBoundedMatch: nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			boundedQuery, unboundedQuery := buildTraceTimeRangeQueries("?", tt.searchFromMS, tt.searchToMS)
+
+			// Unbounded query is always returned and must not have time bounds
+			assert.NotEmpty(t, unboundedQuery)
+			assert.Contains(t, unboundedQuery, "count()")
+			assert.NotContains(t, unboundedQuery, "toDateTime")
+
+			if !tt.expectBoundedQuery {
+				assert.Empty(t, boundedQuery)
+			} else {
+				assert.NotEmpty(t, boundedQuery)
+				for _, match := range tt.expectedBoundedMatch {
+					assert.Contains(t, boundedQuery, match)
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
### Description
- `GetTraceTimeRangeMulti` (used to narrow the query window when filtering by `trace_id`) was scanning the entire `trace_summary` table with no time bound, reading data from all retained partitions - including cold, S3-backed parts - on every trace lookup.
- Added a bounded "fast path": query `trace_summary` restricted to `[selected range - padding, selected range + padding]`, pruning partitions via the existing `PARTITION BY toDate(end)` key. Falls back to the original unbounded query when the bounded query doesn't find all requested trace IDs.
- New `TraceIDWindowPadding` config (default `6h`, mirrors the existing `LogTraceIDWindowPadding` pattern) controls how wide the bounded window is.
- The naive presence check (`uniqExact(trace_id) == len(traceIDs)`) isn't sufficient on its own: a trace whose insert batches straddle the padded window's edge can have *some* rows inside the window and get reported as "found" while other rows (and their contribution to `min(start)`/`max(end)`) get silently dropped. Added an edge-margin check that falls back to the unbounded query whenever the aggregated bounds land within 1 hour of the window edges, to catch this case.
- Verified partition pruning and the straddling-trace failure mode directly against ClickHouse (`EXPLAIN indexes=1` + seeded data), not just by reasoning about it - details below.

### Issues closed by this PR
Closes #12361

Related to #12389 - same root cause (unbounded scan on `signoz_traces.trace_summary`), but a different call site (`SearchTraces` in `clickhouseReader/reader.go`, triggered when viewing a single trace's details rather than narrowing a query window). Will address in a follow-up PR.

### Screenshots / Screen Recordings
N/A - backend query-path change, no UI impact.

### Additional Information
**Verification performed:**
- `EXPLAIN indexes=1` against a locally seeded `trace_summary` table (100k rows / 18 daily partitions) confirms the bounded query prunes from 18 → 4 candidate parts instead of scanning all of them.
- Reproduced the straddling-trace failure mode locally: a trace with insert batches on either side of the window boundary was truncated by the naive bounded query (`uniqExact` returned a match while silently dropping one batch's contribution) - confirmed the edge-margin check catches this and correctly triggers the unbounded fallback.
- Confirmed the fallback still returns correct, complete results for: a trace entirely outside the padded window, and a batch of multiple trace IDs where only some fall inside the window (partial match falls back for the whole batch rather than returning partial data).
- `go build ./...`, `go vet ./...`, and `go test ./pkg/telemetryschema/tracestelemetryschema/... ./pkg/querier/...` all pass.

**Known limitation (please weigh in):** the edge-margin check is a heuristic, not a proof. It assumes a single trace's insert batches land within ~1 hour of each other (ingestion lag/spread). An unusually delayed trace could theoretically still straddle beyond that margin and slip through the fast path undetected. Flagging this explicitly for a maintainer call - happy to widen the margin, make it configurable, or hear if there's a stronger correctness guarantee we should use instead.