### PR TITLE
fix(alert-channel-integrations): de-flake the Google Chat alert channel save tests

### DIFF
--- a/frontend/src/container/AllAlertChannels/__tests__/CreateAlertChannel.test.tsx
+++ b/frontend/src/container/AllAlertChannels/__tests__/CreateAlertChannel.test.tsx
@@ -437,6 +437,17 @@ describe('Create Alert Channel', () => {
 				render(<CreateAlertChannels preType={ChannelType.GoogleChat} />);
 			});
 
+			// paste instead of type: a per-keystroke re-render of the whole form
+			// pushes these tests past the 5s jest timeout on slower CI runners
+			async function fillField(
+				user: ReturnType<typeof userEvent.setup>,
+				testId: string,
+				value: string,
+			): Promise<void> {
+				await user.click(screen.getByTestId(testId));
+				await user.paste(value);
+			}
+
 			it('Should check if the selected item in the type dropdown has text "Google Chat"', () => {
 				expect(screen.getByText('Google Chat')).toBeInTheDocument();
 			});
@@ -463,14 +474,8 @@ describe('Create Alert Channel', () => {
 			it('Should check if saving with a webhook url outside chat.googleapis.com displays error notification', async () => {
 				const user = userEvent.setup();
 
-				await user.type(
-					screen.getByTestId('channel-name-textbox'),
-					'gchat-channel',
-				);
-				await user.type(
-					screen.getByTestId('webhook-url-textbox'),
-					'https://example.com/webhook',
-				);
+				await fillField(user, 'channel-name-textbox', 'gchat-channel');
+				await fillField(user, 'webhook-url-textbox', 'https://example.com/webhook');
 
 				await user.click(screen.getByTestId('save-channel-button'));
 
@@ -496,11 +501,8 @@ describe('Create Alert Channel', () => {
 
 				const user = userEvent.setup();
 
-				await user.type(
-					screen.getByTestId('channel-name-textbox'),
-					'gchat-channel',
-				);
-				await user.type(screen.getByTestId('webhook-url-textbox'), validWebhookUrl);
+				await fillField(user, 'channel-name-textbox', 'gchat-channel');
+				await fillField(user, 'webhook-url-textbox', validWebhookUrl);
 
 				await user.click(screen.getByTestId('save-channel-button'));
 


### PR DESCRIPTION
## Summary

The Google Chat save test fails on CI now and then with `Exceeded timeout of 5000 ms for a test`.

The two Google Chat tests fill the form with `userEvent.type()`, which sends one keystroke at a time. Each keystroke re-renders the whole form. The payload test types 91 characters, so it takes ~850ms locally. CI is about 5x slower, which puts it near the 5s limit. A busy runner then pushes it over.

This PR pastes the values instead of typing them. One event per field, same assertions.

| Test | Before | After |
| --- | --- | --- |
| `saving sends a googlechat_configs payload` | 847 ms | 283 ms |
| `saving with a webhook url outside chat.googleapis.com` | 590 ms | 326 ms |

Nothing regressed. The new test was added recently to an already existing suite. It was always close to the limit.

## Test plan

- `pnpm jest src/container/AllAlertChannels/__tests__/CreateAlertChannel.test.tsx` — 57/57 pass, 3 runs
- `oxfmt`, `oxlint`, `tsgo --noEmit` clean

Closes https://github.com/SigNoz/pulse-pod/issues/259
