### PR TITLE
fix(logs pipelines): preview logs with the body the collector sees

### DIFF
--- a/pkg/query-service/app/http_handler.go
+++ b/pkg/query-service/app/http_handler.go
@@ -3201,7 +3201,19 @@ func (aH *APIHandler) PreviewLogsPipelinesHandler(w http.ResponseWriter, r *http
 		return
 	}
 
-	resultLogs, err := aH.LogsParsingPipelineController.PreviewLogsPipelines(r.Context(), &req)
+	claims, errv2 := authtypes.ClaimsFromContext(r.Context())
+	if errv2 != nil {
+		render.Error(w, errv2)
+		return
+	}
+
+	orgID, errv2 := valuer.NewUUID(claims.OrgID)
+	if errv2 != nil {
+		render.Error(w, errv2)
+		return
+	}
+
+	resultLogs, err := aH.LogsParsingPipelineController.PreviewLogsPipelines(r.Context(), orgID, &req)
 	if err != nil {
 		render.Error(w, err)
 		return

--- a/pkg/query-service/app/logparsingpipeline/controller.go
+++ b/pkg/query-service/app/logparsingpipeline/controller.go
@@ -342,11 +342,17 @@ type PipelinesPreviewResponse struct {
 
 func (ic *LogParsingPipelineController) PreviewLogsPipelines(
 	ctx context.Context,
+	orgID valuer.UUID,
 	request *PipelinesPreviewRequest,
 ) (*PipelinesPreviewResponse, error) {
 	pipelines, err := ic.enrichPipelinesFilters(ctx, request.Pipelines)
 	if err != nil {
 		return nil, err
+	}
+
+	// The collector gets the same pipeline prepended over opamp; see RecommendAgentConfig.
+	if ic.fl.BooleanOrEmpty(ctx, flagger.FeatureUseJSONBody, featuretypes.NewFlaggerEvaluationContext(orgID)) {
+		pipelines = append([]pipelinetypes.GettablePipeline{ic.getNormalizePipeline()}, pipelines...)
 	}
 
 	result, collectorLogs, err := SimulatePipelinesProcessing(ctx, pipelines, request.Logs)

--- a/pkg/query-service/app/logparsingpipeline/preview_test.go
+++ b/pkg/query-service/app/logparsingpipeline/preview_test.go
@@ -6,11 +6,14 @@ import (
 	"testing"
 	"time"
 
+	"github.com/SigNoz/signoz/pkg/flagger/flaggertest"
 	"github.com/SigNoz/signoz/pkg/query-service/model"
 	v3 "github.com/SigNoz/signoz/pkg/query-service/model/v3"
 	"github.com/SigNoz/signoz/pkg/types/pipelinetypes"
+	"github.com/SigNoz/signoz/pkg/valuer"
 	"github.com/google/uuid"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/entry"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -18,39 +21,7 @@ func TestPipelinePreview(t *testing.T) {
 	require := require.New(t)
 
 	testPipelines := []pipelinetypes.GettablePipeline{
-		{
-			StoreablePipeline: pipelinetypes.StoreablePipeline{
-				OrderID: 1,
-				Name:    "pipeline1",
-				Alias:   "pipeline1",
-				Enabled: true,
-			},
-			Filter: &v3.FilterSet{
-				Operator: "AND",
-				Items: []v3.FilterItem{
-					{
-						Key: v3.AttributeKey{
-							Key:      "method",
-							DataType: v3.AttributeKeyDataTypeString,
-							Type:     v3.AttributeKeyTypeTag,
-						},
-						Operator: "=",
-						Value:    "GET",
-					},
-				},
-			},
-			Config: []pipelinetypes.PipelineOperator{
-				{
-					OrderId: 1,
-					ID:      "add",
-					Type:    "add",
-					Field:   "attributes.test",
-					Value:   "val",
-					Enabled: true,
-					Name:    "test add",
-				},
-			},
-		},
+		makeTestAddAttributePipeline(),
 		{
 			StoreablePipeline: pipelinetypes.StoreablePipeline{
 				OrderID: 2,
@@ -146,6 +117,93 @@ func TestPipelinePreview(t *testing.T) {
 		result[1].Resources_string,
 	)
 
+}
+
+func TestPipelinePreviewNormalizesBodyWithJSONBodyEnabled(t *testing.T) {
+	controller := &LogParsingPipelineController{fl: flaggertest.WithUseJSONBody(t, true)}
+
+	result, err := controller.PreviewLogsPipelines(
+		context.Background(),
+		valuer.GenerateUUID(),
+		&PipelinesPreviewRequest{
+			Pipelines: []pipelinetypes.GettablePipeline{makeTestAddAttributePipeline()},
+			Logs: []model.SignozLog{
+				makeTestSignozLog("test log body", map[string]interface{}{"method": "GET"}),
+				makeTestSignozLog(
+					`{"level":"error","msg":"json log body"}`,
+					map[string]interface{}{"method": "GET"},
+				),
+			},
+		},
+	)
+
+	require.NoError(t, err)
+	require.Len(t, result.OutputLogs, 2)
+
+	assert.Equal(t, `{"message":"test log body"}`, result.OutputLogs[0].Body)
+	assert.Equal(
+		t,
+		`{"level":"error","message":"json log body"}`,
+		result.OutputLogs[1].Body,
+	)
+	assert.Equal(t, "val", result.OutputLogs[0].Attributes_string["test"])
+}
+
+func TestPipelinePreviewKeepsBodyAsIsWithJSONBodyDisabled(t *testing.T) {
+	controller := &LogParsingPipelineController{fl: flaggertest.WithUseJSONBody(t, false)}
+
+	result, err := controller.PreviewLogsPipelines(
+		context.Background(),
+		valuer.GenerateUUID(),
+		&PipelinesPreviewRequest{
+			Pipelines: []pipelinetypes.GettablePipeline{makeTestAddAttributePipeline()},
+			Logs: []model.SignozLog{
+				makeTestSignozLog("test log body", map[string]interface{}{"method": "GET"}),
+			},
+		},
+	)
+
+	require.NoError(t, err)
+	require.Len(t, result.OutputLogs, 1)
+
+	assert.Equal(t, "test log body", result.OutputLogs[0].Body)
+	assert.Equal(t, "val", result.OutputLogs[0].Attributes_string["test"])
+}
+
+func makeTestAddAttributePipeline() pipelinetypes.GettablePipeline {
+	return pipelinetypes.GettablePipeline{
+		StoreablePipeline: pipelinetypes.StoreablePipeline{
+			OrderID: 1,
+			Name:    "pipeline1",
+			Alias:   "pipeline1",
+			Enabled: true,
+		},
+		Filter: &v3.FilterSet{
+			Operator: "AND",
+			Items: []v3.FilterItem{
+				{
+					Key: v3.AttributeKey{
+						Key:      "method",
+						DataType: v3.AttributeKeyDataTypeString,
+						Type:     v3.AttributeKeyTypeTag,
+					},
+					Operator: "=",
+					Value:    "GET",
+				},
+			},
+		},
+		Config: []pipelinetypes.PipelineOperator{
+			{
+				OrderId: 1,
+				ID:      "add",
+				Type:    "add",
+				Field:   "attributes.test",
+				Value:   "val",
+				Enabled: true,
+				Name:    "test add",
+			},
+		},
+	}
 }
 
 func TestGrokParsingProcessor(t *testing.T) {


### PR DESCRIPTION
#### Description

- The collector gets a `normalize` pipeline prepended ahead of user pipelines when `use_json_body` is on — injected in `RecommendAgentConfig` and delivered over opamp — which parses the log body into JSON. Preview simulated only the user's pipelines, so a pipeline authored against `body.<field>` behaved differently in preview than in production, and one written against `body` looked fine in preview while doing nothing on real logs.
- Preview now evaluates the flag for the caller's org and prepends the same pipeline, so what it shows is what the collector does.

#### Issues closed by this PR

Fixes https://github.com/SigNoz/engineering-pod/issues/5897

#### Additional Information

Verified end to end against a local stack — devenv ClickHouse, a collector with `body_json_enabled` connected over opamp, `use_json_body` on — by driving the two calls the preview screen makes: sample logs, then preview with those logs. `parse_from: body.message` extracts attributes; `parse_from: body` extracts nothing, matching what the collector does with a normalized body.

Log bodies render as stored rather than unwrapped, so what you see is what the pipeline operates on.

Needs SigNoz/signoz#12534 to pick sample logs by body — without it the v3 query behind the sample-log list errors for these orgs. SigNoz/signoz#12535 stacks on this to surface the collector's own explanation when an operator cannot parse a log.
