### PR TITLE
fix(query-service): check GetServices query error before the NumCalls guard

### DIFF
--- a/pkg/query-service/app/clickhouseReader/reader.go
+++ b/pkg/query-service/app/clickhouseReader/reader.go
@@ -489,12 +489,15 @@ func (r *ClickHouseReader) GetServices(ctx context.Context, queryParams *model.G
 				args...,
 			).ScanStruct(&serviceItem)
 
-			if serviceItem.NumCalls == 0 {
+			// Check the query error before the NumCalls guard: a failed ScanStruct
+			// leaves serviceItem at its zero value (NumCalls == 0), so checking
+			// NumCalls first swallowed the error and silently dropped the service.
+			if err != nil {
+				r.logger.Error("Error in processing sql query", errorsV2.Attr(err))
 				return
 			}
 
-			if err != nil {
-				r.logger.Error("Error in processing sql query", errorsV2.Attr(err))
+			if serviceItem.NumCalls == 0 {
 				return
 			}
 


### PR DESCRIPTION
Fixes #12545.

In `GetServices`, each service is processed in its own goroutine. After running the per-service query it checks the row count before it checks the query error:

```go
err = r.db.QueryRow(ctx, query, args...).ScanStruct(&serviceItem)

if serviceItem.NumCalls == 0 {
    return
}

if err != nil {
    r.logger.Error("Error in processing sql query", errorsV2.Attr(err))
    return
}
```

When the ClickHouse query fails (timeout, connection reset, context cancellation), `ScanStruct` returns a non-nil error and leaves `serviceItem` at its zero value, so `NumCalls` is 0. The `NumCalls == 0` guard fires first and returns, so the `err != nil` branch is never reached. The error is neither logged nor propagated, and the service just drops out of the `/api/v1/services` response as if it had no traffic. On-call ends up chasing a service that only "disappeared" because a query timed out.

This swaps the two checks so the error is inspected first. A real query failure now gets logged and returns; a genuine no-traffic service (nil error, `NumCalls == 0`) still returns quietly as before. The happy path is unchanged.

I confirmed the ordering against `reader.go` in the goroutine spawned by `GetServices`. There is no unit harness around this ClickHouse path to add a case to, so this is the minimal reordering.