### PR TITLE
fix(uplot): stop the time-scale trim hiding data on short windows

### DIFF
--- a/frontend/src/container/DashboardContainer/visualization/panels/utils/baseConfigBuilder.ts
+++ b/frontend/src/container/DashboardContainer/visualization/panels/utils/baseConfigBuilder.ts
@@ -27,6 +27,7 @@ export interface BaseConfigBuilderProps {
 	panelType: PANEL_TYPES;
 	minTimeScale?: number;
 	maxTimeScale?: number;
+	useExactTimeRange?: boolean;
 	stepInterval?: number;
 	isLogScale?: boolean;
 	yAxisUnit?: string;
@@ -46,6 +47,7 @@ export function buildBaseConfig({
 	thresholds,
 	minTimeScale,
 	maxTimeScale,
+	useExactTimeRange,
 	stepInterval,
 	isLogScale,
 	yAxisUnit,
@@ -88,6 +90,7 @@ export function buildBaseConfig({
 		time: true,
 		min: minTimeScale,
 		max: maxTimeScale,
+		useExactTimeRange,
 		logBase: isLogScale ? 10 : undefined,
 		distribution: isLogScale
 			? DistributionType.Logarithmic

--- a/frontend/src/lib/uPlotV2/config/UPlotScaleBuilder.ts
+++ b/frontend/src/lib/uPlotV2/config/UPlotScaleBuilder.ts
@@ -42,6 +42,7 @@ export class UPlotScaleBuilder extends ConfigBuilder<
 			logBase = 10,
 			padMinBy = 0,
 			padMaxBy = 0.05,
+			useExactTimeRange = false,
 		} = this.props;
 
 		// Special handling for time scales (X axis)
@@ -58,14 +59,20 @@ export class UPlotScaleBuilder extends ConfigBuilder<
 
 			// Align max time to "endTime - 1 minute", rounded down to minute precision
 			// This matches legacy getXAxisScale behavior and avoids empty space at the right edge
-			const oneMinuteAgoTimestamp = (maxTime - 60) * 1000;
-			const currentDate = new Date(oneMinuteAgoTimestamp);
+			if (!useExactTimeRange) {
+				const oneMinuteAgoTimestamp = (maxTime - 60) * 1000;
+				const currentDate = new Date(oneMinuteAgoTimestamp);
 
-			currentDate.setSeconds(0);
-			currentDate.setMilliseconds(0);
+				currentDate.setSeconds(0);
+				currentDate.setMilliseconds(0);
 
-			const unixTimestampSeconds = Math.floor(currentDate.getTime() / 1000);
-			maxTime = unixTimestampSeconds;
+				const unixTimestampSeconds = Math.floor(currentDate.getTime() / 1000);
+
+				// Trimming past min inverts the range, which uPlot draws as an empty plot.
+				if (unixTimestampSeconds > minTime) {
+					maxTime = unixTimestampSeconds;
+				}
+			}
 
 			return {
 				[scaleKey]: {

--- a/frontend/src/lib/uPlotV2/config/__tests__/UPlotScaleBuilder.test.ts
+++ b/frontend/src/lib/uPlotV2/config/__tests__/UPlotScaleBuilder.test.ts
@@ -79,6 +79,44 @@ describe('UPlotScaleBuilder', () => {
 		expect(resolvedMax).toBe(expectedMax);
 	});
 
+	it('plots min/max as given when useExactTimeRange is set', () => {
+		const min = 1_700_000_000;
+		const max = 1_700_000_630;
+
+		const builder = new UPlotScaleBuilder(
+			createScaleProps({
+				scaleKey: 'x',
+				time: true,
+				min,
+				max,
+				useExactTimeRange: true,
+			}),
+		);
+
+		const config = builder.getConfig();
+
+		expect(config.x.range).toStrictEqual([min, max]);
+	});
+
+	it('keeps the requested end when the window is shorter than the trim', () => {
+		// 23 second window: trimming a minute off the end would put max before min.
+		const min = 1_786_527_160;
+		const max = 1_786_527_183;
+
+		const builder = new UPlotScaleBuilder(
+			createScaleProps({
+				scaleKey: 'x',
+				time: true,
+				min,
+				max,
+			}),
+		);
+
+		const config = builder.getConfig();
+
+		expect(config.x.range).toStrictEqual([min, max]);
+	});
+
 	it('falls back to getFallbackMinMaxTimeStamp when time scale has no min/max', () => {
 		getFallbackMinMaxSpy.mockReturnValue({
 			fallbackMin: 100,

--- a/frontend/src/lib/uPlotV2/config/types.ts
+++ b/frontend/src/lib/uPlotV2/config/types.ts
@@ -97,6 +97,8 @@ export interface ScaleProps {
 	auto?: boolean;
 	logBase?: uPlot.Scale.LogBase;
 	distribution?: DistributionType;
+	/** Plots a time scale's `min`/`max` as given, skipping the trim below. */
+	useExactTimeRange?: boolean;
 }
 
 export enum DisconnectedValuesMode {


### PR DESCRIPTION
<!--A few plain bullets saying what changed and why, for a reviewer skimming it - not a wall of text, not a restatement of the diff, not generated boilerplate.-->
#### Description

- Time scales always trim a whole minute off `max`. On short durations that trim crosses `min`, the range inverts, and uPlot draws an empty chart — a 1m window shows nothing at all. It is now clamped so the trim can never cross `min`.
- Adds `useExactTimeRange` for panels that would rather show the blank tail than lose their most recent bucket.

<!--If applicable, include screenshots or screen recordings that clearly show the behavior before the change and the result after the change. -->
#### Screenshots / Screen Recordings

Nothing visible on its own — the default range is unchanged, so no existing panel looks different. The blank-chart fix shows up in the first consumer, #12517.

Before - 

https://github.com/user-attachments/assets/a136cc2b-ec6e-4724-a87b-3afac7b86e65


Now - 

https://github.com/user-attachments/assets/850f87a6-0714-4809-9539-bad8931f08fd




<!--Anything reviewers should keep in mind while reviewing -->
#### Additional Information

- Nothing passes `useExactTimeRange` yet except the Logs Explorer frequency chart in #12517, which is stacked on this branch.
- The trim is inherited from legacy `getXAxisScale`, which has the same defect on the v1 uPlot path.
- Worth doing separately:  wanted to do this first and then use it in #12517 
