### PR TITLE
docs: fix Postgres log exporter name

### DIFF
--- a/pkg/query-service/app/integrations/builtin_integrations/postgres/config/collect-logs.md
+++ b/pkg/query-service/app/integrations/builtin_integrations/postgres/config/collect-logs.md
@@ -81,7 +81,7 @@ service:
     logs/postgresql:
       receivers: [filelog/postgresql]
       processors: [batch]
-      exporters: [otlp/postgresql-logs]
+      exporters: [otlp/postgres-logs]
 ```
 
 #### Set Environment Variables


### PR DESCRIPTION
## Summary
- fix the Postgres log collection example so the logs pipeline references the exporter defined in the same config
- changes `otlp/postgresql-logs` to `otlp/postgres-logs`

## Testing
- ran `git diff --check`
- inspected the collector config snippet for matching exporter names