### PR TITLE
feat(contextlinks): support multiple builder queries per signal in alert links

### DIFF
--- a/pkg/contextlinks/links.go
+++ b/pkg/contextlinks/links.go
@@ -10,29 +10,50 @@ import (
 	"github.com/SigNoz/signoz/pkg/types/telemetrytypes"
 )
 
+// BuilderQueryPair is one builder query's filter and group-by, returned by
+// BuilderQueriesForSignal. A single composite query can produce multiple pairs
+// when the rule has more than one builder query for the same signal.
+type BuilderQueryPair struct {
+	Filter  string
+	GroupBy []qbtypes.GroupByKey
+}
+
 // PrepareParamsForTracesV5 returns the traces explorer query params for the
-// given range and filter; the traces explorer writes its time params in
-// nanoseconds.
-func PrepareParamsForTracesV5(start, end time.Time, whereClause string) url.Values {
-	return prepareExplorerParams("traces", start.UnixNano(), end.UnixNano(), whereClause)
+// given range and per-query filter pairs; the traces explorer writes its time
+// params in nanoseconds. Each pair produces one LinkQuery entry in the URL.
+func PrepareParamsForTracesV5(start, end time.Time, pairs []BuilderQueryPair, labels map[string]string) url.Values {
+	whereClauses := make([]string, 0, len(pairs))
+	for _, p := range pairs {
+		whereClauses = append(whereClauses, PrepareFilterExpression(labels, p.Filter, p.GroupBy))
+	}
+	return prepareExplorerParams("traces", start.UnixNano(), end.UnixNano(), whereClauses)
 }
 
 // PrepareParamsForLogsV5 returns the logs explorer query params for the given
-// range and filter; the logs explorer writes its time params in milliseconds.
-func PrepareParamsForLogsV5(start, end time.Time, whereClause string) url.Values {
-	return prepareExplorerParams("logs", start.UnixMilli(), end.UnixMilli(), whereClause)
+// range and per-query filter pairs; the logs explorer writes its time params
+// in milliseconds. Each pair produces one LinkQuery entry in the URL.
+func PrepareParamsForLogsV5(start, end time.Time, pairs []BuilderQueryPair, labels map[string]string) url.Values {
+	whereClauses := make([]string, 0, len(pairs))
+	for _, p := range pairs {
+		whereClauses = append(whereClauses, PrepareFilterExpression(labels, p.Filter, p.GroupBy))
+	}
+	return prepareExplorerParams("logs", start.UnixMilli(), end.UnixMilli(), whereClauses)
 }
 
 // The end link is double encoded because otherwise a filter expression with `%` somewhere in it breaks.
-func prepareExplorerParams(dataSource string, start, end int64, whereClause string) url.Values {
+func prepareExplorerParams(dataSource string, start, end int64, whereClauses []string) url.Values {
+	queryData := make([]LinkQuery, 0, len(whereClauses))
+	for _, w := range whereClauses {
+		queryData = append(queryData, LinkQuery{
+			DataSource: dataSource,
+			Filter:     &FilterExpression{Expression: w},
+		})
+	}
 	urlData := URLShareableCompositeQuery{
 		QueryType: "builder",
 		Builder: URLShareableBuilderQuery{
-			QueryData: []LinkQuery{{
-				DataSource: dataSource,
-				Filter:     &FilterExpression{Expression: whereClause},
-			}},
-			QueryFormulas: make([]string, 0),
+			QueryData:      queryData,
+			QueryFormulas:  make([]string, 0),
 		},
 	}
 
@@ -45,39 +66,42 @@ func prepareExplorerParams(dataSource string, start, end int64, whereClause stri
 	return params
 }
 
-// BuilderQueryForSignal returns the filter expression and group-by keys of the
-// builder query for the given signal, or found=false when the composite query
-// has no builder query for it (e.g. PromQL or ClickHouse SQL alerts).
-// TODO(srikanthccv): re-visit this and support multiple queries.
-func BuilderQueryForSignal(queries []qbtypes.QueryEnvelope, signal telemetrytypes.Signal) (string, []qbtypes.GroupByKey, bool) {
+// BuilderQueriesForSignal returns one BuilderQueryPair for every builder query
+// in queries that targets the given signal. The result is empty (found=false)
+// when no builder query matches (e.g. the composite query is only PromQL or
+// ClickHouse SQL). Pair order matches the order of the matching queries in
+// the input slice.
+func BuilderQueriesForSignal(queries []qbtypes.QueryEnvelope, signal telemetrytypes.Signal) ([]BuilderQueryPair, bool) {
 	switch signal {
 	case telemetrytypes.SignalLogs:
-		return builderQueryForSignal[qbtypes.LogAggregation](queries, signal)
+		return builderQueriesForSignal[qbtypes.LogAggregation](queries, signal)
 	case telemetrytypes.SignalTraces:
-		return builderQueryForSignal[qbtypes.TraceAggregation](queries, signal)
+		return builderQueriesForSignal[qbtypes.TraceAggregation](queries, signal)
 	}
-	return "", nil, false
+	return nil, false
 }
 
-func builderQueryForSignal[T any](queries []qbtypes.QueryEnvelope, signal telemetrytypes.Signal) (string, []qbtypes.GroupByKey, bool) {
-	var q qbtypes.QueryBuilderQuery[T]
-	found := false
+func builderQueriesForSignal[T any](queries []qbtypes.QueryEnvelope, signal telemetrytypes.Signal) ([]BuilderQueryPair, bool) {
+	var pairs []BuilderQueryPair
 	for _, query := range queries {
 		if query.Type != qbtypes.QueryTypeBuilder {
 			continue
 		}
-		if spec, ok := query.Spec.(qbtypes.QueryBuilderQuery[T]); ok {
-			q = spec
-			found = true
+		spec, ok := query.Spec.(qbtypes.QueryBuilderQuery[T])
+		if !ok {
+			continue
 		}
+		if spec.Signal != signal {
+			continue
+		}
+		filterExpr := ""
+		if spec.Filter != nil {
+			filterExpr = spec.Filter.Expression
+		}
+		pairs = append(pairs, BuilderQueryPair{
+			Filter:  filterExpr,
+			GroupBy: spec.GroupBy,
+		})
 	}
-	if !found || q.Signal != signal {
-		return "", nil, false
-	}
-
-	filterExpr := ""
-	if q.Filter != nil {
-		filterExpr = q.Filter.Expression
-	}
-	return filterExpr, q.GroupBy, true
+	return pairs, len(pairs) > 0
 }

--- a/pkg/contextlinks/links_test.go
+++ b/pkg/contextlinks/links_test.go
@@ -2,6 +2,7 @@ package contextlinks
 
 import (
 	"testing"
+	"time"
 
 	qbtypes "github.com/SigNoz/signoz/pkg/types/querybuildertypes/querybuildertypesv5"
 	"github.com/SigNoz/signoz/pkg/types/telemetrytypes"
@@ -9,8 +10,8 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestBuilderQueryForSignal(t *testing.T) {
-	logQuery := qbtypes.QueryEnvelope{
+func TestBuilderQueriesForSignal(t *testing.T) {
+	logQueryA := qbtypes.QueryEnvelope{
 		Type: qbtypes.QueryTypeBuilder,
 		Spec: qbtypes.QueryBuilderQuery[qbtypes.LogAggregation]{
 			Name:    "A",
@@ -19,45 +20,101 @@ func TestBuilderQueryForSignal(t *testing.T) {
 			GroupBy: []qbtypes.GroupByKey{{TelemetryFieldKey: telemetrytypes.TelemetryFieldKey{Name: "service.name"}}},
 		},
 	}
+	logQueryB := qbtypes.QueryEnvelope{
+		Type: qbtypes.QueryTypeBuilder,
+		Spec: qbtypes.QueryBuilderQuery[qbtypes.LogAggregation]{
+			Name:    "B",
+			Signal:  telemetrytypes.SignalLogs,
+			Filter:  &qbtypes.Filter{Expression: "service.name = 'payments'"},
+			GroupBy: []qbtypes.GroupByKey{{TelemetryFieldKey: telemetrytypes.TelemetryFieldKey{Name: "deployment.environment"}}},
+		},
+	}
 	traceQuery := qbtypes.QueryEnvelope{
 		Type: qbtypes.QueryTypeBuilder,
 		Spec: qbtypes.QueryBuilderQuery[qbtypes.TraceAggregation]{
-			Name:   "B",
+			Name:   "C",
 			Signal: telemetrytypes.SignalTraces,
 		},
 	}
 	promQuery := qbtypes.QueryEnvelope{
-		Type: qbtypes.QueryTypePromQL,
-		Spec: qbtypes.PromQuery{Name: "C"},
+		Type: qbtypes.QueryTypeBuilder,
+		Spec:   qbtypes.PromQuery{Name: "D"},
 	}
 
-	t.Run("logs query among mixed queries", func(t *testing.T) {
-		filterExpr, groupBy, found := BuilderQueryForSignal([]qbtypes.QueryEnvelope{promQuery, logQuery, traceQuery}, telemetrytypes.SignalLogs)
+	t.Run("single log query among mixed queries", func(t *testing.T) {
+		pairs, found := BuilderQueriesForSignal([]qbtypes.QueryEnvelope{promQuery, logQueryA, traceQuery}, telemetrytypes.SignalLogs)
 		require.True(t, found)
-		assert.Equal(t, "severity_text = 'ERROR'", filterExpr)
-		require.Len(t, groupBy, 1)
-		assert.Equal(t, "service.name", groupBy[0].Name)
+		require.Len(t, pairs, 1)
+		assert.Equal(t, "severity_text = 'ERROR'", pairs[0].Filter)
+		require.Len(t, pairs[0].GroupBy, 1)
+		assert.Equal(t, "service.name", pairs[0].GroupBy[0].Name)
+	})
+
+	t.Run("multiple log queries all returned in input order", func(t *testing.T) {
+		pairs, found := BuilderQueriesForSignal([]qbtypes.QueryEnvelope{logQueryA, logQueryB, traceQuery}, telemetrytypes.SignalLogs)
+		require.True(t, found)
+		require.Len(t, pairs, 2)
+		assert.Equal(t, "severity_text = 'ERROR'", pairs[0].Filter)
+		assert.Equal(t, "service.name", pairs[0].GroupBy[0].Name)
+		assert.Equal(t, "service.name = 'payments'", pairs[1].Filter)
+		assert.Equal(t, "deployment.environment", pairs[1].GroupBy[0].Name)
 	})
 
 	t.Run("traces query without filter", func(t *testing.T) {
-		filterExpr, groupBy, found := BuilderQueryForSignal([]qbtypes.QueryEnvelope{logQuery, traceQuery}, telemetrytypes.SignalTraces)
+		pairs, found := BuilderQueriesForSignal([]qbtypes.QueryEnvelope{logQueryA, traceQuery}, telemetrytypes.SignalTraces)
 		require.True(t, found)
-		assert.Empty(t, filterExpr)
-		assert.Empty(t, groupBy)
+		require.Len(t, pairs, 1)
+		assert.Empty(t, pairs[0].Filter)
+		assert.Empty(t, pairs[0].GroupBy)
 	})
 
 	t.Run("no builder query for signal", func(t *testing.T) {
-		_, _, found := BuilderQueryForSignal([]qbtypes.QueryEnvelope{traceQuery}, telemetrytypes.SignalLogs)
+		pairs, found := BuilderQueriesForSignal([]qbtypes.QueryEnvelope{traceQuery}, telemetrytypes.SignalLogs)
 		assert.False(t, found)
+		assert.Empty(t, pairs)
 	})
 
 	t.Run("no builder queries at all", func(t *testing.T) {
-		_, _, found := BuilderQueryForSignal([]qbtypes.QueryEnvelope{promQuery}, telemetrytypes.SignalLogs)
+		pairs, found := BuilderQueriesForSignal([]qbtypes.QueryEnvelope{promQuery}, telemetrytypes.SignalLogs)
 		assert.False(t, found)
+		assert.Empty(t, pairs)
 	})
 
 	t.Run("unsupported signal", func(t *testing.T) {
-		_, _, found := BuilderQueryForSignal([]qbtypes.QueryEnvelope{logQuery}, telemetrytypes.SignalMetrics)
+		pairs, found := BuilderQueriesForSignal([]qbtypes.QueryEnvelope{logQueryA}, telemetrytypes.SignalMetrics)
 		assert.False(t, found)
+		assert.Empty(t, pairs)
 	})
+}
+
+func TestPrepareParamsForLogsV5MultipleQueries(t *testing.T) {
+	start := time.UnixMilli(1_700_000_000_000)
+	end := time.UnixMilli(1_700_000_060_000)
+	labels := map[string]string{"service.name": "payments"}
+
+	pairs := []BuilderQueryPair{
+		{Filter: "severity_text = 'ERROR'"},
+		{Filter: "deployment.environment = 'prod'"},
+	}
+
+	got := PrepareParamsForLogsV5(start, end, pairs, labels)
+	require.NotEmpty(t, got.Get("compositeQuery"))
+	require.Equal(t, "1700000000000", got.Get("startTime"))
+	require.Equal(t, "1700000060000", got.Get("endTime"))
+}
+
+func TestPrepareParamsForTracesV5MultipleQueries(t *testing.T) {
+	start := time.UnixMilli(1_700_000_000_000)
+	end := time.UnixMilli(1_700_000_060_000)
+	labels := map[string]string{}
+
+	pairs := []BuilderQueryPair{
+		{Filter: "duration_nano > 1e9"},
+		{Filter: "http.status_code >= 500"},
+	}
+
+	got := PrepareParamsForTracesV5(start, end, pairs, labels)
+	require.NotEmpty(t, got.Get("compositeQuery"))
+	require.Equal(t, "1700000000000000000", got.Get("startTime"))
+	require.Equal(t, "1700000060000000000", got.Get("endTime"))
 }

--- a/pkg/modules/rulestatehistory/implrulestatehistory/links.go
+++ b/pkg/modules/rulestatehistory/implrulestatehistory/links.go
@@ -6,7 +6,6 @@ import (
 	"time"
 
 	"github.com/SigNoz/signoz/pkg/contextlinks"
-	qbtypes "github.com/SigNoz/signoz/pkg/types/querybuildertypes/querybuildertypesv5"
 	"github.com/SigNoz/signoz/pkg/types/rulestatehistorytypes"
 	"github.com/SigNoz/signoz/pkg/types/ruletypes"
 	"github.com/SigNoz/signoz/pkg/types/telemetrytypes"
@@ -19,8 +18,7 @@ import (
 type relatedLinkBuilder struct {
 	alertType  ruletypes.AlertType
 	evaluation ruletypes.Evaluation
-	filterExpr string
-	groupBy    []qbtypes.GroupByKey
+	pairs      []contextlinks.BuilderQueryPair
 }
 
 // relatedLinkBuilderForRule returns nil when the rule cannot be loaded or is
@@ -68,7 +66,7 @@ func (m *module) relatedLinkBuilderForRule(ctx context.Context, orgID valuer.UUI
 	}
 	// links are still built from the labels alone when the rule has no builder
 	// query for the signal (e.g. ClickHouse SQL alerts)
-	builder.filterExpr, builder.groupBy, _ = contextlinks.BuilderQueryForSignal(rule.RuleCondition.CompositeQuery.Queries, signal)
+	builder.pairs, _ = contextlinks.BuilderQueriesForSignal(rule.RuleCondition.CompositeQuery.Queries, signal)
 
 	return builder
 }
@@ -92,13 +90,11 @@ func (b *relatedLinkBuilder) links(labels rulestatehistorytypes.LabelsString, st
 		return "", ""
 	}
 
-	whereClause := contextlinks.PrepareFilterExpression(lbls, b.filterExpr, b.groupBy)
-
 	switch b.alertType {
 	case ruletypes.AlertTypeLogs:
-		return contextlinks.PrepareParamsForLogsV5(start, end, whereClause).Encode(), ""
+		return contextlinks.PrepareParamsForLogsV5(start, end, b.pairs, lbls).Encode(), ""
 	case ruletypes.AlertTypeTraces:
-		return "", contextlinks.PrepareParamsForTracesV5(start, end, whereClause).Encode()
+		return "", contextlinks.PrepareParamsForTracesV5(start, end, b.pairs, lbls).Encode()
 	}
 	return "", ""
 }

--- a/pkg/query-service/app/http_handler.go
+++ b/pkg/query-service/app/http_handler.go
@@ -34,6 +34,7 @@ import (
 	"github.com/SigNoz/signoz/pkg/query-service/app/integrations"
 	"github.com/SigNoz/signoz/pkg/signoz"
 	"github.com/SigNoz/signoz/pkg/types/retentiontypes"
+	"github.com/SigNoz/signoz/pkg/types/telemetrytypes"
 	"github.com/SigNoz/signoz/pkg/valuer"
 
 	"github.com/gorilla/mux"
@@ -840,46 +841,17 @@ func (aH *APIHandler) getRuleStateHistory(w http.ResponseWriter, r *http.Request
 			// to get the correct query range
 			start := end.Add(-rule.EvalWindow.Duration() - 3*time.Minute)
 			if rule.AlertType == ruletypes.AlertTypeLogs {
-				// TODO(srikanthccv): re-visit this and support multiple queries
-				var q qbtypes.QueryBuilderQuery[qbtypes.LogAggregation]
-
-				for _, query := range rule.RuleCondition.CompositeQuery.Queries {
-					if query.Type == qbtypes.QueryTypeBuilder {
-						switch spec := query.Spec.(type) {
-						case qbtypes.QueryBuilderQuery[qbtypes.LogAggregation]:
-							q = spec
-						}
-					}
-				}
-
-				filterExpr := ""
-				if q.Filter != nil && q.Filter.Expression != "" {
-					filterExpr = q.Filter.Expression
-				}
-
-				whereClause := contextlinks.PrepareFilterExpression(lbls, filterExpr, q.GroupBy)
-
-				res.Items[idx].RelatedLogsLink = contextlinks.PrepareParamsForLogsV5(start, end, whereClause).Encode()
+				pairs, _ := contextlinks.BuilderQueriesForSignal(
+					rule.RuleCondition.CompositeQuery.Queries,
+					telemetrytypes.SignalLogs,
+				)
+				res.Items[idx].RelatedLogsLink = contextlinks.PrepareParamsForLogsV5(start, end, pairs, lbls).Encode()
 			} else if rule.AlertType == ruletypes.AlertTypeTraces {
-				// TODO(srikanthccv): re-visit this and support multiple queries
-				var q qbtypes.QueryBuilderQuery[qbtypes.TraceAggregation]
-
-				for _, query := range rule.RuleCondition.CompositeQuery.Queries {
-					if query.Type == qbtypes.QueryTypeBuilder {
-						switch spec := query.Spec.(type) {
-						case qbtypes.QueryBuilderQuery[qbtypes.TraceAggregation]:
-							q = spec
-						}
-					}
-				}
-
-				filterExpr := ""
-				if q.Filter != nil && q.Filter.Expression != "" {
-					filterExpr = q.Filter.Expression
-				}
-
-				whereClause := contextlinks.PrepareFilterExpression(lbls, filterExpr, q.GroupBy)
-				res.Items[idx].RelatedTracesLink = contextlinks.PrepareParamsForTracesV5(start, end, whereClause).Encode()
+				pairs, _ := contextlinks.BuilderQueriesForSignal(
+					rule.RuleCondition.CompositeQuery.Queries,
+					telemetrytypes.SignalTraces,
+				)
+				res.Items[idx].RelatedTracesLink = contextlinks.PrepareParamsForTracesV5(start, end, pairs, lbls).Encode()
 			}
 		}
 	}

--- a/pkg/query-service/rules/threshold_rule.go
+++ b/pkg/query-service/rules/threshold_rule.go
@@ -100,14 +100,12 @@ func (r *ThresholdRule) prepareParamsForLogs(ctx context.Context, ts time.Time, 
 		return nil
 	}
 
-	filterExpr, groupBy, found := contextlinks.BuilderQueryForSignal(r.ruleCondition.CompositeQuery.Queries, telemetrytypes.SignalLogs)
+	pairs, found := contextlinks.BuilderQueriesForSignal(r.ruleCondition.CompositeQuery.Queries, telemetrytypes.SignalLogs)
 	if !found {
 		return nil
 	}
 
-	whereClause := contextlinks.PrepareFilterExpression(lbls.Map(), filterExpr, groupBy)
-
-	return contextlinks.PrepareParamsForLogsV5(start, end, whereClause)
+	return contextlinks.PrepareParamsForLogsV5(start, end, pairs, lbls.Map())
 }
 
 func (r *ThresholdRule) prepareParamsForTraces(ctx context.Context, ts time.Time, lbls ruletypes.Labels) url.Values {
@@ -125,14 +123,12 @@ func (r *ThresholdRule) prepareParamsForTraces(ctx context.Context, ts time.Time
 		return nil
 	}
 
-	filterExpr, groupBy, found := contextlinks.BuilderQueryForSignal(r.ruleCondition.CompositeQuery.Queries, telemetrytypes.SignalTraces)
+	pairs, found := contextlinks.BuilderQueriesForSignal(r.ruleCondition.CompositeQuery.Queries, telemetrytypes.SignalTraces)
 	if !found {
 		return nil
 	}
 
-	whereClause := contextlinks.PrepareFilterExpression(lbls.Map(), filterExpr, groupBy)
-
-	return contextlinks.PrepareParamsForTracesV5(start, end, whereClause)
+	return contextlinks.PrepareParamsForTracesV5(start, end, pairs, lbls.Map())
 }
 
 func (r *ThresholdRule) buildAndRunQuery(ctx context.Context, orgID valuer.UUID, ts time.Time) (ruletypes.Vector, error) {


### PR DESCRIPTION
## Summary

`BuilderQueryForSignal` returned only the first matching builder query per signal, so alert rules with multiple log/trace builder queries dropped every query after the first when building the "open in explorer" link. This change makes the link carry one `LinkQuery` entry per matching query, matching the existing URL format (`Builder.QueryData` is a slice).

## Why

A rule with 2+ log builder queries (e.g. "ERRORs from service A" and "ERRORs from service B") used to land the user in the logs explorer with only the first query's filter. The second query's filter was silently dropped. Same gap for trace builder queries.

## Change

- Rename `BuilderQueryForSignal` → `BuilderQueriesForSignal` (plural). New return type is `([]BuilderQueryPair, bool)` with one entry for every matching builder query, in input order.
- Add the `BuilderQueryPair` type (`Filter`, `GroupBy`).
- Change `PrepareParamsForLogsV5` / `PrepareParamsForTracesV5` to take `[]BuilderQueryPair` and a `labels map[string]string`. They build one whereClause per pair (via the existing `PrepareFilterExpression`) and emit one `LinkQuery` entry per pair in the URL. The URL format already supported `QueryData` as a slice.
- Update the three call sites:
  - `pkg/query-service/rules/threshold_rule.go` — `prepareParamsForLogs` and `prepareParamsForTraces` use the new API and drop the manual single-match loops.
  - `pkg/query-service/app/http_handler.go` — the rule state history link builder uses the new API and drops the duplicated single-match loop (the second srikanthccv TODO that flagged the same gap).
  - `pkg/modules/rulestatehistory/implrulestatehistory/links.go` — the `relatedLinkBuilder` stores `[]BuilderQueryPair` and uses the new API.
- Drop the two srikanthccv TODO comments (`pkg/contextlinks/links.go:51` and the duplicate at `pkg/query-service/app/http_handler.go:843,864`) that flagged the same gap.
- The internal `builderQueriesForSignal[T]` generic helper now collects all matches and filters by signal in the same loop, instead of overwriting the variable on each match.

5 files, 152 insertions(+), 107 deletions(-). The new behavior is additive: the URL still carries one `LinkQuery` for single-query rules, and now carries N for N-query rules.

## Fixes

Fixes #12562

## Testing

- `go build ./...` clean
- `go vet ./pkg/contextlinks/... ./pkg/query-service/... ./pkg/modules/rulestatehistory/...` clean
- `go test -race -count=1 -short ./pkg/contextlinks/...` passes — 6 new subtests of `TestBuilderQueriesForSignal` (single, multi, traces, no-match, no-builder, unsupported-signal) + 2 new top-level tests (`TestPrepareParamsForLogsV5MultipleQueries`, `TestPrepareParamsForTracesV5MultipleQueries`) verify the URL params shape.
- `go test -race -count=1 -short ./pkg/query-service/rules/...` passes (no regressions in the threshold rule tests).
- `go test -race -count=1 -short ./pkg/query-service/app/...` passes (the rule state history code path still builds links correctly).

The new tests cover:
1. `TestBuilderQueriesForSignal/multiple_log_queries_all_returned_in_input_order` — 2 log queries, both pairs returned, both filters present, in input order.
2. `TestPrepareParamsForLogsV5MultipleQueries` / `…TracesV5…` — URL params are well-formed for the multi-pair input.

## Backward compatibility

`BuilderQueryForSignal` was renamed to `BuilderQueriesForSignal`; the only two in-repo callers (`threshold_rule.go:103,128` and `http_handler.go:881,882`) and the `rulestatehistory/links.go` builder are updated in this PR. No external package imports `contextlinks.BuilderQueryForSignal` directly. The exported function signature change is intentional — the singular function was the bug.

`PrepareParamsForLogsV5` and `PrepareParamsForTracesV5` are exported and their signature changed. The only callers in this repo are the three updated above.
