### PR TITLE
fix(alertmanager): drop redundant compat.InitFromFlags(NoopFlags) per SyncServers iteration

### DIFF
--- a/pkg/alertmanager/service.go
+++ b/pkg/alertmanager/service.go
@@ -5,9 +5,6 @@ import (
 	"log/slog"
 	"sync"
 
-	"github.com/prometheus/alertmanager/featurecontrol"
-	"github.com/prometheus/alertmanager/matcher/compat"
-
 	"github.com/SigNoz/signoz/pkg/alertmanager/alertmanagerserver"
 	"github.com/SigNoz/signoz/pkg/alertmanager/nfmanager"
 	"github.com/SigNoz/signoz/pkg/errors"
@@ -68,7 +65,6 @@ func New(
 }
 
 func (service *Service) SyncServers(ctx context.Context) error {
-	compat.InitFromFlags(service.settings.Logger(), featurecontrol.NoopFlags{})
 	orgs, err := service.orgGetter.ListByOwnedKeyRange(ctx)
 	if err != nil {
 		return err


### PR DESCRIPTION
## Summary

`pkg/alertmanager/service.go` `Service.SyncServers` invoked `compat.InitFromFlags(service.settings.Logger(), featurecontrol.NoopFlags{})` on every iteration. The call is redundant in this codebase:

1. `pkg/alertmanager/alertmanagerserver/server.go:209` already constructs the pipeline builder at server creation with `featurecontrol.NoopFlags{}` — the same flag policy
2. Upstream `prometheus/alertmanager@m0.31.1/matcher/compat/parse.go:59` `compat.InitFromFlags(l, NoopFlags)` always falls into the `else` branch (UTF8 + `FallbackMatcherParser`/`FallbackMatchersParser`) producing identical closures on every call. The package globals (`isValidLabelName`, `parseMatcher`, `parseMatchers`) are stateless-reassigned to the same value each tick.

So with NoopFlags the call is operationally a no-op. The pair of unused imports flows from the removed call only.

Closes #12566

## Changes

- `pkg/alertmanager/service.go` — drop the `compat.InitFromFlags(...)` line and unused imports `prometheus/alertmanager/featurecontrol` and `prometheus/alertmanager/matcher/compat`
- Behaviour: preserved. The `compat` package globals stay at their UTF8-Fallback defaults for the process lifetime (which is what `InitFromFlags(NoopFlags)` would also produce).

## Verification

- `go build ./...` — clean
- `golangci-lint run ./pkg/alertmanager/...` — 0 issues
- `go test -race ./pkg/alertmanager/...` — passing (one pre-existing flake in `pkg/alertmanager/alertmanagernotify/email` reproduces on `c40ebb` main as well, not introduced by this commit)

## Risk

Strict cleanup. Matcher parsing in routes / silences uses the same Fallback matchers in both branches; tests pass on the reduced surface. No running state changes.

`grep -rnE "compat\\.InitFromFlags|featurecontrol\\." pkg/ ee/ cmd/` after the change shows only the pipeline-builder call sites in `pkg/alertmanager/alertmanagerserver/server.go` and `pipeline_builder.go` remain — no other production caller of `compat.InitFromFlags` was relying on the removed call.