### PR TITLE
fix(logs pipelines): default parse_from to body.message under JSON bodies

### DIFF
--- a/frontend/src/container/PipelinePage/PipelineListsView/AddNewProcessor/ProcessorForm.tsx
+++ b/frontend/src/container/PipelinePage/PipelineListsView/AddNewProcessor/ProcessorForm.tsx
@@ -2,14 +2,17 @@ import { useTranslation } from 'react-i18next';
 import { Input } from '@signozhq/ui/input';
 import { Switch } from '@signozhq/ui/switch';
 import { Form, Select, Space } from 'antd';
+import { FeatureKeys } from 'constants/features';
 import { ModalFooterTitle } from 'container/PipelinePage/styles';
+import { useAppContext } from 'providers/App/App';
 import { ProcessorData } from 'types/api/pipeline/def';
 
 import { formValidationRules } from '../config';
-import { processorFields, ProcessorFormField } from './config';
+import { ProcessorFormField } from './config';
 import CSVInput from './FormFields/CSVInput';
 import JsonFlattening from './FormFields/JsonFlattening';
 import { FormWrapper, PipelineIndexIcon, StyledSelect } from './styles';
+import { resolveProcessorFields } from './utils';
 
 import './styles.scss';
 
@@ -133,16 +136,23 @@ function ProcessorForm({
 	selectedProcessorData,
 	isAdd,
 }: ProcessorFormProps): JSX.Element {
+	const { featureFlags } = useAppContext();
+	const isBodyJsonEnabled =
+		featureFlags?.find((flag) => flag.name === FeatureKeys.USE_JSON_BODY)
+			?.active || false;
+
 	return (
 		<div className="processor-form-container">
-			{processorFields[processorType]?.map((fieldData: ProcessorFormField) => (
-				<ProcessorFieldInput
-					key={fieldData.name + String(fieldData.initialValue)}
-					fieldData={fieldData}
-					selectedProcessorData={selectedProcessorData}
-					isAdd={isAdd}
-				/>
-			))}
+			{resolveProcessorFields(processorType, isBodyJsonEnabled).map(
+				(fieldData: ProcessorFormField) => (
+					<ProcessorFieldInput
+						key={fieldData.name + String(fieldData.initialValue)}
+						fieldData={fieldData}
+						selectedProcessorData={selectedProcessorData}
+						isAdd={isAdd}
+					/>
+				),
+			)}
 		</div>
 	);
 }

--- a/frontend/src/container/PipelinePage/PipelineListsView/AddNewProcessor/utils.ts
+++ b/frontend/src/container/PipelinePage/PipelineListsView/AddNewProcessor/utils.ts
@@ -1,0 +1,24 @@
+import { processorFields, ProcessorFormField } from './config';
+
+const BODY_PARSE_FROM = 'body';
+const JSON_BODY_PARSE_FROM = 'body.message';
+
+// With use_json_body the collector normalizes every body into a map before user
+// operators run, so a parser pointed at `body` gets a map it cannot read and
+// silently extracts nothing. The log text lives at body.message.
+export function resolveProcessorFields(
+	processorType: string,
+	isBodyJsonEnabled: boolean,
+): Array<ProcessorFormField> {
+	const fields = processorFields[processorType] ?? [];
+
+	if (!isBodyJsonEnabled) {
+		return fields;
+	}
+
+	return fields.map((field) =>
+		field.name === 'parse_from' && field.initialValue === BODY_PARSE_FROM
+			? { ...field, initialValue: JSON_BODY_PARSE_FROM }
+			: field,
+	);
+}

--- a/frontend/src/container/PipelinePage/tests/processorFieldDefaults.test.ts
+++ b/frontend/src/container/PipelinePage/tests/processorFieldDefaults.test.ts
@@ -1,0 +1,45 @@
+import { processorFields } from '../PipelineListsView/AddNewProcessor/config';
+import { resolveProcessorFields } from '../PipelineListsView/AddNewProcessor/utils';
+
+const parseFromDefault = (
+	fields: ReturnType<typeof resolveProcessorFields>,
+): unknown => fields.find((field) => field.name === 'parse_from')?.initialValue;
+
+describe('resolveProcessorFields', () => {
+	it.each(['grok_parser', 'regex_parser', 'json_parser'])(
+		'defaults %s parse_from to body.message when use_json_body is on',
+		(processorType) => {
+			expect(parseFromDefault(resolveProcessorFields(processorType, true))).toBe(
+				'body.message',
+			);
+		},
+	);
+
+	it.each(['grok_parser', 'regex_parser', 'json_parser'])(
+		'keeps %s parse_from as body when use_json_body is off',
+		(processorType) => {
+			expect(parseFromDefault(resolveProcessorFields(processorType, false))).toBe(
+				'body',
+			);
+		},
+	);
+
+	it('leaves parse_from defaults that do not point at the body alone', () => {
+		expect(parseFromDefault(resolveProcessorFields('time_parser', true))).toBe(
+			'attributes.timestamp',
+		);
+		expect(
+			parseFromDefault(resolveProcessorFields('severity_parser', true)),
+		).toBe('attributes.logLevel');
+	});
+
+	it('does not mutate the shared config', () => {
+		resolveProcessorFields('grok_parser', true);
+
+		expect(parseFromDefault(processorFields.grok_parser)).toBe('body');
+	});
+
+	it('returns an empty list for an unknown processor type', () => {
+		expect(resolveProcessorFields('does_not_exist', true)).toStrictEqual([]);
+	});
+});


### PR DESCRIPTION
#### Description

- The processor form pre-fills `parse_from` with `body` for the grok, regex and json parsers (`initialValue: 'body'` in `AddNewProcessor/config.ts`).
- With `use_json_body` the collector prepends a `normalize` pipeline, so by the time user operators run the body is a map. A parser pointed at `body` gets a map it cannot parse and silently extracts nothing — the pipeline is broken by default, without the user ever touching the field.
- Resolve the default to `body.message` when the flag is on. Keying off `initialValue === 'body'` rather than a hardcoded processor list keeps `time_parser` (`attributes.timestamp`) and `severity_parser` (`attributes.logLevel`) untouched, and covers any future processor that defaults to the body.

#### Additional Information

- Saved processors are unaffected — edit mode calls `form.setFieldsValue(savedData)`, which overrides `initialValue`. This only changes what a newly added processor starts with, and only while the flag is on.
- The helper returns new objects rather than mutating the shared config; there is a test asserting `processorFields.grok_parser` still reads `body`.
- This does not help pipelines already saved with a bare `body`. Preview shows them making no change at all, with nothing explaining why — surfacing that is a follow-up.
- Filters have the same problem and are not addressed here: `body contains "x"` cannot match a map, and unlike a failing operator a skipped filter produces no collector log. `queryBuilderToExpr` already special-cases `body.<key>` for EXISTS; extending that to value comparisons is the separate fix.
