### PR TITLE
feat(frontend): register search() as a query builder function

### DIFF
--- a/frontend/src/components/QueryBuilderV2/QueryV2/QuerySearch/QuerySearch.tsx
+++ b/frontend/src/components/QueryBuilderV2/QueryV2/QuerySearch/QuerySearch.tsx
@@ -59,6 +59,7 @@ import {
 	dedupeOptionsByLabel,
 	getFieldContextPrefix,
 	getRecentOptions,
+	isSupportedFunction,
 	renderRecentDeleteButton,
 } from './utils';
 
@@ -1275,11 +1276,13 @@ function QuerySearch({
 		}
 
 		if (queryContext.isInFunction) {
-			options = Object.values(QUERY_BUILDER_FUNCTIONS).map((option) => ({
-				label: option,
-				apply: `${option}()`,
-				type: 'function',
-			}));
+			options = Object.values(QUERY_BUILDER_FUNCTIONS)
+				.filter((option) => isSupportedFunction(option, dataSource))
+				.map((option) => ({
+					label: option,
+					apply: `${option}()`,
+					type: 'function',
+				}));
 
 			// Add space after selection for functions
 			const optionsWithSpace = addSpaceToOptions(options);

--- a/frontend/src/components/QueryBuilderV2/QueryV2/QuerySearch/__tests__/utils.test.ts
+++ b/frontend/src/components/QueryBuilderV2/QueryV2/QuerySearch/__tests__/utils.test.ts
@@ -1,8 +1,12 @@
+import { QUERY_BUILDER_FUNCTIONS } from 'constants/antlrQueryConstants';
+import { DataSource } from 'types/common/queryBuilder';
+
 import {
 	combineInitialAndUserExpression,
 	dedupeOptionsByLabel,
 	getFieldContextPrefix,
 	getUserExpressionFromCombined,
+	isSupportedFunction,
 } from '../utils';
 
 describe('entityLogsExpression', () => {
@@ -116,5 +120,21 @@ describe('dedupeOptionsByLabel', () => {
 
 	it('returns an empty array for empty input', () => {
 		expect(dedupeOptionsByLabel([])).toStrictEqual([]);
+	});
+});
+
+describe('isSupportedFunction', () => {
+	const { HASANY, SEARCH } = QUERY_BUILDER_FUNCTIONS;
+
+	it('allows the has family on every signal', () => {
+		[DataSource.LOGS, DataSource.TRACES, DataSource.METRICS].forEach((signal) => {
+			expect(isSupportedFunction(HASANY, signal)).toBe(true);
+		});
+	});
+
+	it('allows search on logs only', () => {
+		expect(isSupportedFunction(SEARCH, DataSource.LOGS)).toBe(true);
+		expect(isSupportedFunction(SEARCH, DataSource.TRACES)).toBe(false);
+		expect(isSupportedFunction(SEARCH, DataSource.METRICS)).toBe(false);
 	});
 });

--- a/frontend/src/components/QueryBuilderV2/QueryV2/QuerySearch/utils.ts
+++ b/frontend/src/components/QueryBuilderV2/QueryV2/QuerySearch/utils.ts
@@ -1,6 +1,7 @@
 import { closeCompletion, startCompletion } from '@codemirror/autocomplete';
 import type { Completion } from '@codemirror/autocomplete';
 import type { EditorView } from '@uiw/react-codemirror';
+import { QUERY_BUILDER_FUNCTIONS } from 'constants/antlrQueryConstants';
 import dayjs from 'dayjs';
 import { normalizeFilterExpression } from 'lib/recentQueries/normalize';
 import * as recentQueriesStore from 'lib/recentQueries/recentQueriesStore';
@@ -14,6 +15,15 @@ import {
 	RECENTS_DISPLAY_CAP,
 	RECENTS_SECTION,
 } from './constants';
+
+// search() lives in the logs condition builder only; traces and metrics reject it
+// as an unsupported operator. Every other function is implemented for all signals.
+export function isSupportedFunction(
+	functionName: string,
+	signal: SignalType,
+): boolean {
+	return functionName !== QUERY_BUILDER_FUNCTIONS.SEARCH || signal === 'logs';
+}
 
 export interface FieldContextPrefixMatch {
 	context: string;

--- a/frontend/src/constants/antlrQueryConstants.ts
+++ b/frontend/src/constants/antlrQueryConstants.ts
@@ -41,6 +41,7 @@ export const QUERY_BUILDER_FUNCTIONS = {
 	HASANY: 'hasAny',
 	HASALL: 'hasAll',
 	HASTOKEN: 'hasToken',
+	SEARCH: 'search',
 };
 
 export function negateOperator(operatorOrFunction: string): string {

--- a/frontend/src/lib/recentQueries/normalize.test.ts
+++ b/frontend/src/lib/recentQueries/normalize.test.ts
@@ -34,7 +34,7 @@ describe('normalizeFilterExpression', () => {
 		);
 	});
 
-	it('lowercases HAS / HASANY / HASALL / HASTOKEN function names', () => {
+	it('lowercases HAS / HASANY / HASALL / HASTOKEN / SEARCH function names', () => {
 		expect(normalizeFilterExpression('HAS(tags, "x")')).toBe(
 			normalizeFilterExpression('has(tags, "x")'),
 		);
@@ -46,6 +46,9 @@ describe('normalizeFilterExpression', () => {
 		);
 		expect(normalizeFilterExpression('HASTOKEN(msg, "err")')).toBe(
 			normalizeFilterExpression('hasToken(msg, "err")'),
+		);
+		expect(normalizeFilterExpression('SEARCH("err")')).toBe(
+			normalizeFilterExpression('search("err")'),
 		);
 	});
 

--- a/frontend/src/utils/__tests__/queryContextUtils.test.ts
+++ b/frontend/src/utils/__tests__/queryContextUtils.test.ts
@@ -380,6 +380,19 @@ describe('extractQueryPairs', () => {
 		consoleSpy.mockRestore();
 	});
 
+	it('does not turn a search() term into a pair', () => {
+		// The bare form lexes as a KEY; left in it becomes a phantom filter item.
+		expect(extractQueryPairs("search('err')")).toStrictEqual([]);
+		expect(extractQueryPairs('search(err)')).toStrictEqual([]);
+		expect(extractQueryPairs('search(')).toStrictEqual([]);
+
+		expect(
+			extractQueryPairs("search(err) AND service.name = 'api'").map(
+				(pair) => pair.key,
+			),
+		).toStrictEqual(['service.name']);
+	});
+
 	it('should treat lowercase exists as non-value operator', () => {
 		const input = 'body exists service.name contains "test"';
 		const result = extractQueryPairs(input);
@@ -820,4 +833,18 @@ describe('getQueryContextAtCursor - partial operator', () => {
 		expect(ctx.keyToken).toBe('c');
 		expect(ctx.operatorToken).toBe('k');
 	});
+});
+
+describe('getQueryContextAtCursor - function context', () => {
+	// Each function keyword gets its own lexer token, and every one has to be
+	// registered as a function token for the editor to offer the function list.
+	it.each(['has', 'hasAny', 'hasAll', 'hasToken', 'search'])(
+		'resolves %s to function context',
+		(functionName) => {
+			const ctx = getQueryContextAtCursor(functionName, functionName.length);
+
+			expect(ctx.isInFunction).toBe(true);
+			expect(ctx.isInKey).toBe(false);
+		},
+	);
 });

--- a/frontend/src/utils/queryContextUtils.ts
+++ b/frontend/src/utils/queryContextUtils.ts
@@ -1279,6 +1279,41 @@ export function getQueryContextAtCursor(
 	}
 }
 
+// The grammar skips whitespace outright, so hidden-channel tokens do not reach the
+// stream today -- but the rest of this file guards against them, so keep the
+// assumption in one place rather than spread across callers.
+function nextVisibleIndex(tokens: IToken[], start: number): number {
+	let index = start;
+	while (index < tokens.length && tokens[index].channel !== 0) {
+		index += 1;
+	}
+	return index;
+}
+
+// Returns the token index just past the parenthesised argument list at
+// argumentStart, or argumentStart when none follows (a call the user is still
+// typing). An unclosed list consumes the remainder.
+function indexPastArguments(tokens: IToken[], argumentStart: number): number {
+	let index = nextVisibleIndex(tokens, argumentStart);
+	if (index >= tokens.length || tokens[index].type !== FilterQueryLexer.LPAREN) {
+		return argumentStart;
+	}
+
+	let depth = 0;
+	for (; index < tokens.length; index++) {
+		if (tokens[index].type === FilterQueryLexer.LPAREN) {
+			depth += 1;
+		} else if (tokens[index].type === FilterQueryLexer.RPAREN) {
+			depth -= 1;
+			if (depth === 0) {
+				return index + 1;
+			}
+		}
+	}
+
+	return index;
+}
+
 /**
  * Extracts all key-operator-value triplets from a query string
  * This is useful for getting value suggestions based on the current key and operator
@@ -1321,6 +1356,14 @@ export function extractQueryPairs(query: string): IQueryPair[] {
 
 			// Skip EOF and whitespace tokens
 			if (token.type === FilterQueryLexer.EOF || token.channel !== 0) {
+				continue;
+			}
+
+			// A search() term is free text, not a key: the bare form search(x) lexes
+			// as one, and left in it surfaces as a phantom filter item -- the log
+			// detail drawer rebuilds its filters from these pairs.
+			if (token.type === FilterQueryLexer.SEARCH) {
+				iterator = indexPastArguments(allTokens, iterator);
 				continue;
 			}
 

--- a/frontend/src/utils/tokenUtils.ts
+++ b/frontend/src/utils/tokenUtils.ts
@@ -77,6 +77,7 @@ export function isFunctionToken(tokenType: number): boolean {
 		FilterQueryLexer.HASANY,
 		FilterQueryLexer.HASALL,
 		FilterQueryLexer.HASTOKEN,
+		FilterQueryLexer.SEARCH,
 	].includes(tokenType);
 }
 


### PR DESCRIPTION
#### Description

Stacked on SigNoz/signoz#12491 — review that one first.

#12491 makes the frontend parser lex and parse `search()`. This makes the editor act on it. Scoped to `search('x')` and `search(x)` for now — scope arguments are not handled yet.

- **Function suggestion.** The cursor on `search` resolved to no context, so the suggestion list never opened and `search()` was never offered as a completion. Registered alongside the `has` family, in the same two places `hasToken` needed.
- **The term is free text, not a key.** `search(x)` lexes its term as a key, so the editor offered attribute keys inside the call and would complete one into the term — and pair extraction turned it into a filter item keyed `x`, which the log detail drawer rebuilds into a real filter. Key and value suggestions are now suppressed inside a `search()` call, and its argument no longer produces a pair. `has(key, value)` does take a real key, so its suggestions are untouched.
- **Logs only.** `FilterOperatorSearch` is implemented in `logstelemetryschema` alone; traces and metrics reject it as an unsupported operator, so the suggestion is gated to the logs signal.
- **Recents.** `SEARCH(...)` and `search(...)` no longer dedup as two distinct recent queries.

#### Issues closed by this PR

Fixes https://github.com/SigNoz/engineering-pod/issues/5901

#### Additional Information

`search` is a reserved word now, so `search = 'x'` and `search exists` no longer parse — the same tradeoff `has`/`hasAny` already carry, matching the backend grammar.

Three things deliberately left out:

- After picking any function from the autocomplete the cursor lands outside the brackets, so you have to arrow back before typing the argument. Long-standing behaviour across the whole `has` family, but `search()` is the case where an empty call is always a syntax error. Filed as SigNoz/engineering-pod#5893.
- `has(key, value)` still contributes a phantom filter item keyed on its first argument, which reaches the trace waterfall's API query, the metrics drilldown and the infra filter telemetry. Fixing it needs the autocomplete to keep reading that argument as a key, so it is not a one-liner.
- Scope arguments (`search('err', body)`) parse but are not supported here.

`isCursorInSearchTerm` runs on every cursor move, so it text-matches `search` before paying for a lex. A `SEARCH` token only exists where the lexer matched exactly those six letters — a word character on either side would have produced a `KEY` — so the pre-check cannot produce a false negative. `body = 'search this'` is covered by a test, since only the lexer can tell that one is a quoted value.

Unrelated to this PR: `QuerySearch.test.tsx › fetches key suggestions on mount for LOGS` is flaky on `main` too. An earlier test in that file types `http.` and never unmounts, so its debounced `getKeySuggestions` resolves after this test's `mockClear()` and wins the `mock.calls[length - 1]` read.

