### PR TITLE
fix(querier): surface underlying ClickHouse error in builder query execution

### DIFF
--- a/pkg/querier/builder_query.go
+++ b/pkg/querier/builder_query.go
@@ -441,11 +441,12 @@ func (q *builderQuery[T]) executeWithContext(ctx context.Context, query string, 
 		}
 
 		if !errors.Is(err, context.Canceled) {
+			q.logger.ErrorContext(ctx, "failed to execute query", slog.String("query", query), slog.Any("args", args), errors.Attr(err))
 			return nil, errors.Newf(
 				errors.TypeInternal,
 				errors.CodeInternal,
 				"Something went wrong on our end. It's not you, it's us. Our team is notified about it. Reach out to support if issue persists.",
-			)
+			).WithAdditional(err.Error())
 		}
 
 		return nil, err

--- a/pkg/querier/querier_test.go
+++ b/pkg/querier/querier_test.go
@@ -2,6 +2,7 @@ package querier
 
 import (
 	"context"
+	"fmt"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -309,3 +310,64 @@ func TestRunQueryErrorCancelsSiblings(t *testing.T) {
 	require.ErrorContains(t, err, "query A failed")
 	assert.True(t, bCanceled.Load(), "query B should be canceled once query A fails")
 }
+
+func TestQueryRange_ClickHouseQueryErrorSurfacing(t *testing.T) {
+	// When ClickHouse returns an error during query execution,
+	// the returned internal error should contain the ClickHouse error message in its additionals.
+	providerSettings := instrumentationtest.New().ToProviderSettings()
+	metadataStore := telemetrytypestest.NewMockMetadataStore()
+	metadataStore.TypeMap["my_metric"] = metrictypes.SumType
+	metadataStore.TemporalityMap["my_metric"] = metrictypes.Cumulative
+
+	telemetryStore := telemetrystoretest.New(telemetrystore.Config{}, &queryMatcherAny{})
+	telemetryStore.Mock().
+		ExpectQuery("SELECT any").
+		WillReturnError(fmt.Errorf("code: 46, message: Function with name `histogramQuantile` does not exist"))
+
+	q := New(
+		providerSettings,
+		telemetryStore,
+		metadataStore,
+		nil, // prometheus
+		nil, // promV2
+		nil, // traceStmtBuilder
+		nil, // aiTraceStmtBuilder
+		nil, // logStmtBuilder
+		nil, // auditStmtBuilder
+		&mockMetricStmtBuilder{},
+		nil,                // meterStmtBuilder
+		nil,                // traceOperatorStmtBuilder
+		nil,                // bucketCache
+		flaggertest.New(t), // flagger
+		0,                  // logTraceIDWindowPadding
+		0,                  // maxConcurrentQueries
+	)
+
+	req := &qbtypes.QueryRangeRequest{
+		Start:       uint64(time.Now().Add(-5 * time.Minute).UnixMilli()),
+		End:         uint64(time.Now().UnixMilli()),
+		RequestType: qbtypes.RequestTypeTimeSeries,
+		CompositeQuery: qbtypes.CompositeQuery{
+			Queries: []qbtypes.QueryEnvelope{{
+				Type: qbtypes.QueryTypeBuilder,
+				Spec: qbtypes.QueryBuilderQuery[qbtypes.MetricAggregation]{
+					Name:         "A",
+					StepInterval: qbtypes.Step{Duration: time.Minute},
+					Aggregations: []qbtypes.MetricAggregation{
+						{
+							MetricName:       "my_metric",
+							TimeAggregation:  metrictypes.TimeAggregationRate,
+							SpaceAggregation: metrictypes.SpaceAggregationSum,
+						},
+					},
+					Signal: telemetrytypes.SignalMetrics,
+				},
+			}},
+		},
+	}
+
+	_, err := q.QueryRange(context.Background(), valuer.GenerateUUID(), req)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "histogramQuantile")
+}
+


### PR DESCRIPTION
### Summary
When ClickHouse queries fail in \uilderQuery.executeWithContext\ (for example, when a required user-defined function such as \histogramQuantile\ is missing in self-hosted environments), the error handling swallowed the original database error and returned a generic internal error message with empty error details.

This made it difficult for users and administrators to troubleshoot query execution failures from frontend dashboards and API responses.

### Changes
- In \pkg/querier/builder_query.go\, log query execution failures with query text, parameters, and error attributes using \q.logger.ErrorContext\.
- Enrich the returned internal error using \.WithAdditional(err.Error())\ to propagate the underlying database message to the API response.
- In \pkg/querier/querier_test.go\, add unit test \TestQueryRange_ClickHouseQueryErrorSurfacing\ verifying that ClickHouse errors are surfaced in query responses.

### Related Issue
Fixes #12532