### PR TITLE
fix(clickhouse-reader): check ScanStruct error before zero-value guard in GetServices

### DIFF
--- a/pkg/query-service/app/clickhouseReader/reader.go
+++ b/pkg/query-service/app/clickhouseReader/reader.go
@@ -489,12 +489,16 @@ func (r *ClickHouseReader) GetServices(ctx context.Context, queryParams *model.G
 				args...,
 			).ScanStruct(&serviceItem)
 
-			if serviceItem.NumCalls == 0 {
+			if err != nil {
+				// Check the ScanStruct error first. A zero-value serviceItem
+				// (NumCalls == 0) is the same shape the struct takes on a
+				// ClickHouse failure, so the zero-value guard below would
+				// otherwise swallow the error and the service.
+				r.logger.Error("Error in processing sql query", errorsV2.Attr(err))
 				return
 			}
 
-			if err != nil {
-				r.logger.Error("Error in processing sql query", errorsV2.Attr(err))
+			if serviceItem.NumCalls == 0 {
 				return
 			}
 


### PR DESCRIPTION
## Summary

Reorder the two `if` blocks in `pkg/query-service/app/clickhouseReader/reader.go:GetServices` so the `ScanStruct` error is checked before the `serviceItem.NumCalls == 0` guard.

## Why

When `ScanStruct` fails (ClickHouse timeout, context cancel, connection reset), `serviceItem` is left at its zero value and `NumCalls == 0`. The old code checked the zero-value guard first, so the error was silently swallowed and the service simply vanished from the `/api/v1/services` response — no log, no error propagation. The on-call engineer sees a service as having disappeared and wastes time investigating a non-existent problem.

The fix logs the underlying error (`"Error in processing sql query"` with the `errorsv2.Attr` attached) and returns before the guard runs. The "skip zero-call services" behavior is preserved against an actually-populated struct.

## Change

```go
// before
err = r.db.QueryRow(ctx, query, args...).ScanStruct(&serviceItem)
if serviceItem.NumCalls == 0 {
    return
}
if err != nil {
    r.logger.Error("Error in processing sql query", errorsV2.Attr(err))
    return
}

// after
err = r.db.QueryRow(ctx, query, args...).ScanStruct(&serviceItem)
if err != nil {
    r.logger.Error("Error in processing sql query", errorsV2.Attr(err))
    return
}
if serviceItem.NumCalls == 0 {
    return
}
```

1 file, 7 insertions(+), 3 deletions(-). One method in one goroutine in one file.

## Fixes

Fixes #12545

## Testing

- `go build ./...` clean
- `go vet ./pkg/query-service/app/clickhouseReader/...` clean
- `go test -race -count=1 -short ./pkg/query-service/app/clickhouseReader/...` passes (the existing `TestGetStatusFilters`; no in-package test for `GetServices` exists today, and a meaningful regression test would require a mock ClickHouse connection — out of scope for this single-line reorder).

The behavior change is observable by reading the code: the `errorsv2.Attr(err)` log line is now reachable in the failure case, where it was unreachable before. Any test that exercises a ClickHouse failure on this query path will now see the log line.

## Backward compatibility

No API change. No schema change. No behavior change for the success path. The only change is that a previously-silent failure mode now produces a log line and returns the goroutine early.
