### PR TITLE
feat: add useBarChart instead of graph

### DIFF
--- a/frontend/src/container/LiveLogs/LiveLogsList/LiveLogsList.styles.scss
+++ b/frontend/src/container/LiveLogs/LiveLogsList/LiveLogsList.styles.scss
@@ -4,13 +4,6 @@
 			padding: 0px 8px;
 
 			.logs-frequency-chart {
-				.ant-card-body {
-					height: 140px;
-					min-height: 140px;
-					padding: 0 16px 22px 16px;
-					font-family: 'Geist Mono';
-				}
-
 				margin-bottom: 0px;
 			}
 		}

--- a/frontend/src/container/LogsExplorerChart/LogsExplorerChart.styles.scss
+++ b/frontend/src/container/LogsExplorerChart/LogsExplorerChart.styles.scss
@@ -3,10 +3,10 @@
 	min-height: 200px;
 	border-bottom: 1px solid var(--l1-border);
 
-	// Series without a label are still plotted, but a legend entry with no name is
-	// unreadable. The virtualized grid item is hidden rather than the legend item
-	// inside it, so the row closes up instead of leaving an empty cell.
-	.virtuoso-grid-item:has(.legend-label:empty) {
+	// Hides the legend row of a series whose label is blank, keeping it on the chart.
+	.virtuoso-grid-item:has(
+		.legend-copy-button[aria-label^='Copy '][aria-label$=' ']
+	) {
 		display: none;
 	}
 

--- a/frontend/src/container/LogsExplorerChart/LogsExplorerChart.styles.scss
+++ b/frontend/src/container/LogsExplorerChart/LogsExplorerChart.styles.scss
@@ -3,6 +3,13 @@
 	min-height: 200px;
 	border-bottom: 1px solid var(--l1-border);
 
+	// Series without a label are still plotted, but a legend entry with no name is
+	// unreadable. The virtualized grid item is hidden rather than the legend item
+	// inside it, so the row closes up instead of leaving an empty cell.
+	.virtuoso-grid-item:has(.legend-label:empty) {
+		display: none;
+	}
+
 	.logs-frequency-chart-loading {
 		height: 100%;
 		display: flex;

--- a/frontend/src/container/LogsExplorerChart/LogsExplorerChart.styles.scss
+++ b/frontend/src/container/LogsExplorerChart/LogsExplorerChart.styles.scss
@@ -3,13 +3,6 @@
 	min-height: 200px;
 	border-bottom: 1px solid var(--l1-border);
 
-	.ant-card-body {
-		height: 200px;
-		min-height: 200px;
-		padding: 0 16px 16px 16px;
-		font-family: 'Geist Mono';
-	}
-
 	.logs-frequency-chart-loading {
 		height: 100%;
 		display: flex;

--- a/frontend/src/container/LogsExplorerChart/index.tsx
+++ b/frontend/src/container/LogsExplorerChart/index.tsx
@@ -89,7 +89,8 @@ function LogsExplorerChart({
 		onDragSelect,
 		minTimeScale,
 		maxTimeScale,
-		yAxisUnit: '{count}',
+		// Match the previous Chart.js Graph default (yAxisUnit = 'short')
+		yAxisUnit: 'short',
 	});
 
 	return (
@@ -100,7 +101,6 @@ function LogsExplorerChart({
 				</div>
 			) : (
 				<div style={{ zIndex: 1000 }}>
-					{/* The bars are log-line counts, so the y axis is the dimensionless UCUM count unit */}
 					<BarChart
 						config={config}
 						data={chartData}
@@ -111,7 +111,7 @@ function LogsExplorerChart({
 						legendConfig={{ position: LegendPosition.BOTTOM }}
 						timezone={timezone}
 						data-testid="logs-frequency-chart"
-						yAxisUnit={'{count}'}
+						yAxisUnit="short"
 					/>
 				</div>
 			)}

--- a/frontend/src/container/LogsExplorerChart/index.tsx
+++ b/frontend/src/container/LogsExplorerChart/index.tsx
@@ -1,22 +1,23 @@
-import { memo, useCallback, useMemo } from 'react';
+import { memo, useCallback, useMemo, useRef } from 'react';
 // eslint-disable-next-line no-restricted-imports
 import { useDispatch, useSelector } from 'react-redux';
 import { useLocation } from 'react-router-dom';
-import Graph from 'components/Graph';
 import Spinner from 'components/Spinner';
 import { QueryParams } from 'constants/query';
-import { themeColors } from 'constants/theme';
+import BarChart from 'container/DashboardContainer/visualization/charts/BarChart/BarChart';
+import { useResizeObserver } from 'hooks/useDimensions';
 import { useSafeNavigate } from 'hooks/useSafeNavigate';
 import useUrlQuery from 'hooks/useUrlQuery';
-import getChartData, { GetChartDataProps } from 'lib/getChartData';
 import GetMinMax from 'lib/getMinMax';
-import { colors } from 'lib/getRandomColor';
+import { LegendPosition } from 'lib/uPlotV2/components/types';
+import { StackMode } from 'lib/uPlotV2/config/types';
+import { useTimezone } from 'providers/Timezone';
 import { UpdateTimeInterval } from 'store/actions';
 import { AppState } from 'store/reducers';
 import { GlobalReducer } from 'types/reducer/globalTime';
 
 import { LogsExplorerChartProps } from './LogsExplorerChart.interfaces';
-import { getColorsForSeverityLabels } from './utils';
+import { useLogsExplorerChartConfig } from './useLogsExplorerChartConfig';
 
 import './LogsExplorerChart.styles.scss';
 
@@ -37,24 +38,6 @@ function LogsExplorerChart({
 	const { minTime, maxTime } = useSelector<AppState, GlobalReducer>(
 		(state) => state.globalTime,
 	);
-	const handleCreateDatasets: Required<GetChartDataProps>['createDataset'] =
-		useCallback(
-			(element, index, allLabels) => ({
-				data: element,
-				backgroundColor: isLogsExplorerViews
-					? getColorsForSeverityLabels(allLabels[index], index)
-					: colors[index % colors.length] || themeColors.red,
-				borderColor: isLogsExplorerViews
-					? getColorsForSeverityLabels(allLabels[index], index)
-					: colors[index % colors.length] || themeColors.red,
-				...(isLabelEnabled
-					? {
-							label: allLabels[index],
-						}
-					: {}),
-			}),
-			[isLabelEnabled, isLogsExplorerViews],
-		);
 
 	const onDragSelect = useCallback(
 		(start: number, end: number): void => {
@@ -86,45 +69,51 @@ function LogsExplorerChart({
 		[dispatch, location.pathname, safeNavigate, urlQuery, isShowingLiveLogs],
 	);
 
-	const graphData = useMemo(
-		() =>
-			getChartData({
-				queryData: [
-					{
-						queryData: data,
-					},
-				],
-				createDataset: handleCreateDatasets,
-			}),
-		[data, handleCreateDatasets],
-	);
-
-	// Convert nanosecond timestamps to milliseconds for Chart.js
-	const { chartMinTime, chartMaxTime } = useMemo(
+	// uPlot plots the series on a seconds-based x scale
+	const { minTimeScale, maxTimeScale } = useMemo(
 		() => ({
-			chartMinTime: minTime ? Math.floor(minTime / 1e6) : undefined,
-			chartMaxTime: maxTime ? Math.floor(maxTime / 1e6) : undefined,
+			minTimeScale: minTime ? Math.floor(minTime / 1e9) : undefined,
+			maxTimeScale: maxTime ? Math.floor(maxTime / 1e9) : undefined,
 		}),
 		[minTime, maxTime],
 	);
 
+	const { timezone } = useTimezone();
+	const graphRef = useRef<HTMLDivElement>(null);
+	const dimensions = useResizeObserver(graphRef);
+
+	const { config, chartData } = useLogsExplorerChartConfig({
+		data,
+		isLogsExplorerViews,
+		isLabelEnabled,
+		onDragSelect,
+		minTimeScale,
+		maxTimeScale,
+		yAxisUnit: '{count}',
+	});
+
 	return (
-		<div className={`${className} logs-frequency-chart-container`}>
+		<div ref={graphRef} className={`${className} logs-frequency-chart-container`}>
 			{isLoading ? (
 				<div className="logs-frequency-chart-loading">
 					<Spinner size="default" height="100%" />
 				</div>
 			) : (
-				<Graph
-					name="logsExplorerChart"
-					data={graphData.data}
-					isStacked={isLogsExplorerViews}
-					type="bar"
-					animate
-					onDragSelect={onDragSelect}
-					minTime={chartMinTime}
-					maxTime={chartMaxTime}
-				/>
+				<div style={{ zIndex: 1000 }}>
+					{/* The bars are log-line counts, so the y axis is the dimensionless UCUM count unit */}
+					<BarChart
+						config={config}
+						data={chartData}
+						width={dimensions.width}
+						height={dimensions.height}
+						stack={isLogsExplorerViews ? StackMode.Normal : StackMode.None}
+						showLegend={isLabelEnabled}
+						legendConfig={{ position: LegendPosition.BOTTOM }}
+						timezone={timezone}
+						data-testid="logs-frequency-chart"
+						yAxisUnit={'{count}'}
+					/>
+				</div>
 			)}
 		</div>
 	);

--- a/frontend/src/container/LogsExplorerChart/index.tsx
+++ b/frontend/src/container/LogsExplorerChart/index.tsx
@@ -21,6 +21,9 @@ import { useLogsExplorerChartConfig } from './useLogsExplorerChartConfig';
 
 import './LogsExplorerChart.styles.scss';
 
+// Axis and tooltip format separately; both need this or only one abbreviates.
+const Y_AXIS_UNIT = 'short';
+
 function LogsExplorerChart({
 	data,
 	isLoading,
@@ -89,8 +92,7 @@ function LogsExplorerChart({
 		onDragSelect,
 		minTimeScale,
 		maxTimeScale,
-		// Match the previous Chart.js Graph default (yAxisUnit = 'short')
-		yAxisUnit: 'short',
+		yAxisUnit: Y_AXIS_UNIT,
 	});
 
 	return (
@@ -100,20 +102,18 @@ function LogsExplorerChart({
 					<Spinner size="default" height="100%" />
 				</div>
 			) : (
-				<div style={{ zIndex: 1000 }}>
-					<BarChart
-						config={config}
-						data={chartData}
-						width={dimensions.width}
-						height={dimensions.height}
-						stack={isLogsExplorerViews ? StackMode.Normal : StackMode.None}
-						showLegend={isLabelEnabled}
-						legendConfig={{ position: LegendPosition.BOTTOM }}
-						timezone={timezone}
-						data-testid="logs-frequency-chart"
-						yAxisUnit="short"
-					/>
-				</div>
+				<BarChart
+					config={config}
+					data={chartData}
+					width={dimensions.width}
+					height={dimensions.height}
+					stack={isLogsExplorerViews ? StackMode.Normal : StackMode.None}
+					showLegend={isLabelEnabled}
+					legendConfig={{ position: LegendPosition.BOTTOM }}
+					timezone={timezone}
+					data-testid="logs-frequency-chart"
+					yAxisUnit={Y_AXIS_UNIT}
+				/>
 			)}
 		</div>
 	);

--- a/frontend/src/container/LogsExplorerChart/index.tsx
+++ b/frontend/src/container/LogsExplorerChart/index.tsx
@@ -1,22 +1,23 @@
-import { memo, useCallback, useMemo } from 'react';
+import { memo, useCallback, useMemo, useRef } from 'react';
 // eslint-disable-next-line no-restricted-imports
 import { useDispatch, useSelector } from 'react-redux';
 import { useLocation } from 'react-router-dom';
-import Graph from 'components/Graph';
 import Spinner from 'components/Spinner';
 import { QueryParams } from 'constants/query';
-import { themeColors } from 'constants/theme';
+import BarChart from 'container/DashboardContainer/visualization/charts/BarChart/BarChart';
+import { useResizeObserver } from 'hooks/useDimensions';
 import { useSafeNavigate } from 'hooks/useSafeNavigate';
 import useUrlQuery from 'hooks/useUrlQuery';
-import getChartData, { GetChartDataProps } from 'lib/getChartData';
 import GetMinMax from 'lib/getMinMax';
-import { colors } from 'lib/getRandomColor';
+import { LegendPosition } from 'lib/uPlotV2/components/types';
+import { StackMode } from 'lib/uPlotV2/config/types';
+import { useTimezone } from 'providers/Timezone';
 import { UpdateTimeInterval } from 'store/actions';
 import { AppState } from 'store/reducers';
 import { GlobalReducer } from 'types/reducer/globalTime';
 
 import { LogsExplorerChartProps } from './LogsExplorerChart.interfaces';
-import { getColorsForSeverityLabels } from './utils';
+import { useLogsExplorerChartConfig } from './useLogsExplorerChartConfig';
 
 import './LogsExplorerChart.styles.scss';
 
@@ -37,24 +38,6 @@ function LogsExplorerChart({
 	const { minTime, maxTime } = useSelector<AppState, GlobalReducer>(
 		(state) => state.globalTime,
 	);
-	const handleCreateDatasets: Required<GetChartDataProps>['createDataset'] =
-		useCallback(
-			(element, index, allLabels) => ({
-				data: element,
-				backgroundColor: isLogsExplorerViews
-					? getColorsForSeverityLabels(allLabels[index], index)
-					: colors[index % colors.length] || themeColors.red,
-				borderColor: isLogsExplorerViews
-					? getColorsForSeverityLabels(allLabels[index], index)
-					: colors[index % colors.length] || themeColors.red,
-				...(isLabelEnabled
-					? {
-							label: allLabels[index],
-						}
-					: {}),
-			}),
-			[isLabelEnabled, isLogsExplorerViews],
-		);
 
 	const onDragSelect = useCallback(
 		(start: number, end: number): void => {
@@ -86,45 +69,51 @@ function LogsExplorerChart({
 		[dispatch, location.pathname, safeNavigate, urlQuery, isShowingLiveLogs],
 	);
 
-	const graphData = useMemo(
-		() =>
-			getChartData({
-				queryData: [
-					{
-						queryData: data,
-					},
-				],
-				createDataset: handleCreateDatasets,
-			}),
-		[data, handleCreateDatasets],
-	);
-
-	// Convert nanosecond timestamps to milliseconds for Chart.js
-	const { chartMinTime, chartMaxTime } = useMemo(
+	// uPlot plots the series on a seconds-based x scale
+	const { minTimeScale, maxTimeScale } = useMemo(
 		() => ({
-			chartMinTime: minTime ? Math.floor(minTime / 1e6) : undefined,
-			chartMaxTime: maxTime ? Math.floor(maxTime / 1e6) : undefined,
+			minTimeScale: minTime ? Math.floor(minTime / 1e9) : undefined,
+			maxTimeScale: maxTime ? Math.floor(maxTime / 1e9) : undefined,
 		}),
 		[minTime, maxTime],
 	);
 
+	const { timezone } = useTimezone();
+	const graphRef = useRef<HTMLDivElement>(null);
+	const dimensions = useResizeObserver(graphRef);
+
+	const { config, chartData } = useLogsExplorerChartConfig({
+		data,
+		isLogsExplorerViews,
+		isLabelEnabled,
+		onDragSelect,
+		minTimeScale,
+		maxTimeScale,
+		// Match the previous Chart.js Graph default (yAxisUnit = 'short')
+		yAxisUnit: 'short',
+	});
+
 	return (
-		<div className={`${className} logs-frequency-chart-container`}>
+		<div ref={graphRef} className={`${className} logs-frequency-chart-container`}>
 			{isLoading ? (
 				<div className="logs-frequency-chart-loading">
 					<Spinner size="default" height="100%" />
 				</div>
 			) : (
-				<Graph
-					name="logsExplorerChart"
-					data={graphData.data}
-					isStacked={isLogsExplorerViews}
-					type="bar"
-					animate
-					onDragSelect={onDragSelect}
-					minTime={chartMinTime}
-					maxTime={chartMaxTime}
-				/>
+				<div style={{ zIndex: 1000 }}>
+					<BarChart
+						config={config}
+						data={chartData}
+						width={dimensions.width}
+						height={dimensions.height}
+						stack={isLogsExplorerViews ? StackMode.Normal : StackMode.None}
+						showLegend={isLabelEnabled}
+						legendConfig={{ position: LegendPosition.BOTTOM }}
+						timezone={timezone}
+						data-testid="logs-frequency-chart"
+						yAxisUnit="short"
+					/>
+				</div>
 			)}
 		</div>
 	);

--- a/frontend/src/container/LogsExplorerChart/useLogsExplorerChartConfig.ts
+++ b/frontend/src/container/LogsExplorerChart/useLogsExplorerChartConfig.ts
@@ -12,7 +12,6 @@ import { useTimezone } from 'providers/Timezone';
 import { MetricRangePayloadProps } from 'types/api/metrics/getQueryRange';
 import { QueryData } from 'types/api/widgets/getQuery';
 import uPlot from 'uplot';
-import { v4 } from 'uuid';
 
 import { getColorsForSeverityLabels } from './utils';
 
@@ -57,7 +56,7 @@ export function useLogsExplorerChartConfig({
 
 	const config = useMemo(() => {
 		const builder = buildBaseConfig({
-			id: v4(),
+			id: 'logs-explorer-frequency-chart',
 			isDarkMode,
 			onDragSelect,
 			timezone,

--- a/frontend/src/container/LogsExplorerChart/useLogsExplorerChartConfig.ts
+++ b/frontend/src/container/LogsExplorerChart/useLogsExplorerChartConfig.ts
@@ -84,7 +84,7 @@ export function useLogsExplorerChartConfig({
 				// which is meaningless to the reader — the color alone identifies the
 				// series. A blank label has to be whitespace rather than '': uPlot
 				// replaces falsy labels with its own "Value" default.
-				label: isLabelEnabled ? label : ' ',
+				label: isLabelEnabled && label.trim() ? label : ' ',
 				lineColor: color,
 				colorMapping: {},
 				isDarkMode,

--- a/frontend/src/container/LogsExplorerChart/useLogsExplorerChartConfig.ts
+++ b/frontend/src/container/LogsExplorerChart/useLogsExplorerChartConfig.ts
@@ -1,0 +1,113 @@
+import { useMemo } from 'react';
+import { PANEL_TYPES } from 'constants/queryBuilder';
+import { themeColors } from 'constants/theme';
+import { buildBaseConfig } from 'container/DashboardContainer/visualization/panels/utils/baseConfigBuilder';
+import { useIsDarkMode } from 'hooks/useDarkMode';
+import getLabelName from 'lib/getLabelName';
+import { colors } from 'lib/getRandomColor';
+import { getUPlotChartData } from 'lib/uPlotLib/utils/getUplotChartData';
+import { DrawStyle } from 'lib/uPlotV2/config/types';
+import { UPlotConfigBuilder } from 'lib/uPlotV2/config/UPlotConfigBuilder';
+import { useTimezone } from 'providers/Timezone';
+import { MetricRangePayloadProps } from 'types/api/metrics/getQueryRange';
+import { QueryData } from 'types/api/widgets/getQuery';
+import uPlot from 'uplot';
+import { v4 } from 'uuid';
+
+import {
+	getColorsForSeverityLabels,
+	getMinStepIntervalFromSeries,
+} from './utils';
+
+export interface UseLogsExplorerChartConfigParams {
+	data: QueryData[];
+	isLogsExplorerViews?: boolean;
+	isLabelEnabled?: boolean;
+	onDragSelect: (start: number, end: number) => void;
+	minTimeScale?: number;
+	maxTimeScale?: number;
+	yAxisUnit?: string;
+}
+
+export interface UseLogsExplorerChartConfigResult {
+	config: UPlotConfigBuilder;
+	chartData: uPlot.AlignedData;
+}
+
+export function useLogsExplorerChartConfig({
+	data,
+	isLogsExplorerViews = false,
+	isLabelEnabled = true,
+	onDragSelect,
+	minTimeScale,
+	maxTimeScale,
+	yAxisUnit,
+}: UseLogsExplorerChartConfigParams): UseLogsExplorerChartConfigResult {
+	const isDarkMode = useIsDarkMode();
+	const { timezone } = useTimezone();
+
+	// getUPlotChartData / buildBaseConfig both consume the legacy query-range payload
+	// shape, so the raw series list is wrapped instead of being plotted directly.
+	const apiResponse = useMemo(
+		() =>
+			({
+				data: { result: data, resultType: '' },
+			}) as unknown as MetricRangePayloadProps,
+		[data],
+	);
+
+	const chartData = useMemo(() => getUPlotChartData(apiResponse), [apiResponse]);
+
+	const config = useMemo(() => {
+		const builder = buildBaseConfig({
+			id: v4(),
+			isDarkMode,
+			onDragSelect,
+			timezone,
+			minTimeScale,
+			maxTimeScale,
+			yAxisUnit,
+			stepInterval: getMinStepIntervalFromSeries(data),
+			panelType: PANEL_TYPES.BAR,
+		});
+
+		data.forEach((series, index) => {
+			const label = getLabelName(
+				series.metric,
+				series.queryName || '',
+				series.legend || '',
+			);
+
+			const color = isLogsExplorerViews
+				? getColorsForSeverityLabels(label, index)
+				: colors[index % colors.length] || themeColors.red;
+
+			builder.addSeries({
+				scaleKey: 'y',
+				drawStyle: DrawStyle.Bar,
+				// Without a group by, getLabelName falls back to the query name ("A"),
+				// which is meaningless to the reader — the color alone identifies the
+				// series. A blank label has to be whitespace rather than '': uPlot
+				// replaces falsy labels with its own "Value" default.
+				label: isLabelEnabled ? label : ' ',
+				lineColor: color,
+				colorMapping: {},
+				isDarkMode,
+			});
+		});
+
+		return builder;
+	}, [
+		data,
+		isDarkMode,
+		isLabelEnabled,
+		isLogsExplorerViews,
+		maxTimeScale,
+		minTimeScale,
+		onDragSelect,
+		timezone,
+		yAxisUnit,
+	]);
+
+	return { config, chartData };
+}

--- a/frontend/src/container/LogsExplorerChart/useLogsExplorerChartConfig.ts
+++ b/frontend/src/container/LogsExplorerChart/useLogsExplorerChartConfig.ts
@@ -1,0 +1,105 @@
+import { useMemo } from 'react';
+import { PANEL_TYPES } from 'constants/queryBuilder';
+import { themeColors } from 'constants/theme';
+import { buildBaseConfig } from 'container/DashboardContainer/visualization/panels/utils/baseConfigBuilder';
+import { useIsDarkMode } from 'hooks/useDarkMode';
+import getLabelName from 'lib/getLabelName';
+import { colors } from 'lib/getRandomColor';
+import { getUPlotChartData } from 'lib/uPlotLib/utils/getUplotChartData';
+import { DrawStyle } from 'lib/uPlotV2/config/types';
+import { UPlotConfigBuilder } from 'lib/uPlotV2/config/UPlotConfigBuilder';
+import { useTimezone } from 'providers/Timezone';
+import { MetricRangePayloadProps } from 'types/api/metrics/getQueryRange';
+import { QueryData } from 'types/api/widgets/getQuery';
+import uPlot from 'uplot';
+
+import { getColorsForSeverityLabels } from './utils';
+
+export interface UseLogsExplorerChartConfigParams {
+	data: QueryData[];
+	isLogsExplorerViews?: boolean;
+	isLabelEnabled?: boolean;
+	onDragSelect: (start: number, end: number) => void;
+	minTimeScale?: number;
+	maxTimeScale?: number;
+	yAxisUnit?: string;
+}
+
+export interface UseLogsExplorerChartConfigResult {
+	config: UPlotConfigBuilder;
+	chartData: uPlot.AlignedData;
+}
+
+export function useLogsExplorerChartConfig({
+	data,
+	isLogsExplorerViews = false,
+	isLabelEnabled = true,
+	onDragSelect,
+	minTimeScale,
+	maxTimeScale,
+	yAxisUnit,
+}: UseLogsExplorerChartConfigParams): UseLogsExplorerChartConfigResult {
+	const isDarkMode = useIsDarkMode();
+	const { timezone } = useTimezone();
+
+	// getUPlotChartData / buildBaseConfig both consume the legacy query-range payload
+	// shape, so the raw series list is wrapped instead of being plotted directly.
+	const apiResponse = useMemo(
+		() =>
+			({
+				data: { result: data, resultType: '' },
+			}) as unknown as MetricRangePayloadProps,
+		[data],
+	);
+
+	const chartData = useMemo(() => getUPlotChartData(apiResponse), [apiResponse]);
+
+	const config = useMemo(() => {
+		const builder = buildBaseConfig({
+			id: 'logs-explorer-frequency-chart',
+			isDarkMode,
+			onDragSelect,
+			timezone,
+			minTimeScale,
+			maxTimeScale,
+			yAxisUnit,
+			panelType: PANEL_TYPES.BAR,
+		});
+
+		data.forEach((series, index) => {
+			const label = getLabelName(
+				series.metric,
+				series.queryName || '',
+				series.legend || '',
+			);
+
+			const color = isLogsExplorerViews
+				? getColorsForSeverityLabels(label, index)
+				: colors[index % colors.length] || themeColors.red;
+
+			builder.addSeries({
+				scaleKey: 'y',
+				drawStyle: DrawStyle.Bar,
+				// No group-by yields query name "A"; use ' ' not '' so uPlot does not default the label to "Value".
+				label: isLabelEnabled && label.trim() ? label : ' ',
+				lineColor: color,
+				colorMapping: {},
+				isDarkMode,
+			});
+		});
+
+		return builder;
+	}, [
+		data,
+		isDarkMode,
+		isLabelEnabled,
+		isLogsExplorerViews,
+		maxTimeScale,
+		minTimeScale,
+		onDragSelect,
+		timezone,
+		yAxisUnit,
+	]);
+
+	return { config, chartData };
+}

--- a/frontend/src/container/LogsExplorerChart/useLogsExplorerChartConfig.ts
+++ b/frontend/src/container/LogsExplorerChart/useLogsExplorerChartConfig.ts
@@ -14,10 +14,7 @@ import { QueryData } from 'types/api/widgets/getQuery';
 import uPlot from 'uplot';
 import { v4 } from 'uuid';
 
-import {
-	getColorsForSeverityLabels,
-	getMinStepIntervalFromSeries,
-} from './utils';
+import { getColorsForSeverityLabels } from './utils';
 
 export interface UseLogsExplorerChartConfigParams {
 	data: QueryData[];
@@ -67,7 +64,6 @@ export function useLogsExplorerChartConfig({
 			minTimeScale,
 			maxTimeScale,
 			yAxisUnit,
-			stepInterval: getMinStepIntervalFromSeries(data),
 			panelType: PANEL_TYPES.BAR,
 		});
 

--- a/frontend/src/container/LogsExplorerChart/utils.ts
+++ b/frontend/src/container/LogsExplorerChart/utils.ts
@@ -1,8 +1,5 @@
 import { Color } from '@signozhq/design-tokens';
 import { colors } from 'lib/getRandomColor';
-import { QueryData } from 'types/api/widgets/getQuery';
-
-const DEFAULT_STEP_INTERVAL_SECONDS = 60;
 
 // Function to determine if a color is "red-like" based on its RGB values
 export function isRedLike(hex: string): boolean {
@@ -124,32 +121,4 @@ export function getColorsForSeverityLabels(
 		SAFE_FALLBACK_COLORS[index % SAFE_FALLBACK_COLORS.length] ||
 		Color.BG_VANILLA_400
 	);
-}
-
-/**
- * The logs frequency series carry no step interval metadata, so the bar width is
- * derived from the smallest gap between consecutive timestamps (in seconds).
- */
-export function getMinStepIntervalFromSeries(seriesList: QueryData[]): number {
-	const timestamps = new Set<number>();
-
-	seriesList.forEach((series) => {
-		series?.values?.forEach(([timestamp]) => {
-			timestamps.add(timestamp);
-		});
-	});
-
-	const sorted = Array.from(timestamps).sort((a, b) => a - b);
-
-	let minInterval = Number.POSITIVE_INFINITY;
-	for (let index = 1; index < sorted.length; index++) {
-		const gap = sorted[index] - sorted[index - 1];
-		if (gap > 0 && gap < minInterval) {
-			minInterval = gap;
-		}
-	}
-
-	return Number.isFinite(minInterval)
-		? minInterval
-		: DEFAULT_STEP_INTERVAL_SECONDS;
 }

--- a/frontend/src/container/LogsExplorerChart/utils.ts
+++ b/frontend/src/container/LogsExplorerChart/utils.ts
@@ -1,5 +1,8 @@
 import { Color } from '@signozhq/design-tokens';
 import { colors } from 'lib/getRandomColor';
+import { QueryData } from 'types/api/widgets/getQuery';
+
+const DEFAULT_STEP_INTERVAL_SECONDS = 60;
 
 // Function to determine if a color is "red-like" based on its RGB values
 export function isRedLike(hex: string): boolean {
@@ -121,4 +124,32 @@ export function getColorsForSeverityLabels(
 		SAFE_FALLBACK_COLORS[index % SAFE_FALLBACK_COLORS.length] ||
 		Color.BG_VANILLA_400
 	);
+}
+
+/**
+ * The logs frequency series carry no step interval metadata, so the bar width is
+ * derived from the smallest gap between consecutive timestamps (in seconds).
+ */
+export function getMinStepIntervalFromSeries(seriesList: QueryData[]): number {
+	const timestamps = new Set<number>();
+
+	seriesList.forEach((series) => {
+		series?.values?.forEach(([timestamp]) => {
+			timestamps.add(timestamp);
+		});
+	});
+
+	const sorted = Array.from(timestamps).sort((a, b) => a - b);
+
+	let minInterval = Number.POSITIVE_INFINITY;
+	for (let index = 1; index < sorted.length; index++) {
+		const gap = sorted[index] - sorted[index - 1];
+		if (gap > 0 && gap < minInterval) {
+			minInterval = gap;
+		}
+	}
+
+	return Number.isFinite(minInterval)
+		? minInterval
+		: DEFAULT_STEP_INTERVAL_SECONDS;
 }

--- a/frontend/src/container/LogsExplorerViews/LogsExplorerViews.styles.scss
+++ b/frontend/src/container/LogsExplorerViews/LogsExplorerViews.styles.scss
@@ -217,13 +217,6 @@
 		padding: 0px 8px;
 
 		.logs-frequency-chart {
-			.ant-card-body {
-				height: 140px;
-				min-height: 140px;
-				padding: 0 16px 22px 16px;
-				font-family: 'Geist Mono';
-			}
-
 			margin-bottom: 0px;
 		}
 	}


### PR DESCRIPTION
#### Description

- The logs frequency chart now draws with the uPlotV2 `BarChart` instead of the Chart.js `Graph`, putting it on the same chart stack as the rest of the product. Covers both Logs Explorer and Live Logs, which share the component.
- Chart setup moves into a `useLogsExplorerChartConfig` hook built on the shared `buildBaseConfig`. Severity colours, labels, drag-to-zoom and timezone handling all behave as before; stacking goes through `stack`/`StackMode`.
- Timestamps now convert ns → s, since uPlot's x scale is in seconds where Chart.js wanted ms.
- Removes the `.ant-card-body` rules from three stylesheets. They stopped matching anything when #8904 dropped the antd Card wrapper.
- Unblocked by #12627, which removed the last-minute trim from the time scale. My earlier attempt at that (#12528) is closed.

#### Issues closed by this PR

Closes - https://github.com/orgs/SigNoz/projects/39/views/20?pane=issue&itemId=128310734&issue=SigNoz%7Csignoz%7C9059 

#### Screenshots / Screen Recordings


https://github.com/user-attachments/assets/b27f75ae-085d-410b-a5b8-491bac590fd0


#### Additional Information
