### PR TITLE
fix(alerts): tolerate a null channels field when editing an existing alert rule

### DIFF
--- a/frontend/src/container/CreateAlertV2/Footer/__tests__/utils.test.ts
+++ b/frontend/src/container/CreateAlertV2/Footer/__tests__/utils.test.ts
@@ -130,6 +130,28 @@ describe('Footer utils', () => {
 			};
 			expect(validateCreateAlertState(currentArgs)).toBeNull();
 		});
+
+		it('when threshold channels are null', () => {
+			const currentArgs: BuildCreateAlertRulePayloadArgs = {
+				...args,
+				basicAlertState: {
+					...args.basicAlertState,
+					name: 'test name',
+				},
+				thresholdState: {
+					...args.thresholdState,
+					thresholds: [
+						{
+							...args.thresholdState.thresholds[0],
+							channels: null as unknown as string[],
+						},
+					],
+				},
+			};
+			expect(validateCreateAlertState(currentArgs)).toBe(
+				'Please select at least one channel for each threshold or enable routing policies',
+			);
+		});
 	});
 
 	describe('getNotificationSettingsProps', () => {

--- a/frontend/src/container/CreateAlertV2/Footer/utils.tsx
+++ b/frontend/src/container/CreateAlertV2/Footer/utils.tsx
@@ -44,7 +44,8 @@ export function validateCreateAlertState(
 		if (!threshold.label) {
 			return 'Please enter a label for each threshold';
 		}
-		if (!notificationSettings.routingPolicies && !threshold.channels.length) {
+		// this runs during render, so a throw here takes down the whole page
+		if (!notificationSettings.routingPolicies && !threshold.channels?.length) {
 			return 'Please select at least one channel for each threshold or enable routing policies';
 		}
 	}

--- a/frontend/src/container/CreateAlertV2/__tests__/utils.test.tsx
+++ b/frontend/src/container/CreateAlertV2/__tests__/utils.test.tsx
@@ -316,6 +316,34 @@ describe('CreateAlertV2 utils', () => {
 		});
 	});
 
+	describe('getThresholdStateFromAlertDef null channels', () => {
+		it('falls back to an empty array so downstream consumers never see null', () => {
+			const def: PostableAlertRuleV2 = {
+				...defaultPostableAlertRuleV2,
+				condition: {
+					...defaultPostableAlertRuleV2.condition,
+					thresholds: {
+						kind: 'basic',
+						spec: [
+							{
+								name: 'critical',
+								target: 1,
+								targetUnit: UniversalYAxisUnit.MINUTES,
+								channels: null as unknown as string[],
+								matchType: AlertThresholdMatchType.AT_LEAST_ONCE,
+								op: AlertThresholdOperator.IS_ABOVE,
+							},
+						],
+					},
+				},
+			};
+
+			expect(
+				getThresholdStateFromAlertDef(def).thresholds[0].channels,
+			).toStrictEqual([]);
+		});
+	});
+
 	describe('normalizeOperator', () => {
 		it.each([
 			['1', AlertThresholdOperator.IS_ABOVE],

--- a/frontend/src/container/CreateAlertV2/utils.tsx
+++ b/frontend/src/container/CreateAlertV2/utils.tsx
@@ -258,7 +258,9 @@ export function getThresholdStateFromAlertDef(
 				recoveryThresholdValue: null,
 				unit: threshold.targetUnit,
 				color: getColorForThreshold(threshold.name),
-				channels: threshold.channels,
+				// rules created outside the UI can come back with a null channels
+				// field; drop the guard once the API enforces the schema
+				channels: threshold.channels ?? [],
 			})) || [],
 		selectedQuery: alertDef.condition.selectedQueryName || '',
 		operator:


### PR DESCRIPTION
## Summary

Opening an existing alert rule for editing crashes the whole page with `Cannot read properties of null (reading 'length')`. It happens when a rule's threshold has `channels: null`, which is the case for rules not created through the UI.

The generated type is right — `RuletypesBasicRuleThresholdDTO.channels` is `string[] | null`. The problem is our own `BasicThreshold` wrapper type, which we keep because v1 and v2 alert shapes both exist. It says `channels: string[]`, and `fromRuleDTOToPostableRuleV2` casts the DTO straight into it with `as unknown as`. So the null reaches our code while the compiler thinks it can't.

`getThresholdStateFromAlertDef` copied that null into state, and the footer validator then read `.length` on it during render, which takes down the page instead of failing one field.

This PR defaults `channels` to `[]` where the API data becomes local state, so the validator, the payload builder and both channel dropdowns are all safe. The validator also gets an optional chain, since a throw there can't be recovered.

This is a guard, not the real fix. The cast in `fromRuleDTOToPostableRuleV2` is the actual gap, and the same wrapper also claims `spec` is non-nullable when the generated type allows null — so `spec.map` and `spec[0].op` in the same function can still crash. Worth fixing at the converter.

## Test plan

One test per guard. Both fail with the original error when the fix is reverted.

- `pnpm jest src/container/CreateAlertV2/` — 420 pass, 28 suites
- `oxfmt`, `oxlint`, `tsgo --noEmit` clean

Closes https://github.com/SigNoz/pulse-pod/issues/261
