### PR TITLE
fix(onboarding): list multi-signal data sources under every signal they support

### DIFF
--- a/frontend/src/container/OnboardingV2Container/onboarding-configs/onboarding-config-with-links.ts
+++ b/frontend/src/container/OnboardingV2Container/onboarding-configs/onboarding-config-with-links.ts
@@ -1521,9 +1521,9 @@ const onboardingConfigWithLinks = [
 	},
 	{
 		dataSource: 'nginx-tracing',
-		label: 'Nginx - Tracing',
+		label: 'Nginx - OpenTelemetry',
 		imgUrl: nginxUrl,
-		tags: ['apm/traces'],
+		tags: ['apm/traces', 'logs', 'metrics'],
 		module: 'apm',
 		relatedSearchKeywords: [
 			'apm',
@@ -1626,7 +1626,7 @@ const onboardingConfigWithLinks = [
 		dataSource: 'cloudflare-workers',
 		label: 'Cloudflare Workers',
 		imgUrl: cloudflareUrl,
-		tags: ['apm/traces'],
+		tags: ['apm/traces', 'logs'],
 		module: 'apm',
 		relatedSearchKeywords: [
 			'cloudflare',
@@ -5346,13 +5346,17 @@ const onboardingConfigWithLinks = [
 		dataSource: 'temporal',
 		label: 'Temporal',
 		imgUrl: temporalUrl,
-		tags: ['apm/traces'],
+		tags: ['apm/traces', 'logs', 'metrics'],
 		module: 'apm',
 		relatedSearchKeywords: [
 			'apm',
 			'application performance monitoring',
 			'integrations',
+			'logs',
+			'metrics',
 			'temporal',
+			'temporal logs',
+			'temporal metrics',
 			'temporal traces',
 			'traces',
 			'tracing',
@@ -5478,7 +5482,7 @@ const onboardingConfigWithLinks = [
 		dataSource: 'dbos',
 		label: 'DBOS',
 		imgUrl: dbosUrl,
-		tags: ['apm/traces'],
+		tags: ['apm/traces', 'logs'],
 		module: 'apm',
 		relatedSearchKeywords: [
 			'database oriented',
@@ -6622,7 +6626,7 @@ const onboardingConfigWithLinks = [
 		dataSource: 'opentelemetry-ebpf',
 		label: 'OpenTelemetry eBPF (OBI)',
 		imgUrl: opentelemetryUrl,
-		tags: ['apm/traces'],
+		tags: ['apm/traces', 'metrics'],
 		module: 'apm',
 		relatedSearchKeywords: [
 			'auto instrumentation',


### PR DESCRIPTION
#### Description

- Some data sources ship a single doc that sets up two or three signals, but carried only one tag, so they showed up in exactly one section of the picker. Searching `temporal` surfaced it only under APM/Traces even though both Temporal docs configure traces, metrics and logs.
- Tagged them with every signal their doc actually configures, so they list under each matching section — the same way `Deno` already does. No UI changes needed: `groupDataSourcesByTags` already fans an entry out across its tags.

| entry | was | now |
| --- | --- | --- |
| Temporal | `apm/traces` | `apm/traces`, `logs`, `metrics` |
| Nginx - OpenTelemetry (was "Nginx - Tracing") | `apm/traces` | `apm/traces`, `logs`, `metrics` |
| OpenTelemetry eBPF (OBI) | `apm/traces` | `apm/traces`, `metrics` |
| DBOS | `apm/traces` | `apm/traces`, `logs` |
| Cloudflare Workers | `apm/traces` | `apm/traces`, `logs` |

- "Nginx - Tracing" is renamed to "Nginx - OpenTelemetry" since it no longer lists only under traces, and to stay distinct from the existing built-in Nginx integration entry.

#### Additional Information

- All 82 docs behind the 70 single-signal-tagged entries were read to decide this; the other 77 are genuinely single-signal. Every language APM doc explicitly sets `OTEL_METRICS_EXPORTER=none` / `OTEL_LOGS_EXPORTER=none`, and the matching metrics docs set `OTEL_TRACES_EXPORTER=none` — so splits like `Java` / `Java logs` / `Java Metrics` are correct as they stand.
- Left unchanged, but worth a second opinion: the logs docs for Java, Python, Node.js (Pino/Winston/Bunyan) and Golang (Logrus/Zerolog) run auto-instrumentation that emits traces, but only ever mention traces to tell you how to switch them off. Read as logs-only here.