### PR TITLE
test(integration): move role cleanups to the v2 user_roles API

### DIFF
--- a/tests/integration/tests/dashboard/06_authz.py
+++ b/tests/integration/tests/dashboard/06_authz.py
@@ -583,15 +583,15 @@ def test_dashboard_authz_cleanup(
     actor = find_user_by_email(signoz, admin_token, _ACTOR_EMAIL)
 
     response = requests.get(
-        signoz.self.host_configs["8080"].get(f"/api/v2/users/{actor['id']}/roles"),
+        signoz.self.host_configs["8080"].get(f"/api/v2/users/{actor['id']}"),
         headers={"Authorization": f"Bearer {admin_token}"},
         timeout=5,
     )
     assert response.status_code == HTTPStatus.OK, response.text
-    actor_entry = next((role for role in response.json()["data"] if role["name"] == _ACTOR_ROLE_NAME), None)
+    actor_entry = next((ur for ur in response.json()["data"]["userRoles"] if ur["role"]["name"] == _ACTOR_ROLE_NAME), None)
     if actor_entry is not None:
         response = requests.delete(
-            signoz.self.host_configs["8080"].get(f"/api/v2/users/{actor['id']}/roles/{actor_entry['id']}"),
+            signoz.self.host_configs["8080"].get(f"/api/v2/user_roles/{actor_entry['id']}"),
             headers={"Authorization": f"Bearer {admin_token}"},
             timeout=5,
         )

--- a/tests/integration/tests/role/03_fga.py
+++ b/tests/integration/tests/role/03_fga.py
@@ -260,12 +260,12 @@ def test_role_fga_cleanup(
     admin_token = get_token(USER_ADMIN_EMAIL, USER_ADMIN_PASSWORD)
     user = find_user_by_email(signoz, admin_token, _ACTOR_USER_EMAIL)
 
-    resp = requests.get(signoz.self.host_configs["8080"].get(f"/api/v2/users/{user['id']}/roles"), headers={"Authorization": f"Bearer {admin_token}"}, timeout=5)
+    resp = requests.get(signoz.self.host_configs["8080"].get(f"/api/v2/users/{user['id']}"), headers={"Authorization": f"Bearer {admin_token}"}, timeout=5)
     assert resp.status_code == HTTPStatus.OK, resp.text
-    actor_entry = next((r for r in resp.json()["data"] if r["name"] == _ACTOR_ROLE_NAME), None)
+    actor_entry = next((ur for ur in resp.json()["data"]["userRoles"] if ur["role"]["name"] == _ACTOR_ROLE_NAME), None)
     if actor_entry is not None:
         resp = requests.delete(
-            signoz.self.host_configs["8080"].get(f"/api/v2/users/{user['id']}/roles/{actor_entry['id']}"),
+            signoz.self.host_configs["8080"].get(f"/api/v2/user_roles/{actor_entry['id']}"),
             headers={"Authorization": f"Bearer {admin_token}"},
             timeout=5,
         )

--- a/tests/integration/tests/savedview/02_authz.py
+++ b/tests/integration/tests/savedview/02_authz.py
@@ -319,12 +319,12 @@ def test_saved_view_fga_cleanup(
     admin_token = get_token(USER_ADMIN_EMAIL, USER_ADMIN_PASSWORD)
     user = find_user_by_email(signoz, admin_token, _SAVED_VIEW_FGA_CUSTOM_USER_EMAIL)
 
-    resp = requests.get(signoz.self.host_configs["8080"].get(f"/api/v2/users/{user['id']}/roles"), headers={"Authorization": f"Bearer {admin_token}"}, timeout=5)
+    resp = requests.get(signoz.self.host_configs["8080"].get(f"/api/v2/users/{user['id']}"), headers={"Authorization": f"Bearer {admin_token}"}, timeout=5)
     assert resp.status_code == HTTPStatus.OK, resp.text
-    custom_entry = next((r for r in resp.json()["data"] if r["name"] == _SAVED_VIEW_FGA_CUSTOM_ROLE_NAME), None)
+    custom_entry = next((ur for ur in resp.json()["data"]["userRoles"] if ur["role"]["name"] == _SAVED_VIEW_FGA_CUSTOM_ROLE_NAME), None)
     if custom_entry is not None:
         resp = requests.delete(
-            signoz.self.host_configs["8080"].get(f"/api/v2/users/{user['id']}/roles/{custom_entry['id']}"),
+            signoz.self.host_configs["8080"].get(f"/api/v2/user_roles/{custom_entry['id']}"),
             headers={"Authorization": f"Bearer {admin_token}"},
             timeout=5,
         )

--- a/tests/integration/tests/serviceaccount/06_fga.py
+++ b/tests/integration/tests/serviceaccount/06_fga.py
@@ -285,12 +285,12 @@ def test_delete_custom_role_cleanup(
     role_id = find_role_by_name(signoz, admin_token, _SA_FGA_CUSTOM_ROLE_NAME)
     user = find_user_by_email(signoz, admin_token, _SA_FGA_CUSTOM_USER_EMAIL)
 
-    resp = requests.get(signoz.self.host_configs["8080"].get(f"/api/v2/users/{user['id']}/roles"), headers={"Authorization": f"Bearer {admin_token}"}, timeout=5)
+    resp = requests.get(signoz.self.host_configs["8080"].get(f"/api/v2/users/{user['id']}"), headers={"Authorization": f"Bearer {admin_token}"}, timeout=5)
     assert resp.status_code == HTTPStatus.OK, resp.text
-    custom_entry = next((r for r in resp.json()["data"] if r["name"] == _SA_FGA_CUSTOM_ROLE_NAME), None)
+    custom_entry = next((ur for ur in resp.json()["data"]["userRoles"] if ur["role"]["name"] == _SA_FGA_CUSTOM_ROLE_NAME), None)
     if custom_entry is not None:
         resp = requests.delete(
-            signoz.self.host_configs["8080"].get(f"/api/v2/users/{user['id']}/roles/{custom_entry['id']}"),
+            signoz.self.host_configs["8080"].get(f"/api/v2/user_roles/{custom_entry['id']}"),
             headers={"Authorization": f"Bearer {admin_token}"},
             timeout=5,
         )


### PR DESCRIPTION
#### Description

- Four `*_cleanup` teardown tests still removed a role via the deprecated `DELETE /api/v2/users/{id}/roles/{roleId}`. They now use `DELETE /api/v2/user_roles/{id}`.
- Removal is keyed by the `user_role` entry id, which `GET /api/v2/users/{id}/roles` cannot supply, so the entry is read from `GET /api/v2/users/{id}` instead. That endpoint is not deprecated and its other uses are untouched.
- Follow-up to #12529, which missed these four.

#### Issues closed by this PR

Contributes to SigNoz/platform-pod#2667