### PR TITLE
Revert "fix(querier): use collector-stamped insert time for last_observed stats"

### DIFF
--- a/pkg/querier/collect.go
+++ b/pkg/querier/collect.go
@@ -23,11 +23,7 @@ func (q *querier) Collect(ctx context.Context, _ valuer.UUID) (map[string]any, e
 		traces           uint64
 		tracesLastSeenAt time.Time
 	)
-	tracesLastSeenExpr := "max(timestamp)"
-	if q.hasColumn(ctx, tracestelemetryschema.DBName, tracestelemetryschema.SpanIndexV3TableName, "inserted_at") {
-		tracesLastSeenExpr = "max(inserted_at)"
-	}
-	if err := q.telemetryStore.ClickhouseDB().QueryRow(ctx, fmt.Sprintf("SELECT COUNT(*), %s FROM %s", tracesLastSeenExpr, tracesTable)).Scan(&traces, &tracesLastSeenAt); err == nil {
+	if err := q.telemetryStore.ClickhouseDB().QueryRow(ctx, fmt.Sprintf("SELECT COUNT(*), max(timestamp) FROM %s", tracesTable)).Scan(&traces, &tracesLastSeenAt); err == nil {
 		stats["telemetry.traces.count"] = traces
 		if tracesLastSeenAt.Unix() != 0 {
 			stats["telemetry.traces.last_observed.time"] = tracesLastSeenAt.UTC()
@@ -41,11 +37,7 @@ func (q *querier) Collect(ctx context.Context, _ valuer.UUID) (map[string]any, e
 		logs           uint64
 		logsLastSeenAt time.Time
 	)
-	logsLastSeenExpr := "fromUnixTimestamp64Nano(max(timestamp))"
-	if q.hasColumn(ctx, logstelemetryschema.DBName, logstelemetryschema.LogsV2TableName, "inserted_at") {
-		logsLastSeenExpr = "max(inserted_at)"
-	}
-	if err := q.telemetryStore.ClickhouseDB().QueryRow(ctx, fmt.Sprintf("SELECT COUNT(*), %s FROM %s", logsLastSeenExpr, logsTable)).Scan(&logs, &logsLastSeenAt); err == nil {
+	if err := q.telemetryStore.ClickhouseDB().QueryRow(ctx, fmt.Sprintf("SELECT COUNT(*), fromUnixTimestamp64Nano(max(timestamp)) FROM %s", logsTable)).Scan(&logs, &logsLastSeenAt); err == nil {
 		stats["telemetry.logs.count"] = logs
 		if logsLastSeenAt.Unix() != 0 {
 			stats["telemetry.logs.last_observed.time"] = logsLastSeenAt.UTC()
@@ -59,11 +51,7 @@ func (q *querier) Collect(ctx context.Context, _ valuer.UUID) (map[string]any, e
 		metrics           uint64
 		metricsLastSeenAt time.Time
 	)
-	metricsLastSeenExpr := "toDateTime(max(unix_milli) / 1000)"
-	if q.hasColumn(ctx, metricstelemetryschema.DBName, metricstelemetryschema.SamplesV4TableName, "inserted_at_unix_milli") {
-		metricsLastSeenExpr = "fromUnixTimestamp64Milli(max(inserted_at_unix_milli))"
-	}
-	if err := q.telemetryStore.ClickhouseDB().QueryRow(ctx, fmt.Sprintf("SELECT COUNT(*), %s FROM %s", metricsLastSeenExpr, metricsTable)).Scan(&metrics, &metricsLastSeenAt); err == nil {
+	if err := q.telemetryStore.ClickhouseDB().QueryRow(ctx, fmt.Sprintf("SELECT COUNT(*), toDateTime(max(unix_milli) / 1000) FROM %s", metricsTable)).Scan(&metrics, &metricsLastSeenAt); err == nil {
 		stats["telemetry.metrics.count"] = metrics
 		if metricsLastSeenAt.Unix() != 0 {
 			stats["telemetry.metrics.last_observed.time"] = metricsLastSeenAt.UTC()
@@ -74,13 +62,4 @@ func (q *querier) Collect(ctx context.Context, _ valuer.UUID) (map[string]any, e
 	}
 
 	return stats, nil
-}
-
-func (q *querier) hasColumn(ctx context.Context, database, table, column string) bool {
-	var exists bool
-	if err := q.telemetryStore.ClickhouseDB().QueryRow(ctx, "SELECT hasColumnInTable(?, ?, ?)", database, table, column).Scan(&exists); err != nil {
-		q.logger.DebugContext(ctx, "failed to check column existence", errors.Attr(err))
-		return false
-	}
-	return exists
 }


### PR DESCRIPTION
Reverts SigNoz/signoz#12455 since the new column the PR was querying on is not indexed and leading to latency across deployments.

Part of https://github.com/SigNoz/engineering-pod/issues/5916