### PR TITLE
feat: filter fields with no name in field selector

### DIFF
--- a/frontend/src/container/OptionsMenu/__test__/useOptionsMenu.test.ts
+++ b/frontend/src/container/OptionsMenu/__test__/useOptionsMenu.test.ts
@@ -387,4 +387,42 @@ describe('useOptionsMenu', () => {
 			expect(remaining).toHaveLength(seedColumns.length);
 		});
 	});
+
+	describe('fieldsSelector.value drops legacy columns without a name', () => {
+		it('excludes entries missing name while keeping valid columns', () => {
+			(useGetQueryKeySuggestions as jest.Mock).mockReturnValue({
+				data: { data: { data: { keys: {} } } },
+				isFetching: false,
+			});
+			(usePreferenceContext as jest.Mock).mockReturnValue({
+				traces: {
+					preferences: {
+						columns: [
+							{ name: 'body', fieldContext: 'log' },
+							{ key: 'legacy-key-no-name', fieldContext: 'log' },
+							{ name: 'timestamp', fieldContext: 'log' },
+						],
+						formatting: { format: 'table', maxLines: 1, fontSize: 'small' },
+					},
+					updateColumns: mockUpdateColumns,
+					updateFormatting: mockUpdateFormatting,
+				},
+				logs: {
+					preferences: { columns: [], formatting: {} },
+					updateColumns: mockUpdateColumns,
+					updateFormatting: mockUpdateFormatting,
+				},
+			});
+
+			const { result } = renderHook(() =>
+				useOptionsMenu({
+					dataSource: DataSource.TRACES,
+					aggregateOperator: 'count',
+				}),
+			);
+
+			const fields = result.current.config.fieldsSelector?.value ?? [];
+			expect(fields.map((f) => f.name)).toStrictEqual(['body', 'timestamp']);
+		});
+	});
 });

--- a/frontend/src/container/OptionsMenu/useOptionsMenu.ts
+++ b/frontend/src/container/OptionsMenu/useOptionsMenu.ts
@@ -399,7 +399,7 @@ const useOptionsMenu = ({
 				onReorder: reorderSelectColumns,
 			},
 			fieldsSelector: {
-				value: preferences?.columns ?? [],
+				value: preferences?.columns?.filter((item) => has(item, 'name')) ?? [],
 				onFieldsChange: updateColumns,
 			},
 			format: {


### PR DESCRIPTION
<!--A few plain bullets saying what changed and why, for a reviewer skimming it - not a wall of text, not a restatement of the diff, not generated boilerplate.-->
#### Description
Filter field selector options with name field empty

<!--Reference issues using `Closes #issue-number` to enable automatic closure on merge. -->
#### Issues closed by this PR
closes https://github.com/SigNoz/engineering-pod/issues/5890

<!--If applicable, include screenshots or screen recordings that clearly show the behavior before the change and the result after the change. -->
#### Screenshots / Screen Recordings
No screen recording as this is hard to reproduce.

