### PR TITLE
fix(LogLiveTail): close EventSource on STOPPED and unmount to prevent connection leak (#12546)

### DIFF
--- a/frontend/src/container/LogLiveTail/index.tsx
+++ b/frontend/src/container/LogLiveTail/index.tsx
@@ -90,6 +90,13 @@ function LogLiveTail({ getLogsAggregate }: Props): JSX.Element {
 	// This ref depicts thats whether the live tail is played from paused state or not.
 	const liveTailSourceRef = useRef<EventSource>();
 
+	const closeLiveTailSource = useCallback(() => {
+		if (liveTailSourceRef.current) {
+			liveTailSourceRef.current.close();
+			liveTailSourceRef.current = undefined;
+		}
+	}, []);
+
 	useEffect(() => {
 		if (liveTail === 'PLAYING') {
 			const timeStamp = dayjs().subtract(liveTailStartRange, 'minute').valueOf();
@@ -130,10 +137,19 @@ function LogLiveTail({ getLogsAggregate }: Props): JSX.Element {
 		}
 
 		if (liveTail === 'STOPPED') {
-			liveTailSourceRef.current = undefined;
+			closeLiveTailSource();
 		}
+
 		// eslint-disable-next-line react-hooks/exhaustive-deps
-	}, [liveTail, queryString, notifications, dispatch]);
+	}, [liveTail, queryString, notifications, dispatch, closeLiveTailSource]);
+
+	// Close the EventSource when the component unmounts
+	useEffect(
+		() => (): void => {
+			closeLiveTailSource();
+		},
+		[closeLiveTailSource],
+	);
 
 	const handleLiveTailStart = (): void => {
 		handleLiveTail('PLAYING');
@@ -202,9 +218,7 @@ function LogLiveTail({ getLogsAggregate }: Props): JSX.Element {
 			type: SET_LOADING,
 			payload: false,
 		});
-		if (liveTailSourceRef.current) {
-			liveTailSourceRef.current.close();
-		}
+		closeLiveTailSource();
 	};
 
 	return (


### PR DESCRIPTION
#### Description

- The live tail EventSource was never closed when the component transitioned to `STOPPED` — the ref was cleared but the underlying SSE connection stayed open, streaming events to an unmounted component.
- When the component unmounted without going through the stop button (e.g. navigating away), the `EventSource` kept the connection open indefinitely, and every incoming message fired `onmessage`/`batchLiveLog` which dispatched to the Redux store from an unmounted component.
- Extracted a `closeLiveTailSource` helper that both closes the source and clears the ref. Applied it to the `STOPPED` branch, the unmount cleanup, and the `onLiveTailStop` handler to keep all three paths in sync.

#### Issues closed by this PR

Closes #12546

#### Screenshots / Screen Recordings

N/A — the fix is a non-visible code change. The regression is that no `EventSource` connection survives past the component lifecycle. Verified by inspection: all three paths (`STOPPED`, unmount, `onLiveTailStop`) now call the same `closeLiveTailSource` helper.

#### Additional Information

- The `closeLiveTailSource` callback is stable (empty deps) so it can be safely added to dependency arrays without causing re-renders.
- The existing `onLiveTailStop` handler already called `.close()` but did not clear the ref, so a subsequent `handleLiveTailStart` would see a stale ref and skip the `FLUSH_LOGS` dispatch. This is now fixed by clearing the ref consistently.