### PR TITLE
docs: fix contributing integration test link

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -79,4 +79,4 @@ Need assistance? Join our Slack community:
 - Set up your [development environment](docs/contributing/development.md)
 - Deploy and observe [SigNoz in action with OpenTelemetry Demo Application](docs/otel-demo-docs.md)
 - Explore the [SigNoz Community Advocate Program](ADVOCATE.md), which recognises contributors who support the community, share their expertise, and help shape SigNoz's future.
-- Write [integration tests](docs/contributing/go/integration.md)
+- Write [integration tests](docs/contributing/tests/integration.md)


### PR DESCRIPTION
## Summary
- fix the CONTRIBUTING.md link for integration test docs
- point to the existing `docs/contributing/tests/integration.md` file

## Testing
- `git diff --check`