### PR TITLE
fix(querier): decode JSON columns in table and graph queries

### DIFF
--- a/pkg/querier/consume.go
+++ b/pkg/querier/consume.go
@@ -1,6 +1,7 @@
 package querier
 
 import (
+	"encoding/json"
 	"fmt"
 	"math"
 	"reflect"
@@ -11,12 +12,12 @@ import (
 	"strings"
 	"time"
 
+	"github.com/ClickHouse/clickhouse-go/v2/lib/chcol"
 	"github.com/ClickHouse/clickhouse-go/v2/lib/driver"
-	"github.com/SigNoz/signoz/pkg/errors"
 	qbtypes "github.com/SigNoz/signoz/pkg/types/querybuildertypes/querybuildertypesv5"
 	"github.com/SigNoz/signoz/pkg/types/spantypes"
+	"github.com/SigNoz/signoz/pkg/types/telemetrystoretypes"
 	"github.com/SigNoz/signoz/pkg/types/telemetrytypes"
-	"github.com/bytedance/sonic"
 )
 
 var (
@@ -30,14 +31,38 @@ var (
 	// written clickhouse query. The column alias indcate which value is
 	// to be considered as final result (or target).
 	legacyReservedColumnTargetAliases = []string{"__result", "__value", "result", "res", "value"}
-
-	CodeFailUnmarshalJSONColumn = errors.MustNewCode("fail_unmarshal_json_column")
 )
 
 // stripKeyAlias removes the __SELECT_KEY_<n>_ / __GROUP_BY_KEY_<n>_ prefix from a result
 // column name, recovering the field name; unprefixed names are returned unchanged.
 func stripKeyAlias(name string) string {
 	return keyAliasRe.ReplaceAllString(name, "")
+}
+
+// unwrapVariant returns the concrete value inside the chcol.Variant envelope the driver scans a
+// Dynamic column — a JSON path such as body_v2.level — into.
+func unwrapVariant(val any) any {
+	if v, ok := val.(chcol.Variant); ok {
+		return v.Any()
+	}
+	return val
+}
+
+// labelValue renders a group-by value the payload cannot carry as a scalar — a JSON column, or a
+// Dynamic one — as a stable string, so that rows differing only in that value land in different
+// series. JSON goes through encoding/json for its sorted map keys: ClickHouse groups documents by
+// structure, so two rows it considers equal have to produce the same label.
+func labelValue(val any) string {
+	val = unwrapVariant(val)
+	if val == nil {
+		return ""
+	}
+	if v, ok := val.(telemetrystoretypes.JSONValue); ok {
+		if raw, err := json.Marshal(v); err == nil {
+			return string(raw)
+		}
+	}
+	return fmt.Sprint(val)
 }
 
 // consume reads every row and shapes it into the payload expected for the
@@ -205,6 +230,14 @@ func readAsTimeSeries(rows driver.Rows, queryWindow *qbtypes.TimeRange, step qbt
 					Value: *val,
 				})
 
+			case *telemetrystoretypes.JSONValue, *chcol.Variant:
+				val := labelValue(derefValue(ptr))
+				lblVals = append(lblVals, val)
+				lblObjs = append(lblObjs, &qbtypes.Label{
+					Key:   telemetrytypes.TelemetryFieldKey{Name: name},
+					Value: val,
+				})
+
 			default:
 				continue
 			}
@@ -345,7 +378,7 @@ func readAsScalar(rows driver.Rows, queryName string) (*qbtypes.ScalarData, erro
 		// 2. deref each slot into the output row
 		row := make([]any, len(scan))
 		for i, cell := range scan {
-			row[i] = derefValue(cell)
+			row[i] = unwrapVariant(derefValue(cell))
 		}
 		data = append(data, row)
 	}
@@ -382,31 +415,13 @@ func readAsRaw(rows driver.Rows, queryName string) (*qbtypes.RawData, error) {
 	colTypes := rows.ColumnTypes()
 	colCnt := len(colNames)
 
-	// Helper that decides scan target per column based on DB type
-	makeScanTarget := func(i int) any {
-		dbt := strings.ToUpper(colTypes[i].DatabaseTypeName())
-		if strings.HasPrefix(dbt, "JSON") {
-			// Since the driver fails to decode JSON/Dynamic into native Go values, we read it as raw bytes
-			// TODO: check in future if fixed in the driver
-			var v []byte
-			return &v
-		}
-		return reflect.New(colTypes[i].ScanType()).Interface()
-	}
-
-	// Build a template slice of correctly-typed pointers once
-	scanTpl := make([]any, colCnt)
-	for i := range colTypes {
-		scanTpl[i] = makeScanTarget(i)
-	}
-
 	var outRows []*qbtypes.RawRow
 
 	for rows.Next() {
 		// fresh copy of the scan slice (otherwise the driver reuses pointers)
 		scan := make([]any, colCnt)
-		for i := range scanTpl {
-			scan[i] = makeScanTarget(i)
+		for i := range colTypes {
+			scan[i] = reflect.New(colTypes[i].ScanType()).Interface()
 		}
 
 		if err := rows.Scan(scan...); err != nil {
@@ -421,21 +436,7 @@ func readAsRaw(rows driver.Rows, queryName string) (*qbtypes.RawData, error) {
 			name := stripKeyAlias(colNames[i])
 
 			// de-reference the typed pointer to any
-			val := reflect.ValueOf(cellPtr).Elem().Interface()
-			// Post-process JSON columns: unmarshal bytes into map[string]any
-			if strings.HasPrefix(strings.ToUpper(colTypes[i].DatabaseTypeName()), "JSON") {
-				switch x := val.(type) {
-				case []byte:
-					var m map[string]any
-					err := sonic.Unmarshal(x, &m)
-					if err != nil {
-						return nil, errors.WrapInternalf(err, CodeFailUnmarshalJSONColumn, "failed to unmarshal JSON column %s", name)
-					}
-					val = m
-				default:
-					// already a structured type (map[string]any, []any, etc.)
-				}
-			}
+			val := unwrapVariant(reflect.ValueOf(cellPtr).Elem().Interface())
 
 			// special-case: timestamp column
 			if name == "timestamp" || name == "timestamp_datetime" {

--- a/pkg/querier/consume_test.go
+++ b/pkg/querier/consume_test.go
@@ -3,8 +3,16 @@ package querier
 import (
 	"reflect"
 	"testing"
+	"time"
 
+	"github.com/ClickHouse/clickhouse-go/v2/lib/chcol"
+	cmock "github.com/SigNoz/clickhouse-go-mock"
+	"github.com/SigNoz/signoz/pkg/telemetrystore"
+	qbtypes "github.com/SigNoz/signoz/pkg/types/querybuildertypes/querybuildertypesv5"
 	"github.com/SigNoz/signoz/pkg/types/spantypes"
+	"github.com/SigNoz/signoz/pkg/types/telemetrystoretypes"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestMergeSpanAttributeColumns_ParsesEventsAndLinks(t *testing.T) {
@@ -73,6 +81,103 @@ func TestMergeSpanAttributeColumns_ParsesEventsAndLinks(t *testing.T) {
 	if !reflect.DeepEqual(links, wantLinks) {
 		t.Fatalf("links parsed incorrectly:\n got:  %#v\nwant: %#v", links, wantLinks)
 	}
+}
+
+// A ClickHouse query can put a JSON column in the result of any request type — e.g.
+// `select * from signoz_logs.logs_v2` on a body_v2 stack, where `*` covers body_v2.
+func TestConsume_JSONColumn(t *testing.T) {
+	ts := time.Date(2026, 8, 14, 10, 0, 0, 0, time.UTC)
+	body := `{"level":"error","attrs":{"code":500}}`
+	wantBody := telemetrystoretypes.JSONValue{
+		"level": "error",
+		"attrs": map[string]any{"code": float64(500)},
+	}
+
+	// the scalar reader reuses its scan slots across rows, so each row must still carry its own body
+	t.Run("scalar", func(t *testing.T) {
+		rows := telemetrystore.WrapRows(cmock.NewRows([]cmock.ColumnType{
+			{Name: "body_v2", Type: "JSON"},
+			{Name: "__result_0", Type: "UInt64"},
+		}, [][]any{{body, uint64(3)}, {`{"level":"warn"}`, uint64(1)}}))
+
+		payload, err := consume(rows, qbtypes.RequestTypeScalar, nil, qbtypes.Step{}, "A")
+		require.NoError(t, err)
+
+		data := payload.(*qbtypes.ScalarData)
+		require.Len(t, data.Data, 2)
+		assert.Equal(t, wantBody, data.Data[0][0])
+		assert.Equal(t, uint64(3), data.Data[0][1])
+		assert.Equal(t, telemetrystoretypes.JSONValue{"level": "warn"}, data.Data[1][0])
+		assert.Equal(t, uint64(1), data.Data[1][1])
+	})
+
+	t.Run("time series", func(t *testing.T) {
+		rows := telemetrystore.WrapRows(cmock.NewRows([]cmock.ColumnType{
+			{Name: "ts", Type: "DateTime"},
+			{Name: "body_v2", Type: "JSON"},
+			{Name: "__result_0", Type: "UInt64"},
+		}, [][]any{{ts, body, uint64(3)}}))
+
+		payload, err := consume(rows, qbtypes.RequestTypeTimeSeries, nil, qbtypes.Step{}, "A")
+		require.NoError(t, err)
+
+		data := payload.(*qbtypes.TimeSeriesData)
+		require.Len(t, data.Aggregations, 1)
+		require.Len(t, data.Aggregations[0].Series, 1)
+		require.Len(t, data.Aggregations[0].Series[0].Values, 1)
+		assert.Equal(t, float64(3), data.Aggregations[0].Series[0].Values[0].Value)
+	})
+
+	// grouping by a JSON column is legal in ClickHouse, so each document has to label its own
+	// series rather than being dropped, which would merge every group into one
+	t.Run("time series grouped by the JSON column", func(t *testing.T) {
+		rows := telemetrystore.WrapRows(cmock.NewRows([]cmock.ColumnType{
+			{Name: "ts", Type: "DateTime"},
+			{Name: "body_v2", Type: "JSON"},
+			{Name: "__result_0", Type: "UInt64"},
+		}, [][]any{
+			{ts, `{"level":"error"}`, uint64(7)},
+			{ts, `{"level":"warn"}`, uint64(2)},
+		}))
+
+		payload, err := consume(rows, qbtypes.RequestTypeTimeSeries, nil, qbtypes.Step{}, "A")
+		require.NoError(t, err)
+
+		data := payload.(*qbtypes.TimeSeriesData)
+		require.Len(t, data.Aggregations, 1)
+		require.Len(t, data.Aggregations[0].Series, 2)
+
+		got := map[string]float64{}
+		for _, series := range data.Aggregations[0].Series {
+			require.Len(t, series.Labels, 1)
+			require.Len(t, series.Values, 1)
+			got[series.Labels[0].Value.(string)] = series.Values[0].Value
+		}
+		assert.Equal(t, map[string]float64{`{"level":"error"}`: 7, `{"level":"warn"}`: 2}, got)
+	})
+
+	t.Run("raw", func(t *testing.T) {
+		rows := telemetrystore.WrapRows(cmock.NewRows([]cmock.ColumnType{
+			{Name: "timestamp", Type: "DateTime"},
+			{Name: "body_v2", Type: "JSON"},
+		}, [][]any{{ts, body}}))
+
+		payload, err := consume(rows, qbtypes.RequestTypeRaw, nil, qbtypes.Step{}, "A")
+		require.NoError(t, err)
+
+		data := payload.(*qbtypes.RawData)
+		require.Len(t, data.Rows, 1)
+		assert.Equal(t, ts, data.Rows[0].Timestamp.UTC())
+		assert.Equal(t, wantBody, data.Rows[0].Data["body_v2"])
+	})
+}
+
+// A JSON path (e.g. `body_v2.level`) comes back as a Dynamic column, which the driver scans
+// into a chcol.Variant envelope rather than the value itself.
+func TestUnwrapVariant(t *testing.T) {
+	assert.Equal(t, "error", unwrapVariant(chcol.NewDynamicWithType("error", "String")))
+	assert.Nil(t, unwrapVariant(chcol.Dynamic{}))
+	assert.Equal(t, uint64(3), unwrapVariant(uint64(3)))
 }
 
 func TestMergeSpanAttributeColumns_EmptyEventsAndLinks(t *testing.T) {

--- a/pkg/querier/postprocess.go
+++ b/pkg/querier/postprocess.go
@@ -13,8 +13,8 @@ import (
 
 	"github.com/SigNoz/signoz/pkg/errors"
 	"github.com/SigNoz/signoz/pkg/flagger"
-	"github.com/SigNoz/signoz/pkg/types/featuretypes"
 	"github.com/SigNoz/signoz/pkg/querybuilder"
+	"github.com/SigNoz/signoz/pkg/types/featuretypes"
 	qbtypes "github.com/SigNoz/signoz/pkg/types/querybuildertypes/querybuildertypesv5"
 	"github.com/SigNoz/signoz/pkg/types/telemetrystoretypes"
 	"github.com/SigNoz/signoz/pkg/types/telemetrytypes"
@@ -73,8 +73,12 @@ func (q *querier) postProcessResults(ctx context.Context, orgID valuer.UUID, res
 		case qbtypes.QueryBuilderQuery[qbtypes.LogAggregation]:
 			if result, ok := typedResults[spec.Name]; ok {
 				result = postProcessBuilderQuery(q, result, spec, req)
-				result = q.postProcessLogBody(ctx, orgID, result, req)
+				result = q.postProcessLogBody(ctx, orgID, result)
 				typedResults[spec.Name] = result
+			}
+		case qbtypes.ClickHouseQuery:
+			if result, ok := typedResults[spec.Name]; ok {
+				typedResults[spec.Name] = q.postProcessLogBody(ctx, orgID, result)
 			}
 		case qbtypes.QueryBuilderQuery[qbtypes.MetricAggregation]:
 			if result, ok := typedResults[spec.Name]; ok {
@@ -1052,32 +1056,44 @@ func (q *querier) calculateFormulaStep(expression string, req *qbtypes.QueryRang
 	return result
 }
 
-// postProcessLogBody removes the "message" key from the body map when it is empty.
-// Only runs for raw list queries with the use_json_body feature enabled.
-func (q *querier) postProcessLogBody(ctx context.Context, orgID valuer.UUID, result *qbtypes.Result, req *qbtypes.QueryRangeRequest) *qbtypes.Result {
-	if req.RequestType != qbtypes.RequestTypeRaw {
-		return result
-	}
+// postProcessLogBody removes the empty "message" the typed body path materializes into every
+// document, wherever a decoded body lands in the payload — raw rows and scalar cells, under the
+// column's own name or the builder's `body` alias. Only runs with the use_json_body feature
+// enabled. A time-series label keeps the document verbatim: it is the group key.
+func (q *querier) postProcessLogBody(ctx context.Context, orgID valuer.UUID, result *qbtypes.Result) *qbtypes.Result {
 	if !q.fl.BooleanOrEmpty(ctx, flagger.FeatureUseJSONBody, featuretypes.NewFlaggerEvaluationContext(orgID)) {
 		return result
 	}
-	rawData, ok := result.Value.(*qbtypes.RawData)
-	if !ok {
-		return result
-	}
-	for _, row := range rawData.Rows {
-		bodyMap, ok := row.Data["body"].(telemetrystoretypes.JSONValue)
-		if !ok {
-			continue
+	switch data := result.Value.(type) {
+	case *qbtypes.RawData:
+		for _, row := range data.Rows {
+			for _, name := range []string{"body", "body_v2"} {
+				stripEmptyBodyMessage(row.Data[name])
+			}
 		}
-		if msg, exists := bodyMap["message"]; exists {
-			switch v := msg.(type) {
-			case string:
-				if v == "" {
-					delete(bodyMap, "message")
-				}
+	case *qbtypes.ScalarData:
+		for idx, column := range data.Columns {
+			if column.Name != "body" && column.Name != "body_v2" {
+				continue
+			}
+			for _, row := range data.Data {
+				stripEmptyBodyMessage(row[idx])
 			}
 		}
 	}
 	return result
+}
+
+// stripEmptyBodyMessage drops `message: ""` from a decoded body document: the message path is
+// typed String in the JSON column, so ClickHouse materializes it even for documents that never
+// carried one. Anything that is not a decoded document — the legacy string body, a NULL cell —
+// is legal under these names and left alone.
+func stripEmptyBodyMessage(val any) {
+	bodyMap, ok := val.(telemetrystoretypes.JSONValue)
+	if !ok {
+		return
+	}
+	if msg, ok := bodyMap["message"].(string); ok && msg == "" {
+		delete(bodyMap, "message")
+	}
 }

--- a/pkg/querier/postprocess.go
+++ b/pkg/querier/postprocess.go
@@ -16,6 +16,7 @@ import (
 	"github.com/SigNoz/signoz/pkg/types/featuretypes"
 	"github.com/SigNoz/signoz/pkg/querybuilder"
 	qbtypes "github.com/SigNoz/signoz/pkg/types/querybuildertypes/querybuildertypesv5"
+	"github.com/SigNoz/signoz/pkg/types/telemetrystoretypes"
 	"github.com/SigNoz/signoz/pkg/types/telemetrytypes"
 	"github.com/SigNoz/signoz/pkg/valuer"
 )
@@ -1065,7 +1066,7 @@ func (q *querier) postProcessLogBody(ctx context.Context, orgID valuer.UUID, res
 		return result
 	}
 	for _, row := range rawData.Rows {
-		bodyMap, ok := row.Data["body"].(map[string]any)
+		bodyMap, ok := row.Data["body"].(telemetrystoretypes.JSONValue)
 		if !ok {
 			continue
 		}

--- a/pkg/querier/querier_test.go
+++ b/pkg/querier/querier_test.go
@@ -189,6 +189,7 @@ func TestRunExecutesQueriesConcurrently(t *testing.T) {
 
 	q := &querier{
 		logger:               instrumentationtest.New().Logger(),
+		fl:                   flaggertest.New(t),
 		maxConcurrentQueries: numQueries,
 	}
 
@@ -236,6 +237,7 @@ func TestRunRespectsMaxConcurrentQueries(t *testing.T) {
 
 	q := &querier{
 		logger:               instrumentationtest.New().Logger(),
+		fl:                   flaggertest.New(t),
 		maxConcurrentQueries: limit,
 	}
 
@@ -273,6 +275,7 @@ func TestRunRespectsMaxConcurrentQueries(t *testing.T) {
 func TestRunQueryErrorCancelsSiblings(t *testing.T) {
 	q := &querier{
 		logger:               instrumentationtest.New().Logger(),
+		fl:                   flaggertest.New(t),
 		maxConcurrentQueries: 4,
 	}
 

--- a/pkg/telemetrystore/clickhousetelemetrystore/provider.go
+++ b/pkg/telemetrystore/clickhousetelemetrystore/provider.go
@@ -184,7 +184,7 @@ func (p *provider) Query(ctx context.Context, query string, args ...interface{})
 	}
 
 	return &rowsWithHooks{
-		Rows:    rows,
+		Rows:    telemetrystore.WrapRows(rows),
 		ctx:     ctx,
 		event:   event,
 		onClose: func() { telemetrystore.WrapAfterQuery(p.hooks, ctx, event) },

--- a/pkg/telemetrystore/rows.go
+++ b/pkg/telemetrystore/rows.go
@@ -1,0 +1,39 @@
+package telemetrystore
+
+import (
+	"reflect"
+	"strings"
+
+	"github.com/ClickHouse/clickhouse-go/v2/lib/driver"
+	"github.com/SigNoz/signoz/pkg/types/telemetrystoretypes"
+)
+
+// WrapRows reports JSONValue as the scan type of every JSON column. Nested JSON — Array(JSON),
+// Map(String, JSON) — is not covered.
+func WrapRows(rows driver.Rows) driver.Rows {
+	return &rowsWithJSONScanType{Rows: rows}
+}
+
+type rowsWithJSONScanType struct {
+	driver.Rows
+}
+
+func (r *rowsWithJSONScanType) ColumnTypes() []driver.ColumnType {
+	colTypes := r.Rows.ColumnTypes()
+	wrapped := make([]driver.ColumnType, len(colTypes))
+	for i, colType := range colTypes {
+		wrapped[i] = colType
+		if strings.HasPrefix(strings.ToUpper(colType.DatabaseTypeName()), "JSON") {
+			wrapped[i] = jsonColumnType{ColumnType: colType}
+		}
+	}
+	return wrapped
+}
+
+type jsonColumnType struct {
+	driver.ColumnType
+}
+
+func (jsonColumnType) ScanType() reflect.Type {
+	return reflect.TypeFor[telemetrystoretypes.JSONValue]()
+}

--- a/pkg/telemetrystore/telemetrystoretest/conn.go
+++ b/pkg/telemetrystore/telemetrystoretest/conn.go
@@ -1,0 +1,23 @@
+package telemetrystoretest
+
+import (
+	"context"
+
+	"github.com/ClickHouse/clickhouse-go/v2"
+	"github.com/ClickHouse/clickhouse-go/v2/lib/driver"
+	"github.com/SigNoz/signoz/pkg/telemetrystore"
+)
+
+// conn wraps rows the way the clickhouse provider does, so mocked JSON columns report the scan
+// type they do in production.
+type conn struct {
+	clickhouse.Conn
+}
+
+func (c conn) Query(ctx context.Context, query string, args ...any) (driver.Rows, error) {
+	rows, err := c.Conn.Query(ctx, query, args...)
+	if err != nil {
+		return nil, err
+	}
+	return telemetrystore.WrapRows(rows), nil
+}

--- a/pkg/telemetrystore/telemetrystoretest/provider.go
+++ b/pkg/telemetrystore/telemetrystoretest/provider.go
@@ -4,7 +4,6 @@ import (
 	"context"
 
 	"github.com/ClickHouse/clickhouse-go/v2"
-	"github.com/ClickHouse/clickhouse-go/v2/lib/driver"
 	"github.com/DATA-DOG/go-sqlmock"
 	cmock "github.com/SigNoz/clickhouse-go-mock"
 	"github.com/SigNoz/signoz/pkg/telemetrystore"
@@ -34,20 +33,6 @@ func New(_ telemetrystore.Config, matcher sqlmock.QueryMatcher) *Provider {
 // ClickhouseDB returns the mock Clickhouse connection.
 func (p *Provider) ClickhouseDB() clickhouse.Conn {
 	return conn{Conn: p.clickhouseDB.(clickhouse.Conn)}
-}
-
-// conn wraps rows the way the clickhouse provider does, so mocked JSON columns report the scan
-// type they do in production.
-type conn struct {
-	clickhouse.Conn
-}
-
-func (c conn) Query(ctx context.Context, query string, args ...any) (driver.Rows, error) {
-	rows, err := c.Conn.Query(ctx, query, args...)
-	if err != nil {
-		return nil, err
-	}
-	return telemetrystore.WrapRows(rows), nil
 }
 
 // Cluster returns the cluster name.

--- a/pkg/telemetrystore/telemetrystoretest/provider.go
+++ b/pkg/telemetrystore/telemetrystoretest/provider.go
@@ -4,6 +4,7 @@ import (
 	"context"
 
 	"github.com/ClickHouse/clickhouse-go/v2"
+	"github.com/ClickHouse/clickhouse-go/v2/lib/driver"
 	"github.com/DATA-DOG/go-sqlmock"
 	cmock "github.com/SigNoz/clickhouse-go-mock"
 	"github.com/SigNoz/signoz/pkg/telemetrystore"
@@ -32,7 +33,21 @@ func New(_ telemetrystore.Config, matcher sqlmock.QueryMatcher) *Provider {
 
 // ClickhouseDB returns the mock Clickhouse connection.
 func (p *Provider) ClickhouseDB() clickhouse.Conn {
-	return p.clickhouseDB.(clickhouse.Conn)
+	return conn{Conn: p.clickhouseDB.(clickhouse.Conn)}
+}
+
+// conn wraps rows the way the clickhouse provider does, so mocked JSON columns report the scan
+// type they do in production.
+type conn struct {
+	clickhouse.Conn
+}
+
+func (c conn) Query(ctx context.Context, query string, args ...any) (driver.Rows, error) {
+	rows, err := c.Conn.Query(ctx, query, args...)
+	if err != nil {
+		return nil, err
+	}
+	return telemetrystore.WrapRows(rows), nil
 }
 
 // Cluster returns the cluster name.

--- a/pkg/types/telemetrystoretypes/json.go
+++ b/pkg/types/telemetrystoretypes/json.go
@@ -1,0 +1,37 @@
+package telemetrystoretypes
+
+import (
+	"github.com/SigNoz/signoz/pkg/errors"
+	"github.com/bytedance/sonic"
+)
+
+var ErrCodeUnmarshalJSONColumn = errors.MustNewCode("fail_unmarshal_json_column")
+
+// JSONValue is the scan target for a ClickHouse JSON column: the connection sets
+// output_format_native_write_json_as_string, so the column arrives as a raw document rather than
+// the chcol.JSON the driver reports as its scan type.
+type JSONValue map[string]any
+
+// Scan decodes into a fresh map every time: a scan target is reused across rows, and unmarshalling
+// into the map already there would both keep its keys and hand every row the same map.
+func (v *JSONValue) Scan(src any) error {
+	var raw []byte
+	switch value := src.(type) {
+	case nil:
+		*v = nil
+		return nil
+	case string:
+		raw = []byte(value)
+	case []byte:
+		raw = value
+	default:
+		return errors.NewInternalf(ErrCodeUnmarshalJSONColumn, "cannot decode %T as a JSON column", src)
+	}
+
+	decoded := JSONValue{}
+	if err := sonic.Unmarshal(raw, &decoded); err != nil {
+		return errors.WrapInternalf(err, ErrCodeUnmarshalJSONColumn, "failed to unmarshal JSON column")
+	}
+	*v = decoded
+	return nil
+}

--- a/tests/integration/tests/querier_json_body/06_json_column_scan.py
+++ b/tests/integration/tests/querier_json_body/06_json_column_scan.py
@@ -1,0 +1,159 @@
+import json
+from collections.abc import Callable
+from datetime import UTC, datetime, timedelta
+from http import HTTPStatus
+
+from fixtures import querier, types
+from fixtures.auth import USER_ADMIN_EMAIL, USER_ADMIN_PASSWORD
+from fixtures.logs import Logs
+
+# A raw ClickHouse query is the one place a JSON column can land in a scalar or
+# time-series result: the builder only selects body_v2 in raw list queries.
+
+DOC_ERROR = {"level": "error", "attrs": {"code": 500}}
+DOC_WARN = {"level": "warn"}
+
+SERVICE = "json-column-scan"
+WHERE = f"resources_string['service.name'] = '{SERVICE}'"
+
+
+def test_clickhouse_scalar_with_json_column(
+    signoz: types.SigNoz,
+    create_user_admin: None,  # pylint: disable=unused-argument
+    get_token: Callable[[str, str], str],
+    insert_logs: Callable[[list[Logs]], None],
+) -> None:
+    """A scalar result carrying the body_v2 JSON column decodes it into an object."""
+    now = datetime.now(tz=UTC)
+    insert_logs(
+        [
+            Logs(
+                timestamp=now - timedelta(seconds=seconds),
+                resources={"service.name": SERVICE},
+                body_v2=json.dumps(doc, separators=(",", ":")),
+                body_promoted="",
+                severity_text="INFO",
+            )
+            for seconds, doc in [(3, DOC_ERROR), (2, DOC_ERROR), (1, DOC_WARN)]
+        ]
+    )
+    token = get_token(USER_ADMIN_EMAIL, USER_ADMIN_PASSWORD)
+    start_ms = int((now - timedelta(minutes=10)).timestamp() * 1000)
+    end_ms = int(now.timestamp() * 1000)
+
+    # `select *` picks up body_v2 without naming it
+    response = querier.make_query_request(
+        signoz,
+        token,
+        start_ms,
+        end_ms,
+        [
+            {
+                "type": "clickhouse_sql",
+                "spec": {
+                    "name": "A",
+                    "query": f"SELECT * FROM signoz_logs.distributed_logs_v2 WHERE {WHERE} ORDER BY timestamp LIMIT 1",
+                    "disabled": False,
+                },
+            }
+        ],
+        request_type=querier.RequestType.SCALAR,
+    )
+
+    assert response.status_code == HTTPStatus.OK, response.text
+    assert response.json()["status"] == "success"
+
+    columns = [column["name"] for column in querier.get_scalar_columns(response.json())]
+    rows = querier.get_scalar_table_data(response.json())
+    assert len(rows) == 1
+    assert rows[0][columns.index("body_v2")] == DOC_ERROR
+
+    # a JSON column is a legal GROUP BY key, so it can sit next to an aggregation
+    response = querier.make_query_request(
+        signoz,
+        token,
+        start_ms,
+        end_ms,
+        [
+            {
+                "type": "clickhouse_sql",
+                "spec": {
+                    "name": "A",
+                    "query": f"SELECT body_v2, count() AS __result_0 FROM signoz_logs.distributed_logs_v2 WHERE {WHERE} GROUP BY body_v2",
+                    "disabled": False,
+                },
+            }
+        ],
+        request_type=querier.RequestType.SCALAR,
+    )
+
+    assert response.status_code == HTTPStatus.OK, response.text
+    assert response.json()["status"] == "success"
+
+    rows = querier.get_scalar_table_data(response.json())
+    counts = {json.dumps(row[0], sort_keys=True): row[1] for row in rows}
+    assert counts == {
+        json.dumps(DOC_ERROR, sort_keys=True): 2,
+        json.dumps(DOC_WARN, sort_keys=True): 1,
+    }
+
+
+def test_clickhouse_time_series_grouped_by_json_column(
+    signoz: types.SigNoz,
+    create_user_admin: None,  # pylint: disable=unused-argument
+    get_token: Callable[[str, str], str],
+    insert_logs: Callable[[list[Logs]], None],
+) -> None:
+    """Grouping a graph by the JSON column labels each series with its document."""
+    now = datetime.now(tz=UTC)
+    insert_logs(
+        [
+            Logs(
+                timestamp=now - timedelta(seconds=seconds),
+                resources={"service.name": SERVICE},
+                body_v2=json.dumps(doc, separators=(",", ":")),
+                body_promoted="",
+                severity_text="INFO",
+            )
+            for seconds, doc in [(3, DOC_ERROR), (2, DOC_ERROR), (1, DOC_WARN)]
+        ]
+    )
+    token = get_token(USER_ADMIN_EMAIL, USER_ADMIN_PASSWORD)
+
+    response = querier.make_query_request(
+        signoz,
+        token,
+        int((now - timedelta(minutes=10)).timestamp() * 1000),
+        int(now.timestamp() * 1000),
+        [
+            {
+                "type": "clickhouse_sql",
+                "spec": {
+                    "name": "A",
+                    "query": (f"SELECT toStartOfInterval(fromUnixTimestamp64Nano(timestamp), INTERVAL 60 SECOND) AS ts, body_v2, count() AS __result_0 FROM signoz_logs.distributed_logs_v2 WHERE {WHERE} GROUP BY ts, body_v2"),
+                    "disabled": False,
+                },
+            }
+        ],
+        request_type=querier.RequestType.TIME_SERIES,
+    )
+
+    assert response.status_code == HTTPStatus.OK, response.text
+    assert response.json()["status"] == "success"
+
+    series = querier.get_all_series(response.json(), "A")
+    assert len(series) == 2
+
+    # One series per document, labelled with the document rendered with sorted keys. The label is
+    # the verbatim group key, so it keeps the `message: ""` the typed body path materializes into
+    # every document; points may split across minute buckets, so compare the per-series sum.
+    counts = {}
+    for single_series in series:
+        labels = single_series["labels"]
+        assert len(labels) == 1
+        assert labels[0]["key"]["name"] == "body_v2"
+        counts[labels[0]["value"]] = sum(point["value"] for point in single_series["values"])
+    assert counts == {
+        json.dumps(DOC_ERROR | {"message": ""}, sort_keys=True, separators=(",", ":")): 2,
+        json.dumps(DOC_WARN | {"message": ""}, sort_keys=True, separators=(",", ":")): 1,
+    }


### PR DESCRIPTION
#### Description

**What was broken:** on a stack using the new JSON log body, any query asking for a **table** (`scalar`) or a **graph** (`time_series`) failed with HTTP 500 if the result contained a JSON column. The logs list view worked fine, which is why this went unnoticed. The smallest way to hit it is a raw ClickHouse panel running `select * from signoz_logs.logs_v2`.

**Why it happened:** we ask ClickHouse to send JSON columns as plain text, but the driver reports that such a column needs a different Go type — so the reader prepared the wrong kind of container and the read failed. The driver only reports the correct type *after* the first row has been read, which is too late for code that sets up its containers up front. The original JSON work patched around this inside the logs-list reader only; the connection setting that causes it is global, so the other two readers stayed broken.

**The fix:** correct the reported type once, at the connection that sets that option, so every reader gets a container that works and receives a normal map. Concretely:

- `pkg/querier` no longer needs its own workaround — the three readers are back to ordinary code.
- The older v3/v4 read paths had the same bug and are fixed without any changes of their own.
- A JSON path value such as `body_v2.level` now comes back as `"error"` or `7` instead of a driver wrapper object.
- Grouping a graph by the whole JSON body used to collapse every group into a single unlabelled line; each document now labels its own series.

#### Issues closed by this PR

Fixes https://github.com/SigNoz/engineering-pod/issues/5911

#### Additional Information

Verified end to end against a local stack with 1,000,000 log rows and 200,002 distinct `trace_id`s:

| query | before | after |
| --- | --- | --- |
| table query over a JSON column | 500 | 200, body returned as an object |
| graph grouped by the JSON body | 500 | 200, 22 series, one per document |
| graph grouped by `trace_id` (200k groups) | 200 | 200, unchanged |

A follow-up PR stacked on this one reworks how the graph reader classifies columns — fixing boolean and small-integer columns in raw SQL panels and cutting the reader's allocations.

Known gaps, unchanged from `main` and out of scope here:

- Waterfall and flamegraph read rows into structs, which this fix does not cover. Moving span attributes to JSON will need the same type on those fields, and one helper there fails silently rather than erroring.
- Dashboard variable queries no longer crash on a JSON column but still reject it as an unsupported value type.
- A `Map(String, JSON)` column **panics inside the driver**, which can take the process down. Confirmed still unfixed on `clickhouse-go` main, and not yet reported upstream.
