### PR TITLE
feat(logs pipelines): surface the collector logs in the preview

### DIFF
--- a/frontend/src/api/pipeline/preview.ts
+++ b/frontend/src/api/pipeline/preview.ts
@@ -9,6 +9,9 @@ export interface PipelineSimulationRequest {
 
 export interface PipelineSimulationResponse {
 	logs: ILog[];
+	// what the collector itself logged while simulating, e.g. an operator that
+	// could not parse a log
+	collectorLogs: string[];
 }
 
 const simulatePipelineProcessing = async (

--- a/frontend/src/container/PipelinePage/PipelineListsView/Preview/PipelineProcessingPreview/components/PipelineSimulationResult/index.tsx
+++ b/frontend/src/container/PipelinePage/PipelineListsView/Preview/PipelineProcessingPreview/components/PipelineSimulationResult/index.tsx
@@ -10,7 +10,13 @@ function PipelineSimulationResult({
 	inputLogs,
 	pipeline,
 }: PipelineSimulationResultProps): JSX.Element {
-	const { isLoading, outputLogs, isError, errorMsg } = usePipelinePreview({
+	const {
+		isLoading,
+		outputLogs,
+		collectorLogs,
+		isError,
+		errorMsg,
+	} = usePipelinePreview({
 		pipeline: {
 			...pipeline,
 			// Ensure disabled pipelines can also be previewed
@@ -32,11 +38,27 @@ function PipelineSimulationResult({
 		return <div>Loading...</div>;
 	}
 
-	if (outputLogs.length < 1) {
-		return <div>No logs found</div>;
-	}
-
-	return <LogsList logs={outputLogs} />;
+	return (
+		<>
+			{outputLogs.length > 0 ? (
+				<LogsList logs={outputLogs} />
+			) : (
+				<div>No logs found</div>
+			)}
+			{collectorLogs.length > 0 && (
+				<div className="pipeline-simulation-collector-logs">
+					<div className="pipeline-simulation-collector-logs-title">
+						Collector logs
+					</div>
+					{collectorLogs.map((collectorLog) => (
+						<pre key={collectorLog} className="pipeline-simulation-collector-log">
+							{collectorLog}
+						</pre>
+					))}
+				</div>
+			)}
+		</>
+	);
 }
 
 export interface PipelineSimulationResultProps {

--- a/frontend/src/container/PipelinePage/PipelineListsView/Preview/PipelineProcessingPreview/components/PipelineSimulationResult/styles.scss
+++ b/frontend/src/container/PipelinePage/PipelineListsView/Preview/PipelineProcessingPreview/components/PipelineSimulationResult/styles.scss
@@ -1,3 +1,24 @@
 .pipeline-simulation-error {
 	text-align: center;
 }
+
+.pipeline-simulation-collector-logs {
+	margin-top: 12px;
+
+	.pipeline-simulation-collector-logs-title {
+		font-weight: 500;
+		margin-bottom: 4px;
+	}
+
+	.pipeline-simulation-collector-log {
+		margin: 0 0 4px;
+		padding: 8px;
+		max-height: 120px;
+		overflow: auto;
+		font-size: 11px;
+		white-space: pre-wrap;
+		word-break: break-word;
+		border-radius: 3px;
+		background: var(--bg-ink-400);
+	}
+}

--- a/frontend/src/container/PipelinePage/PipelineListsView/Preview/hooks/usePipelinePreview.ts
+++ b/frontend/src/container/PipelinePage/PipelineListsView/Preview/hooks/usePipelinePreview.ts
@@ -15,6 +15,7 @@ export interface PipelinePreviewRequest {
 export interface PipelinePreviewResponse {
 	isLoading: boolean;
 	outputLogs: ILog[];
+	collectorLogs: string[];
 	isError: boolean;
 	errorMsg: string;
 }
@@ -52,6 +53,7 @@ const usePipelinePreview = ({
 	return {
 		isLoading: isFetching,
 		outputLogs,
+		collectorLogs: data?.collectorLogs || [],
 		isError,
 		errorMsg: error?.message || '',
 	};

--- a/pkg/query-service/app/http_handler.go
+++ b/pkg/query-service/app/http_handler.go
@@ -3201,7 +3201,19 @@ func (aH *APIHandler) PreviewLogsPipelinesHandler(w http.ResponseWriter, r *http
 		return
 	}
 
-	resultLogs, err := aH.LogsParsingPipelineController.PreviewLogsPipelines(r.Context(), &req)
+	claims, errv2 := authtypes.ClaimsFromContext(r.Context())
+	if errv2 != nil {
+		render.Error(w, errv2)
+		return
+	}
+
+	orgID, errv2 := valuer.NewUUID(claims.OrgID)
+	if errv2 != nil {
+		render.Error(w, errv2)
+		return
+	}
+
+	resultLogs, err := aH.LogsParsingPipelineController.PreviewLogsPipelines(r.Context(), orgID, &req)
 	if err != nil {
 		render.Error(w, err)
 		return

--- a/pkg/query-service/app/logparsingpipeline/controller.go
+++ b/pkg/query-service/app/logparsingpipeline/controller.go
@@ -342,11 +342,17 @@ type PipelinesPreviewResponse struct {
 
 func (ic *LogParsingPipelineController) PreviewLogsPipelines(
 	ctx context.Context,
+	orgID valuer.UUID,
 	request *PipelinesPreviewRequest,
 ) (*PipelinesPreviewResponse, error) {
 	pipelines, err := ic.enrichPipelinesFilters(ctx, request.Pipelines)
 	if err != nil {
 		return nil, err
+	}
+
+	// The collector gets the same pipeline prepended over opamp; see RecommendAgentConfig.
+	if ic.fl.BooleanOrEmpty(ctx, flagger.FeatureUseJSONBody, featuretypes.NewFlaggerEvaluationContext(orgID)) {
+		pipelines = append([]pipelinetypes.GettablePipeline{ic.getNormalizePipeline()}, pipelines...)
 	}
 
 	result, collectorLogs, err := SimulatePipelinesProcessing(ctx, pipelines, request.Logs)

--- a/pkg/query-service/app/logparsingpipeline/preview.go
+++ b/pkg/query-service/app/logparsingpipeline/preview.go
@@ -89,6 +89,11 @@ func SimulatePipelinesProcessing(ctx context.Context, pipelines []pipelinetypes.
 		if log == "" || strings.Contains(log, "featuregate.go") {
 			continue
 		}
+		// each line of a stack trace arrives as its own entry: a symbol (no spaces)
+		// followed by a tab indented file:line
+		if strings.HasPrefix(log, "\t") || !strings.Contains(log, " ") {
+			continue
+		}
 		collectorWarnAndErrorLogs = append(collectorWarnAndErrorLogs, log)
 	}
 

--- a/pkg/query-service/app/logparsingpipeline/preview_test.go
+++ b/pkg/query-service/app/logparsingpipeline/preview_test.go
@@ -6,11 +6,14 @@ import (
 	"testing"
 	"time"
 
+	"github.com/SigNoz/signoz/pkg/flagger/flaggertest"
 	"github.com/SigNoz/signoz/pkg/query-service/model"
 	v3 "github.com/SigNoz/signoz/pkg/query-service/model/v3"
 	"github.com/SigNoz/signoz/pkg/types/pipelinetypes"
+	"github.com/SigNoz/signoz/pkg/valuer"
 	"github.com/google/uuid"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/entry"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -18,39 +21,7 @@ func TestPipelinePreview(t *testing.T) {
 	require := require.New(t)
 
 	testPipelines := []pipelinetypes.GettablePipeline{
-		{
-			StoreablePipeline: pipelinetypes.StoreablePipeline{
-				OrderID: 1,
-				Name:    "pipeline1",
-				Alias:   "pipeline1",
-				Enabled: true,
-			},
-			Filter: &v3.FilterSet{
-				Operator: "AND",
-				Items: []v3.FilterItem{
-					{
-						Key: v3.AttributeKey{
-							Key:      "method",
-							DataType: v3.AttributeKeyDataTypeString,
-							Type:     v3.AttributeKeyTypeTag,
-						},
-						Operator: "=",
-						Value:    "GET",
-					},
-				},
-			},
-			Config: []pipelinetypes.PipelineOperator{
-				{
-					OrderId: 1,
-					ID:      "add",
-					Type:    "add",
-					Field:   "attributes.test",
-					Value:   "val",
-					Enabled: true,
-					Name:    "test add",
-				},
-			},
-		},
+		makeTestAddAttributePipeline(),
 		{
 			StoreablePipeline: pipelinetypes.StoreablePipeline{
 				OrderID: 2,
@@ -146,6 +117,93 @@ func TestPipelinePreview(t *testing.T) {
 		result[1].Resources_string,
 	)
 
+}
+
+func TestPipelinePreviewNormalizesBodyWithJSONBodyEnabled(t *testing.T) {
+	controller := &LogParsingPipelineController{fl: flaggertest.WithUseJSONBody(t, true)}
+
+	result, err := controller.PreviewLogsPipelines(
+		context.Background(),
+		valuer.GenerateUUID(),
+		&PipelinesPreviewRequest{
+			Pipelines: []pipelinetypes.GettablePipeline{makeTestAddAttributePipeline()},
+			Logs: []model.SignozLog{
+				makeTestSignozLog("test log body", map[string]interface{}{"method": "GET"}),
+				makeTestSignozLog(
+					`{"level":"error","msg":"json log body"}`,
+					map[string]interface{}{"method": "GET"},
+				),
+			},
+		},
+	)
+
+	require.NoError(t, err)
+	require.Len(t, result.OutputLogs, 2)
+
+	assert.Equal(t, `{"message":"test log body"}`, result.OutputLogs[0].Body)
+	assert.Equal(
+		t,
+		`{"level":"error","message":"json log body"}`,
+		result.OutputLogs[1].Body,
+	)
+	assert.Equal(t, "val", result.OutputLogs[0].Attributes_string["test"])
+}
+
+func TestPipelinePreviewKeepsBodyAsIsWithJSONBodyDisabled(t *testing.T) {
+	controller := &LogParsingPipelineController{fl: flaggertest.WithUseJSONBody(t, false)}
+
+	result, err := controller.PreviewLogsPipelines(
+		context.Background(),
+		valuer.GenerateUUID(),
+		&PipelinesPreviewRequest{
+			Pipelines: []pipelinetypes.GettablePipeline{makeTestAddAttributePipeline()},
+			Logs: []model.SignozLog{
+				makeTestSignozLog("test log body", map[string]interface{}{"method": "GET"}),
+			},
+		},
+	)
+
+	require.NoError(t, err)
+	require.Len(t, result.OutputLogs, 1)
+
+	assert.Equal(t, "test log body", result.OutputLogs[0].Body)
+	assert.Equal(t, "val", result.OutputLogs[0].Attributes_string["test"])
+}
+
+func makeTestAddAttributePipeline() pipelinetypes.GettablePipeline {
+	return pipelinetypes.GettablePipeline{
+		StoreablePipeline: pipelinetypes.StoreablePipeline{
+			OrderID: 1,
+			Name:    "pipeline1",
+			Alias:   "pipeline1",
+			Enabled: true,
+		},
+		Filter: &v3.FilterSet{
+			Operator: "AND",
+			Items: []v3.FilterItem{
+				{
+					Key: v3.AttributeKey{
+						Key:      "method",
+						DataType: v3.AttributeKeyDataTypeString,
+						Type:     v3.AttributeKeyTypeTag,
+					},
+					Operator: "=",
+					Value:    "GET",
+				},
+			},
+		},
+		Config: []pipelinetypes.PipelineOperator{
+			{
+				OrderId: 1,
+				ID:      "add",
+				Type:    "add",
+				Field:   "attributes.test",
+				Value:   "val",
+				Enabled: true,
+				Name:    "test add",
+			},
+		},
+	}
 }
 
 func TestGrokParsingProcessor(t *testing.T) {


### PR DESCRIPTION
#### Description

- The preview response has always carried `collectorLogs` — what the collector logged while simulating — but the UI dropped the field. They are now shown under the previewed output, so a pipeline that silently does nothing explains itself.
- The collector emits a stack trace after each error, one array entry per frame, so a single failure arrived as 19 entries. Those frames are filtered out server-side, leaving one line per failure.

#### Additional Information

The case this exists for: with `use_json_body` on, the collector runs a `normalize` pipeline before user operators, so the body is a map by then. A parser pointed at `body` instead of `body.message` cannot work — it extracts nothing and, until now, said nothing. Driven against a local collector, preview with `parse_from: body` returns empty attributes plus:

```
type 'map[string]interface {}' cannot be parsed as grok
```

Stacked on #12520 — retarget to `main` once that merges.
