### PR TITLE
fix(user): clear role assignments when a user is deleted

### DIFF
--- a/pkg/modules/user/impluser/store.go
+++ b/pkg/modules/user/impluser/store.go
@@ -274,6 +274,15 @@ func (store *store) SoftDeleteUser(ctx context.Context, orgID string, id string)
 		return errors.Wrapf(err, errors.TypeInternal, errors.CodeInternal, "failed to delete tokens")
 	}
 
+	// delete user_role assignments so the roles can be deleted later
+	_, err = tx.NewDelete().
+		Model(new(authtypes.UserRole)).
+		Where("user_id = ?", id).
+		Exec(ctx)
+	if err != nil {
+		return errors.Wrapf(err, errors.TypeInternal, errors.CodeInternal, "failed to delete user roles")
+	}
+
 	// soft delete user
 	now := time.Now()
 	_, err = tx.NewUpdate().

--- a/pkg/signoz/provider.go
+++ b/pkg/signoz/provider.go
@@ -241,6 +241,7 @@ func NewSQLMigrationProviderFactories(
 		sqlmigration.NewBackfillSavedViewRequestTypeFactory(sqlstore),
 		sqlmigration.NewRestructureAuthDomainConfigFactory(sqlstore),
 		sqlmigration.NewFixSavedViewSelectFieldsFactory(sqlstore),
+		sqlmigration.NewDeleteOrphanUserRolesFactory(),
 	)
 }
 

--- a/pkg/sqlmigration/115_delete_orphan_user_roles.go
+++ b/pkg/sqlmigration/115_delete_orphan_user_roles.go
@@ -1,0 +1,65 @@
+package sqlmigration
+
+import (
+	"context"
+	"database/sql"
+
+	"github.com/SigNoz/signoz/pkg/factory"
+	"github.com/SigNoz/signoz/pkg/types"
+	"github.com/SigNoz/signoz/pkg/types/authtypes"
+	"github.com/uptrace/bun"
+	"github.com/uptrace/bun/migrate"
+)
+
+type deleteOrphanUserRoles struct{}
+
+func NewDeleteOrphanUserRolesFactory() factory.ProviderFactory[SQLMigration, Config] {
+	return factory.NewProviderFactory(
+		factory.MustNewName("delete_orphan_user_roles"),
+		func(ctx context.Context, ps factory.ProviderSettings, c Config) (SQLMigration, error) {
+			return &deleteOrphanUserRoles{}, nil
+		},
+	)
+}
+
+func (migration *deleteOrphanUserRoles) Register(migrations *migrate.Migrations) error {
+	return migrations.Register(migration.Up, migration.Down)
+}
+
+func (migration *deleteOrphanUserRoles) Up(ctx context.Context, db *bun.DB) error {
+	tx, err := db.BeginTx(ctx, nil)
+	if err != nil {
+		return err
+	}
+	defer func() {
+		_ = tx.Rollback()
+	}()
+
+	var deletedUserIDs []string
+	err = tx.NewSelect().
+		Model(new(types.User)).
+		Column("id").
+		Where("status = ?", types.UserStatusDeleted).
+		Scan(ctx, &deletedUserIDs)
+	if err != nil && err != sql.ErrNoRows {
+		return err
+	}
+
+	if len(deletedUserIDs) == 0 {
+		return tx.Commit()
+	}
+
+	_, err = tx.NewDelete().
+		Model(new(authtypes.UserRole)).
+		Where("user_id IN (?)", bun.In(deletedUserIDs)).
+		Exec(ctx)
+	if err != nil {
+		return err
+	}
+
+	return tx.Commit()
+}
+
+func (migration *deleteOrphanUserRoles) Down(context.Context, *bun.DB) error {
+	return nil
+}

--- a/tests/integration/tests/passwordauthn/06_invite_status.py
+++ b/tests/integration/tests/passwordauthn/06_invite_status.py
@@ -129,4 +129,4 @@ def test_delete_user(
     assert response.status_code == HTTPStatus.OK
     data = response.json()["data"]
     assert data["status"] == "deleted"
-    assert len(data["userRoles"]) == 1
+    assert len(data["userRoles"]) == 0

--- a/tests/integration/tests/role/02_crud.py
+++ b/tests/integration/tests/role/02_crud.py
@@ -267,6 +267,40 @@ def test_delete_role_with_assignee_guarded(
     assert resp.status_code == HTTPStatus.NO_CONTENT, resp.text
 
 
+def test_delete_role_after_deleting_assigned_user(
+    signoz: types.SigNoz,
+    create_user_admin: types.Operation,  # pylint: disable=unused-argument
+    get_token: Callable[[str, str], str],
+    create_role: Callable[..., str],
+):
+    admin_token = get_token(USER_ADMIN_EMAIL, USER_ADMIN_PASSWORD)
+
+    role_id = create_role(admin_token, "crud-deleted-assignee-role", [transaction_group("read", "metaresource", "dashboard", ["*"])])
+
+    user_id = create_active_user(
+        signoz,
+        admin_token,
+        email="crud+deleted-assignee@integration.test",
+        role="signoz-viewer",
+        password=CRUD_ASSIGNEE_USER_PASSWORD,
+        name="crud-deleted-assignee-user",
+    )
+
+    resp = requests.post(
+        signoz.self.host_configs["8080"].get("/api/v2/user_roles"),
+        json={"userId": user_id, "roleId": role_id},
+        headers={"Authorization": f"Bearer {admin_token}"},
+        timeout=5,
+    )
+    assert resp.status_code == HTTPStatus.CREATED, resp.text
+
+    resp = requests.delete(signoz.self.host_configs["8080"].get(f"/api/v2/users/{user_id}"), headers={"Authorization": f"Bearer {admin_token}"}, timeout=5)
+    assert resp.status_code == HTTPStatus.NO_CONTENT, resp.text
+
+    resp = requests.delete(signoz.self.host_configs["8080"].get(f"/api/v1/roles/{role_id}"), headers={"Authorization": f"Bearer {admin_token}"}, timeout=5)
+    assert resp.status_code == HTTPStatus.NO_CONTENT, f"delete role after deleting its only assignee: {resp.text}"
+
+
 def test_delete_removes_role(
     signoz: types.SigNoz,
     create_user_admin: types.Operation,  # pylint: disable=unused-argument


### PR DESCRIPTION
#### Description

- Soft-deleting a user revoked the FGA grant but left the `user_role` rows behind. The role-delete guard (`OnBeforeRoleDelete` → `GetUsersByOrgIDAndRoleID`) still counted the deleted user, so the role could never be deleted — and detaching the assignment was also blocked because the user is deleted. That left the role permanently undeletable.
- `SoftDeleteUser` now deletes the user's `user_role` rows in the same transaction that already clears its password, tokens, and preferences, so the SQL side matches the FGA revoke.
- Migration `delete_orphan_user_roles` clears the orphan `user_role` rows left by users deleted before this change.

#### Additional Information

- Regression test in `role/02_crud.py`: assign a custom role to a user, delete the user, then delete the role → now `204` (was the deadlock).