### PR TITLE
refactor: remove unused manager pause method

### DIFF
--- a/pkg/query-service/rules/manager.go
+++ b/pkg/query-service/rules/manager.go
@@ -238,15 +238,6 @@ func (m *Manager) MaintenanceStore() alertmanagertypes.MaintenanceStore {
 	return m.maintenanceStore
 }
 
-// TODO(jatinderjit): remove (unused)?
-func (m *Manager) Pause(b bool) {
-	m.mtx.Lock()
-	defer m.mtx.Unlock()
-	for _, t := range m.tasks {
-		t.Pause(b)
-	}
-}
-
 func (m *Manager) initiate(ctx context.Context) error {
 	orgs, err := m.orgGetter.ListByOwnedKeyRange(ctx)
 	if err != nil {


### PR DESCRIPTION
## Summary

- remove the unused Manager.Pause wrapper and its maintainer TODO
- preserve the Task.Pause interface and concrete task implementations

Closes #12378

## Validation

- repository-wide search confirmed no Manager.Pause call sites remain
- git diff --check passed
- Go tests, vet, and build could not run because Go 1.25.7 is not installed or available on PATH in the local environment