### PR TITLE
fix(query-builder): let tag add-on fields grow instead of spilling their tags

### DIFF
--- a/frontend/src/periscope.scss
+++ b/frontend/src/periscope.scss
@@ -183,7 +183,7 @@
 			font-family: 'Space Mono', monospace !important;
 
 			border: none;
-			height: 36px;
+			min-height: 36px;
 			.ant-select-selection-search-input {
 				min-width: max-content !important;
 				max-width: 100% !important;
@@ -191,7 +191,7 @@
 		}
 
 		.ant-select-selector {
-			height: 36px;
+			min-height: 36px;
 			border-color: var(--input-with-label-border-color, var(--l2-border));
 			background: var(--input-with-label-background-color, var(--l2-background));
 			border-radius: 0;


### PR DESCRIPTION
<!--A few plain bullets saying what changed and why, for a reviewer skimming it - not a wall of text, not a restatement of the diff, not generated boilerplate.-->
#### Description

- Adding a few values to **Group By** made the tags wrap onto a second row that rendered outside the field, on top of the add-on toggles below it. **Order By** and the formula Order By row had the same bug.
- The add-on field pinned the antd select and its selector to `height: 36px`, so it could never grow. Both are `min-height: 36px` now — single-line selects keep the same 36px row, tag selects grow with their rows.

<!--If applicable, include screenshots or screen recordings that clearly show the behavior before the change and the result after the change. -->
#### Screenshots / Screen Recordings

Before
<img width="1742" height="117" alt="image" src="https://github.com/user-attachments/assets/12dfccbe-d087-4857-9bd0-3b6dfa0a1da1" />

After
<img width="1778" height="164" alt="image" src="https://github.com/user-attachments/assets/abeb0b38-b0ce-4749-bf1c-32fc865833b9" />

#### Issues Closed
Closes https://github.com/SigNoz/pulse-pod/issues/270


<!--Anything reviewers should keep in mind while reviewing -->
#### Additional Information

- Broke in #11992, which put `height: 36px` on `.ant-select-selector` and moved the field's border onto it. The same `height` on the root `.ant-select` predates that but never applied, because `GroupByFilter`/`OrderByFilter` pass an inline `height: 100%` — antd was left to size the selector from its content, so the field used to grow as tags wrapped.
- Checked in a headless-Chromium repro of the field using antd 5.11's select rules: 12 tags in a ~900px field hang 20px below the box on `main`, and sit inside it with this change.
