### PR TITLE
fix: prevent stale log pages from being dropped

### DIFF
--- a/frontend/src/hooks/__tests__/useLogsData.test.tsx
+++ b/frontend/src/hooks/__tests__/useLogsData.test.tsx
@@ -1,11 +1,52 @@
-import { renderHook } from '@testing-library/react';
+import { act, renderHook } from '@testing-library/react';
 import { PANEL_TYPES } from 'constants/queryBuilder';
 import { AllTheProviders } from 'tests/test-utils';
 import { Query } from 'types/api/queryBuilder/queryBuilderData';
+import { ListItem, QueryDataV3 } from 'types/api/widgets/getQuery';
 
+import { useGetExplorerQueryRange } from '../queryBuilder/useGetExplorerQueryRange';
 import { useLogsData } from '../useLogsData';
 
+jest.mock('../queryBuilder/useGetExplorerQueryRange', () => ({
+	useGetExplorerQueryRange: jest.fn(),
+}));
+
+const mockedUseGetExplorerQueryRange = jest.mocked(useGetExplorerQueryRange);
+
+const createLogResult = (id: string): QueryDataV3[] => [
+	{
+		list: [
+			{
+				timestamp: id,
+				data: { id } as ListItem['data'],
+			},
+		],
+		queryName: 'A',
+		series: null,
+	},
+];
+
+const createPageResponse = (id: string) => ({
+	payload: {
+		data: {
+			newResult: {
+				data: {
+					result: createLogResult(id),
+					resultType: 'matrix',
+				},
+			},
+		},
+	},
+});
+
 describe('useLogsData', () => {
+	beforeEach(() => {
+		mockedUseGetExplorerQueryRange.mockReturnValue({
+			data: undefined,
+			isFetching: false,
+		} as ReturnType<typeof useGetExplorerQueryRange>);
+	});
+
 	// Public dashboards redact the widget query (orderBy/filter/limit stripped),
 	// so a LIST query can arrive with no orderBy — the hook must not crash on it.
 	it('does not crash when the query has no orderBy', () => {
@@ -26,5 +67,54 @@ describe('useLogsData', () => {
 		);
 
 		expect(result.current.logs).toStrictEqual([]);
+	});
+
+	it('appends fetched log pages', async () => {
+		let response: ReturnType<typeof createPageResponse> | undefined;
+		mockedUseGetExplorerQueryRange.mockImplementation(
+			() =>
+				({
+					data: response,
+					isFetching: false,
+				} as ReturnType<typeof useGetExplorerQueryRange>),
+		);
+
+		const stagedQuery = {
+			builder: {
+				queryData: [{ dataSource: 'logs', queryName: 'A', disabled: false }],
+			},
+		} as unknown as Query;
+		const firstPage = createLogResult('page-1');
+
+		const { result, rerender } = renderHook(
+			() =>
+				useLogsData({
+					result: firstPage,
+					panelType: PANEL_TYPES.LIST,
+					stagedQuery,
+				}),
+			{ wrapper: AllTheProviders },
+		);
+
+		await act(async () => {
+			response = createPageResponse('page-2');
+			rerender();
+		});
+
+		expect(result.current.logs.map((log) => log.id)).toStrictEqual([
+			'page-1',
+			'page-2',
+		]);
+
+		await act(async () => {
+			response = createPageResponse('page-3');
+			rerender();
+		});
+
+		expect(result.current.logs.map((log) => log.id)).toStrictEqual([
+			'page-1',
+			'page-2',
+			'page-3',
+		]);
 	});
 });

--- a/frontend/src/hooks/useLogsData.ts
+++ b/frontend/src/hooks/useLogsData.ts
@@ -163,9 +163,8 @@ export const useLogsData = ({
 				...item.data,
 				timestamp: item.timestamp,
 			}));
-			const newLogs = [...logs, ...currentLogs];
 
-			setLogs(newLogs);
+			setLogs((previousLogs) => [...previousLogs, ...currentLogs]);
 		}
 
 		// eslint-disable-next-line react-hooks/exhaustive-deps


### PR DESCRIPTION
## Summary

- use a functional state updater when accumulating log pages
- add regression coverage for multiple responses resolving in one render cycle

Fixes #12547

## Validation

- git diff --check passed
- Jest/lint/build could not be completed locally because the locked frontend dependency installation timed out in the environment