### PR TITLE
perf(FE): lazy-load Sentry replay integration out of the entry bundle

### DIFF
--- a/frontend/src/AppRoutes/index.tsx
+++ b/frontend/src/AppRoutes/index.tsx
@@ -368,10 +368,6 @@ function App(): JSX.Element {
 						// Kept for the `transaction` tag used in routing, even though
 						// tracing is disabled. Ref: https://github.com/SigNoz/platform-pod/issues/2393#issuecomment-4603658055
 						Sentry.browserTracingIntegration(),
-						Sentry.replayIntegration({
-							maskAllText: false,
-							blockAllMedia: false,
-						}),
 					],
 					tracesSampleRate: 0, // Ref: https://github.com/SigNoz/platform-pod/issues/2393#issuecomment-4603658055
 					replaysSessionSampleRate: 0.1, // This sets the sample rate at 10%. You may want to change it to 100% while in development and then sample at a lower rate in production.
@@ -395,6 +391,15 @@ function App(): JSX.Element {
 						return event;
 					},
 				});
+				Sentry.lazyLoadIntegration('replayIntegration')
+					.then((replayIntegration) =>
+						Sentry.addIntegration(
+							replayIntegration({ maskAllText: false, blockAllMedia: false }),
+						),
+					)
+					.catch((err) => {
+						console.error('[Sentry_Lazy_load] sentry lazy load failed:', err);
+					});
 
 				setIsSentryInitialized(true);
 			}


### PR DESCRIPTION
Part of #10192. Moves the Sentry session-replay integration out of the entry bundle by loading it with Sentry.lazyLoadIntegration() after Sentry.init() instead of registering it statically.
▎
▎ - Entry chunk: 3,219 kB → 3,094 kB raw, 952 kB → 912 kB gzipped (−40 kB for every user on first load)
▎ - Replay only ever initialized for cloud/enterprise deployments with sentry.enabled — self-hosted users were paying this cost for code that never ran
▎ - Config unchanged (maskAllText: false, blockAllMedia: false); failures to load are caught and logged
▎
▎ Note for reviewers: with lazy loading, the replay bundle is fetched from Sentry's CDN at runtime rather than being self-hosted in our build. If that's undesirable given the tunnel setup / CSP, happy to switch to a locally-chunked dynamic import instead.
▎
▎ Verified: pnpm tsc, pnpm lint:js (no new warnings), pnpm build before/after. Runtime replay path needs validation on a cloud environment — self-hosted never enables Sentry, so I could only verify the bundle split and that init still succeeds.