### PR TITLE
fix(alerts): disable Query Builder tab for Exceptions-based alerts

### DIFF
--- a/frontend/src/container/FormAlertRules/QuerySection.tsx
+++ b/frontend/src/container/FormAlertRules/QuerySection.tsx
@@ -31,6 +31,9 @@ const ANOMALY_QUERY_SUPPORT_CLICKHOUSE_ISSUE =
 const ANOMALY_QUERY_SUPPORT_PROMQL_ISSUE =
 	'https://github.com/SigNoz/signoz/issues/11036';
 
+const EXCEPTIONS_QUERY_BUILDER_UNSUPPORTED_ISSUE =
+	'https://github.com/SigNoz/signoz/issues/4914';
+
 function QuerySection({
 	queryCategory,
 	setQueryCategory,
@@ -86,9 +89,9 @@ function QuerySection({
 		/>
 	);
 
-	const anomalyDisabledTooltip = (url: string): JSX.Element => (
+	const disabledTooltip = (message: string, url: string): JSX.Element => (
 		<span>
-			Coming soon for anomaly detection.{' '}
+			{message}{' '}
 			<Typography.Link
 				href={url}
 				target="_blank"
@@ -100,6 +103,15 @@ function QuerySection({
 			to help us prioritize!
 		</span>
 	);
+
+	const anomalyDisabledTooltip = (url: string): JSX.Element =>
+		disabledTooltip('Coming soon for anomaly detection.', url);
+
+	const exceptionsDisabledTooltip = (url: string): JSX.Element =>
+		disabledTooltip(
+			"Query Builder isn't supported for Exceptions-based alerts yet.",
+			url,
+		);
 
 	const tabs = [
 		{
@@ -139,6 +151,50 @@ function QuerySection({
 			setCurrentTab(EQueryType.QUERY_BUILDER);
 		}
 	}, [isAnomalyDetection, queryCategory, setQueryCategory]);
+
+	// Query Builder isn't backend-supported for Exceptions-based alerts today
+	// (it queries DataSource.TRACES instead of the exceptions index). Force
+	// ClickHouse for this alert type, including for pre-existing rules that
+	// were saved with Query Builder selected before this restriction existed.
+	useEffect(() => {
+		if (
+			alertType === AlertTypes.EXCEPTIONS_BASED_ALERT &&
+			queryCategory !== EQueryType.CLICKHOUSE
+		) {
+			setQueryCategory(EQueryType.CLICKHOUSE);
+			setCurrentTab(EQueryType.CLICKHOUSE);
+		}
+	}, [alertType, queryCategory, setQueryCategory]);
+
+	const exceptionsTabs = [
+		{
+			label: (
+				<Tooltip
+					title={exceptionsDisabledTooltip(
+						EXCEPTIONS_QUERY_BUILDER_UNSUPPORTED_ISSUE,
+					)}
+				>
+					<Button className="nav-btns" disabled>
+						<Atom size={14} />
+						<Typography.Text>Query Builder</Typography.Text>
+					</Button>
+				</Tooltip>
+			),
+			key: EQueryType.QUERY_BUILDER,
+			disabled: true,
+		},
+		{
+			label: (
+				<Tooltip title="ClickHouse">
+					<Button className="nav-btns">
+						<Terminal size={14} />
+						<Typography.Text>ClickHouse Query</Typography.Text>
+					</Button>
+				</Tooltip>
+			),
+			key: EQueryType.CLICKHOUSE,
+		},
+	];
 
 	const items = useMemo(
 		() => [
@@ -208,9 +264,38 @@ function QuerySection({
 
 	const renderTabs = (typ: AlertTypes): JSX.Element | null => {
 		switch (typ) {
+			case AlertTypes.EXCEPTIONS_BASED_ALERT:
+				return (
+					<div className="alert-tabs">
+						<Tabs
+							type="card"
+							style={{ width: '100%', padding: '0px 8px' }}
+							defaultActiveKey={currentTab}
+							activeKey={currentTab}
+							onChange={handleQueryCategoryChange}
+							tabBarExtraContent={
+								<span style={{ display: 'flex', gap: '1rem', alignItems: 'center' }}>
+									<RunQueryBtn
+										onStageRunQuery={(): void => {
+											runQuery();
+											logEvent('Alert: Stage and run query', {
+												dataSource: ALERTS_DATA_SOURCE_MAP[alertType],
+												isNewRule: !ruleId || isEmpty(ruleId),
+												ruleId,
+												queryType: queryCategory,
+											});
+										}}
+										handleCancelQuery={handleCancelQuery}
+										isLoadingQueries={isLoadingQueries}
+									/>
+								</span>
+							}
+							items={exceptionsTabs}
+						/>
+					</div>
+				);
 			case AlertTypes.TRACES_BASED_ALERT:
 			case AlertTypes.LOGS_BASED_ALERT:
-			case AlertTypes.EXCEPTIONS_BASED_ALERT:
 				return (
 					<div className="alert-tabs">
 						<Tabs

--- a/frontend/src/container/FormAlertRules/__tests__/QuerySection.test.tsx
+++ b/frontend/src/container/FormAlertRules/__tests__/QuerySection.test.tsx
@@ -1,0 +1,150 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { PANEL_TYPES } from 'constants/queryBuilder';
+import { AlertTypes } from 'types/api/alerts/alertTypes';
+import { AlertDef } from 'types/api/alerts/def';
+import { EQueryType } from 'types/common/dashboard';
+
+import QuerySection from '../QuerySection';
+
+jest.mock('components/QueryBuilderV2/QueryBuilderV2', () => ({
+	QueryBuilderV2: function MockQueryBuilderV2(): JSX.Element {
+		return <div data-testid="query-builder-v2-mock">Query Builder V2</div>;
+	},
+}));
+
+jest.mock(
+	'../ChQuerySection',
+	() =>
+		function MockChQuerySection(): JSX.Element {
+			return <div data-testid="ch-query-section-mock">ClickHouse Query</div>;
+		},
+);
+
+jest.mock(
+	'../PromqlSection',
+	() =>
+		function MockPromqlSection(): JSX.Element {
+			return <div data-testid="promql-section-mock">PromQL</div>;
+		},
+);
+
+jest.mock(
+	'container/QueryBuilder/components/RunQueryBtn/RunQueryBtn',
+	() =>
+		function MockRunQueryBtn(): JSX.Element {
+			return <button type="button">Run Query</button>;
+		},
+);
+
+jest.mock('hooks/useDarkMode', () => ({
+	useIsDarkMode: (): boolean => false,
+}));
+
+jest.mock('api/common/logEvent', () => jest.fn());
+
+const baseAlertDef: AlertDef = {
+	alert: 'test-alert',
+	condition: { compositeQuery: {} as never },
+	version: 'v4',
+};
+
+interface RenderQuerySectionOverrides {
+	alertType?: AlertTypes;
+	queryCategory?: EQueryType;
+	setQueryCategory?: jest.Mock;
+}
+
+const renderQuerySection = ({
+	alertType = AlertTypes.METRICS_BASED_ALERT,
+	queryCategory = EQueryType.QUERY_BUILDER,
+	setQueryCategory = jest.fn(),
+}: RenderQuerySectionOverrides = {}): ReturnType<typeof render> =>
+	render(
+		<QuerySection
+			queryCategory={queryCategory}
+			setQueryCategory={setQueryCategory}
+			alertType={alertType}
+			runQuery={jest.fn()}
+			isLoadingQueries={false}
+			handleCancelQuery={jest.fn()}
+			alertDef={baseAlertDef}
+			panelType={PANEL_TYPES.TIME_SERIES}
+			ruleId=""
+		/>,
+	);
+
+describe('FormAlertRules QuerySection', () => {
+	// Regression coverage for https://github.com/SigNoz/signoz/issues/4914 —
+	// Query Builder isn't backend-supported for Exceptions-based alerts (it
+	// queries DataSource.TRACES instead of the exceptions index), so it must
+	// stay disabled and any pre-existing rule stuck on it must be migrated
+	// over to ClickHouse.
+
+	it('disables the Query Builder tab for Exceptions-based alerts, and keeps ClickHouse enabled', () => {
+		renderQuerySection({
+			alertType: AlertTypes.EXCEPTIONS_BASED_ALERT,
+			queryCategory: EQueryType.CLICKHOUSE,
+		});
+
+		const queryBuilderButton = screen.getByRole('button', {
+			name: /query builder/i,
+		});
+		const clickHouseButton = screen.getByRole('button', {
+			name: /clickhouse query/i,
+		});
+
+		expect(queryBuilderButton).toBeDisabled();
+		expect(clickHouseButton).not.toBeDisabled();
+	});
+
+	it('does not switch tabs when the disabled Query Builder tab is clicked for an Exceptions alert', async () => {
+		const setQueryCategory = jest.fn();
+		renderQuerySection({
+			alertType: AlertTypes.EXCEPTIONS_BASED_ALERT,
+			queryCategory: EQueryType.CLICKHOUSE,
+			setQueryCategory,
+		});
+
+		const queryBuilderButton = screen.getByRole('button', {
+			name: /query builder/i,
+		});
+
+		await userEvent.click(queryBuilderButton);
+
+		expect(setQueryCategory).not.toHaveBeenCalledWith(EQueryType.QUERY_BUILDER);
+		expect(screen.getByTestId('ch-query-section-mock')).toBeInTheDocument();
+	});
+
+	it('leaves both tabs enabled for Traces-based alerts (unaffected by the Exceptions restriction)', () => {
+		renderQuerySection({
+			alertType: AlertTypes.TRACES_BASED_ALERT,
+			queryCategory: EQueryType.QUERY_BUILDER,
+		});
+
+		const queryBuilderButton = screen.getByRole('button', {
+			name: /query builder/i,
+		});
+		const clickHouseButton = screen.getByRole('button', {
+			name: /clickhouse query/i,
+		});
+
+		expect(queryBuilderButton).not.toBeDisabled();
+		expect(clickHouseButton).not.toBeDisabled();
+	});
+
+	it('migrates a rule previously saved with Query Builder over to ClickHouse when the alert type is Exceptions', async () => {
+		const setQueryCategory = jest.fn();
+		renderQuerySection({
+			alertType: AlertTypes.EXCEPTIONS_BASED_ALERT,
+			queryCategory: EQueryType.QUERY_BUILDER,
+			setQueryCategory,
+		});
+
+		expect(setQueryCategory).toHaveBeenCalledWith(EQueryType.CLICKHOUSE);
+		await expect(
+			screen.findByTestId('ch-query-section-mock'),
+		).resolves.toBeInTheDocument();
+		expect(screen.queryByTestId('query-builder-v2-mock')).not.toBeInTheDocument();
+	});
+});


### PR DESCRIPTION
Fixes #4914

## Problem
Exceptions-based alerts let you freely pick between "Query Builder" and
"ClickHouse Query" for defining the alert condition, with no restriction.
Query Builder isn't backend-supported for this alert type: it queries
`DataSource.TRACES` (the generic traces dataset) rather than the actual
exceptions index. A user can build and save a Query-Builder-based
Exceptions alert that looks correct and saves without error, and it will
just silently never detect what they think it's detecting.

## Fix
`FormAlertRules/QuerySection.tsx`'s `renderTabs()` now gives
`EXCEPTIONS_BASED_ALERT` its own case with a Query Builder tab that's
disabled (with an explanatory tooltip), following the same pattern
already used for `isAnomalyDetection`. ClickHouse Query — whose default
template already correctly targets the exceptions index — remains the
only usable option.

A rule that was already saved with Query Builder selected (from before
this fix) is automatically migrated to ClickHouse on load, instead of
staying stuck in the broken state.

## Testing
Added `FormAlertRules/__tests__/QuerySection.test.tsx`:
- Query Builder tab is disabled, ClickHouse stays enabled, for Exceptions alerts
- clicking the disabled tab is a no-op
- Traces-based alerts are unaffected (control case)
- a rule previously saved with Query Builder auto-migrates to ClickHouse

`pnpm lint`, `pnpm tsc --noEmit`, and `pnpm test QuerySection` all pass.

## Screenshots
<!-- attach before/after screenshots of the disabled tab + tooltip here -->
<img width="1289" height="656" alt="Screenshot 2026-08-16 at 4 04 52 AM" src="https://github.com/user-attachments/assets/1bb6d38d-bb87-4db3-8d12-34bb10308a5d" />
