### PR TITLE
fix(opamp): stop unexpected agent config shapes from panicking the parser

### DIFF
--- a/pkg/query-service/app/opamp/otelconfig/config_parser.go
+++ b/pkg/query-service/app/opamp/otelconfig/config_parser.go
@@ -17,12 +17,27 @@ func NewConfigParser(agentConf *confmap.Conf) ConfigParser {
 	}
 }
 
+// The config being read here is the agent's own reported config, so its shape
+// is whatever the collector had rather than anything validated on this side. A
+// key can be present and still hold the wrong type: `processors: batch` gives a
+// string where a list is expected, and a pipeline block written as a list gives
+// a slice where a map is expected. Both used to panic on the assertion. They
+// now degrade to the same empty value an absent key produces, which callers
+// already handle.
 func toMap(i interface{}) map[string]interface{} {
-	return i.(map[string]interface{})
+	m, ok := i.(map[string]interface{})
+	if !ok {
+		return emptyMap()
+	}
+	return m
 }
 
 func toList(i interface{}) []interface{} {
-	return i.([]interface{})
+	l, ok := i.([]interface{})
+	if !ok {
+		return emptyList()
+	}
+	return l
 }
 
 // sent when key is not found in config

--- a/pkg/query-service/app/opamp/otelconfig/config_parser_shape_test.go
+++ b/pkg/query-service/app/opamp/otelconfig/config_parser_shape_test.go
@@ -1,0 +1,79 @@
+package otelconfig
+
+import (
+	"testing"
+
+	"github.com/knadh/koanf/parsers/yaml"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/collector/confmap"
+)
+
+func parserFromYAML(t *testing.T, src string) ConfigParser {
+	t.Helper()
+	c, err := yaml.Parser().Unmarshal([]byte(src))
+	require.NoError(t, err)
+	return NewConfigParser(confmap.NewFromStringMap(c))
+}
+
+// The config read here is the agent's own reported config, so a key can be
+// present while holding a type the parser does not expect. Each of these used
+// to panic on a type assertion rather than degrading to the empty value that an
+// absent key already produces.
+func TestConfigParserWithUnexpectedShapes(t *testing.T) {
+	t.Run("processors is a scalar rather than a list", func(t *testing.T) {
+		cp := parserFromYAML(t, `
+service:
+  pipelines:
+    traces:
+      processors: batch
+`)
+		assert.Empty(t, cp.PipelineProcessors("traces"))
+	})
+
+	t.Run("pipelines is a list rather than a map", func(t *testing.T) {
+		cp := parserFromYAML(t, `
+service:
+  pipelines:
+    - traces
+`)
+		assert.Empty(t, cp.Pipelines("traces"))
+	})
+
+	t.Run("service is a scalar rather than a map", func(t *testing.T) {
+		cp := parserFromYAML(t, `
+service: none
+`)
+		assert.Empty(t, cp.Service())
+	})
+
+	t.Run("named pipeline is a scalar rather than a map", func(t *testing.T) {
+		cp := parserFromYAML(t, `
+service:
+  pipelines:
+    traces: batch
+`)
+		assert.Empty(t, cp.PipelineProcessors("traces"))
+	})
+}
+
+func TestConfigParserReadsWellFormedConfig(t *testing.T) {
+	cp := parserFromYAML(t, `
+service:
+  pipelines:
+    traces:
+      receivers:
+        - otlp
+      processors:
+        - batch
+        - signozspanmetrics
+      exporters:
+        - clickhousetraces
+`)
+
+	assert.Equal(t, []interface{}{"batch", "signozspanmetrics"}, cp.PipelineProcessors("traces"))
+	assert.Equal(t, []interface{}{"otlp"}, cp.PipelineReceivers("traces"))
+	assert.Equal(t, []interface{}{"clickhousetraces"}, cp.PipelineExporters("traces"))
+	assert.True(t, cp.CheckPipelineExists("traces"))
+	assert.False(t, cp.CheckPipelineExists("metrics"))
+}

--- a/pkg/query-service/app/opamp/pipeline_builder.go
+++ b/pkg/query-service/app/opamp/pipeline_builder.go
@@ -90,7 +90,13 @@ func checkDuplicates(pipeline []interface{}) bool {
 	exists := make(map[string]bool, len(pipeline))
 	slog.Debug("checking duplicate processors in the pipeline", "pipeline", pipeline)
 	for _, processor := range pipeline {
-		name := processor.(string)
+		// A pipeline entry is a processor name, but this list comes from the
+		// agent's own config, so an entry can be any YAML value. Anything that
+		// is not a name cannot collide with one.
+		name, ok := processor.(string)
+		if !ok {
+			continue
+		}
 		if _, ok := exists[name]; ok {
 			return true
 		}
@@ -120,7 +126,10 @@ func buildPipeline(signal Signal, current []interface{}) ([]interface{}, error) 
 	// create a reverse map of existing config processors and their position
 	existing := map[string]int{}
 	for i, p := range current {
-		name := p.(string)
+		name, ok := p.(string)
+		if !ok {
+			continue
+		}
 		existing[name] = i
 	}
 

--- a/pkg/query-service/app/opamp/pipeline_builder_test.go
+++ b/pkg/query-service/app/opamp/pipeline_builder_test.go
@@ -1,0 +1,38 @@
+package opamp
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// A pipeline's processor list comes from the agent's own config, so an entry is
+// not guaranteed to be a processor name. Indenting a processor's settings under
+// the pipeline list, rather than under the top level processors block, yields a
+// map here. That used to panic on the type assertion.
+func TestBuildPipelineIgnoresNonStringEntries(t *testing.T) {
+	current := []interface{}{
+		"signoztailsampler",
+		map[string]interface{}{"batch": map[string]interface{}{"timeout": "1s"}},
+		"batch",
+	}
+
+	merged, err := buildPipeline(Traces, current)
+	require.NoError(t, err)
+	assert.Contains(t, merged, "batch")
+	assert.Contains(t, merged, "signoztailsampler")
+}
+
+func TestCheckDuplicatesIgnoresNonStringEntries(t *testing.T) {
+	nonName := map[string]interface{}{"batch": map[string]interface{}{"timeout": "1s"}}
+
+	// Two entries that are not names are not duplicate processor names.
+	assert.False(t, checkDuplicates([]interface{}{nonName, nonName}))
+
+	// Real duplicates are still reported, and a non-string alongside them does
+	// not hide them.
+	assert.True(t, checkDuplicates([]interface{}{"batch", nonName, "batch"}))
+
+	assert.False(t, checkDuplicates([]interface{}{"batch", "signoztailsampler"}))
+}


### PR DESCRIPTION
## What happens

`addIngestionControlToAgent` parses `agent.Config`, the collector config the agent itself reported, and hands it to `ConfigParser`. A YAML parse error is handled, but the resulting *shape* is not checked, and the parser asserts types outright:

```go
func toMap(i interface{}) map[string]interface{} { return i.(map[string]interface{}) }
func toList(i interface{}) []interface{}         { return i.([]interface{}) }
```

`buildPipeline` and `checkDuplicates` then assert every pipeline entry is a processor name:

```go
for i, p := range current {
    name := p.(string)
    existing[name] = i
}
```

So a key that is present but holds an unexpected type panics rather than being reported. Four shapes reach a panic, all ordinary YAML mistakes rather than anything exotic:

| config | panic |
|---|---|
| `service: none` | `interface {} is string, not map[string]interface {}` |
| `service.pipelines: [traces]` | `interface {} is []interface {}, not map[string]interface {}` |
| `processors: batch` | `interface {} is string, not []interface {}` |
| `processors: [{batch: {timeout: 1s}}]` | `interface {} is map[string]interface {}, not string` |

The last one is the easiest to hit by accident. It is a processor's settings indented under the pipeline list instead of under the top level `processors` block:

```yaml
service:
  pipelines:
    traces:
      processors:
        - batch:
            timeout: 1s
```

## Scope, since I would rather not overstate it

This is reached from `UpsertControlProcessors`, so in practice it is the sampling and filter config paths rather than the OpAMP message handler. Those run inside HTTP handlers, and `pkg/http/middleware/recovery.go` recovers, so the process does not go down. The visible effect is that the request fails with the generic "An unexpected error occurred" and the operator gets no indication that the problem is the agent's own config, which is not somewhere the config is even being edited at the time. I did not find a path where this escapes the recovery middleware, and I would not describe it as a crash.

## The change

`toMap` and `toList` fall back to the empty value an absent key already produces, which is what every caller in this file already handles via `emptyMap()` and `emptyList()`. That is one place and it covers the first three rows. The two pipeline loops skip entries that are not names, covering the fourth. Well formed configs take exactly the same path as before.

I kept it to degrading rather than returning an error because these helpers have no error return and threading one through `Service`, `Pipelines`, `PipelineComponent` and their callers would be a much larger and more invasive change. Happy to do it that way instead if you would rather the operator see an explicit "agent config is malformed" error, which is arguably the better behaviour. I just did not want to make that call unilaterally in a first PR.

## Testing

`TestConfigParserWithUnexpectedShapes` covers the three parser shapes, `TestBuildPipelineIgnoresNonStringEntries` and `TestCheckDuplicatesIgnoresNonStringEntries` cover the pipeline entries, and `TestConfigParserReadsWellFormedConfig` pins the normal path so the fallback cannot quietly swallow a valid config. They fail on unpatched `main`:

```
--- FAIL: TestBuildPipelineIgnoresNonStringEntries
panic: interface conversion: interface {} is map[string]interface {}, not string [recovered, repanicked]

--- FAIL: TestConfigParserWithUnexpectedShapes/processors_is_a_scalar_rather_than_a_list
panic: interface conversion: interface {} is string, not []interface {} [recovered, repanicked]
```

and pass with the change. The existing `TestServiceConfig` is untouched and still passes. `gofmt` and `go vet ./pkg/query-service/app/opamp/...` are clean.

New tests are in a separate `config_parser_shape_test.go` rather than appended to `config_parser_test.go`, so the existing file is unchanged. Say the word if you would rather have them merged into one.
