### PR TITLE
fix(apm): stop the service drilldown crashing on an empty operations list

### DIFF
--- a/frontend/src/container/GridCardLayout/__tests__/useResolveQuery.test.tsx
+++ b/frontend/src/container/GridCardLayout/__tests__/useResolveQuery.test.tsx
@@ -1,0 +1,91 @@
+import { renderHook } from '@testing-library/react';
+import { PANEL_TYPES } from 'constants/queryBuilder';
+import MockQueryClientProvider from 'providers/test/MockQueryClientProvider';
+import { Query } from 'types/api/queryBuilder/queryBuilderData';
+
+import useUpdatedQuery from '../useResolveQuery';
+
+const mockGetSubstituteVars = jest.fn();
+const mockDynamicVariables: unknown[] = [];
+
+jest.mock('api/dashboard/substitute_vars', () => ({
+	getSubstituteVars: (...args: unknown[]): unknown =>
+		mockGetSubstituteVars(...args),
+}));
+
+jest.mock('api/v5/v5', () => ({
+	prepareQueryRangePayloadV5: (): { queryPayload: unknown } => ({
+		queryPayload: { start: 0, end: 1 },
+	}),
+}));
+
+jest.mock(
+	'lib/newQueryBuilder/queryBuilderMappers/mapQueryDataFromApi',
+	() => ({
+		mapQueryDataFromApi: (): Query => ({ resolved: true }) as unknown as Query,
+	}),
+);
+
+jest.mock('hooks/dashboard/useDashboardVariablesByType', () => ({
+	useDashboardVariablesByType: (): unknown[] => mockDynamicVariables,
+}));
+
+jest.mock('react-redux', () => ({
+	...jest.requireActual('react-redux'),
+	useSelector: (): unknown => ({
+		selectedTime: 'GLOBAL_TIME',
+	}),
+}));
+
+const QUERY = { builder: { queryData: [] } } as unknown as Query;
+
+const WIDGET_CONFIG = {
+	query: QUERY,
+	panelTypes: PANEL_TYPES.TIME_SERIES,
+	timePreferance: 'GLOBAL_TIME' as const,
+};
+
+describe('useResolveQuery', () => {
+	beforeEach(() => {
+		jest.clearAllMocks();
+		mockDynamicVariables.length = 0;
+	});
+
+	it('skips the substitute_vars round-trip when there are no variables', async () => {
+		const { result } = renderHook(() => useUpdatedQuery(), {
+			wrapper: MockQueryClientProvider,
+		});
+
+		const resolved = await result.current.getUpdatedQuery({
+			widgetConfig: WIDGET_CONFIG,
+		});
+
+		expect(mockGetSubstituteVars).not.toHaveBeenCalled();
+		expect(resolved).toBe(QUERY);
+	});
+
+	it('resolves through substitute_vars when the dashboard has variables', async () => {
+		mockGetSubstituteVars.mockResolvedValue({
+			httpStatusCode: 200,
+			data: { compositeQuery: {} },
+		});
+
+		const { result } = renderHook(() => useUpdatedQuery(), {
+			wrapper: MockQueryClientProvider,
+		});
+
+		const resolved = await result.current.getUpdatedQuery({
+			widgetConfig: WIDGET_CONFIG,
+			dashboardData: {
+				data: {
+					variables: {
+						env: { name: 'env', selectedValue: 'prod' },
+					},
+				},
+			},
+		});
+
+		expect(mockGetSubstituteVars).toHaveBeenCalledTimes(1);
+		expect(resolved).toStrictEqual({ resolved: true });
+	});
+});

--- a/frontend/src/container/GridCardLayout/useResolveQuery.ts
+++ b/frontend/src/container/GridCardLayout/useResolveQuery.ts
@@ -2,6 +2,7 @@ import { useCallback } from 'react';
 import { useMutation } from 'react-query';
 // eslint-disable-next-line no-restricted-imports
 import { useSelector } from 'react-redux';
+import { isEmpty } from 'lodash-es';
 import { getSubstituteVars } from 'api/dashboard/substitute_vars';
 import { prepareQueryRangePayloadV5 } from 'api/v5/v5';
 import { PANEL_TYPES } from 'constants/queryBuilder';
@@ -46,13 +47,21 @@ function useUpdatedQuery(): UseUpdatedQueryResult {
 			widgetConfig,
 			dashboardData,
 		}: UseUpdatedQueryOptions): Promise<Query> => {
+			const variables = getDashboardVariables(dashboardData?.data?.variables);
+
+			// `/substitute_vars` only rewrites `$variable` references, so on surfaces with no
+			// dashboard behind them (APM, Celery, API monitoring) the round-trip is a no-op.
+			if (isEmpty(variables) && isEmpty(dashboardDynamicVariables)) {
+				return widgetConfig.query;
+			}
+
 			// Prepare query payload with resolved variables
 			const { queryPayload } = prepareQueryRangePayloadV5({
 				query: widgetConfig.query,
 				graphType: getGraphType(widgetConfig.panelTypes),
 				selectedTime: widgetConfig.timePreferance,
 				globalSelectedInterval,
-				variables: getDashboardVariables(dashboardData?.data?.variables),
+				variables,
 				originalGraphType: widgetConfig.panelTypes,
 				dynamicVariables: dashboardDynamicVariables,
 			});

--- a/frontend/src/container/MetricsApplication/Tabs/Overview.tsx
+++ b/frontend/src/container/MetricsApplication/Tabs/Overview.tsx
@@ -124,6 +124,9 @@ function Application(): JSX.Element {
 				start: minTime,
 				end: maxTime,
 			}),
+		// the time range is part of the key, so without this every window change blanks the
+		// operations list and the widgets below are rebuilt with an empty `operation in []`
+		keepPreviousData: true,
 	});
 
 	const selectedTraceTags: string = JSON.stringify(

--- a/frontend/src/container/QueryTable/Drilldown/__tests__/useBaseAggregateOptions.test.tsx
+++ b/frontend/src/container/QueryTable/Drilldown/__tests__/useBaseAggregateOptions.test.tsx
@@ -1,0 +1,88 @@
+import { renderHook, waitFor } from '@testing-library/react';
+import { Query } from 'types/api/queryBuilder/queryBuilderData';
+
+import useBaseAggregateOptions from '../useBaseAggregateOptions';
+
+const mockGetUpdatedQuery = jest.fn();
+const mockNotificationsError = jest.fn();
+
+jest.mock('container/GridCardLayout/useResolveQuery', () => ({
+	__esModule: true,
+	default: (): unknown => ({
+		getUpdatedQuery: mockGetUpdatedQuery,
+		isLoading: false,
+	}),
+}));
+
+jest.mock('hooks/useNotifications', () => ({
+	useNotifications: (): unknown => ({
+		notifications: { error: mockNotificationsError },
+	}),
+}));
+
+jest.mock('providers/Dashboard/store/useDashboardStore', () => ({
+	useDashboardStore: (): unknown => ({ dashboardData: undefined }),
+}));
+
+jest.mock('hooks/dashboard/useContextVariables', () => ({
+	__esModule: true,
+	default: (): unknown => ({ processedVariables: {} }),
+}));
+
+jest.mock('hooks/useSafeNavigate', () => ({
+	useSafeNavigate: (): unknown => ({ safeNavigate: jest.fn() }),
+}));
+
+jest.mock('react-router-dom', () => ({
+	...jest.requireActual('react-router-dom'),
+	useLocation: (): { pathname: string } => ({ pathname: '/services/socky-api' }),
+}));
+
+const QUERY = {
+	builder: {
+		queryData: [{ queryName: 'A', dataSource: 'traces', aggregations: [] }],
+	},
+} as unknown as Query;
+
+const AGGREGATE_DATA = { queryName: 'A', filters: [] };
+
+const renderOptions = (): ReturnType<typeof renderHook> =>
+	renderHook(() =>
+		useBaseAggregateOptions({
+			query: QUERY,
+			onClose: jest.fn(),
+			subMenu: '',
+			setSubMenu: jest.fn(),
+			aggregateData: AGGREGATE_DATA,
+			fieldVariables: {},
+		}),
+	);
+
+describe('useBaseAggregateOptions', () => {
+	beforeEach(() => {
+		jest.clearAllMocks();
+	});
+
+	it('notifies and keeps the unresolved query when variable resolution fails', async () => {
+		mockGetUpdatedQuery.mockRejectedValue(
+			new Error('syntax errors in expression'),
+		);
+
+		renderOptions();
+
+		await waitFor(() =>
+			expect(mockNotificationsError).toHaveBeenCalledWith({
+				message: 'Unable to resolve variables',
+			}),
+		);
+	});
+
+	it('does not notify when variable resolution succeeds', async () => {
+		mockGetUpdatedQuery.mockResolvedValue(QUERY);
+
+		renderOptions();
+
+		await waitFor(() => expect(mockGetUpdatedQuery).toHaveBeenCalled());
+		expect(mockNotificationsError).not.toHaveBeenCalled();
+	});
+});

--- a/frontend/src/container/QueryTable/Drilldown/useBaseAggregateOptions.tsx
+++ b/frontend/src/container/QueryTable/Drilldown/useBaseAggregateOptions.tsx
@@ -6,6 +6,7 @@ import { PANEL_TYPES } from 'constants/queryBuilder';
 import useUpdatedQuery from 'container/GridCardLayout/useResolveQuery';
 import { processContextLinks } from 'container/NewWidget/RightContainer/ContextLinks/utils';
 import useContextVariables from 'hooks/dashboard/useContextVariables';
+import { useNotifications } from 'hooks/useNotifications';
 import ContextMenu from 'periscope/components/ContextMenu';
 import { useDashboardStore } from 'providers/Dashboard/store/useDashboardStore';
 import { ContextLinksData } from 'types/api/dashboard/getAll';
@@ -50,23 +51,25 @@ const useBaseAggregateOptions = ({
 	const { getUpdatedQuery, isLoading: isResolveQueryLoading } =
 		useUpdatedQuery();
 	const { dashboardData } = useDashboardStore();
+	const { notifications } = useNotifications();
 
 	useEffect(() => {
 		if (!aggregateData) {
 			return;
 		}
-		const resolveQuery = async (): Promise<void> => {
-			const updatedQuery = await getUpdatedQuery({
-				widgetConfig: {
-					query,
-					panelTypes: panelType || PANEL_TYPES.TIME_SERIES,
-					timePreferance: 'GLOBAL_TIME',
-				},
-				dashboardData,
+		getUpdatedQuery({
+			widgetConfig: {
+				query,
+				panelTypes: panelType || PANEL_TYPES.TIME_SERIES,
+				timePreferance: 'GLOBAL_TIME',
+			},
+			dashboardData,
+		})
+			.then(setResolvedQuery)
+			.catch(() => {
+				setResolvedQuery(query);
+				notifications.error({ message: 'Unable to resolve variables' });
 			});
-			setResolvedQuery(updatedQuery);
-		};
-		resolveQuery();
 		// eslint-disable-next-line react-hooks/exhaustive-deps
 	}, [query, aggregateData, panelType]);
 


### PR DESCRIPTION
<!--A few plain bullets saying what changed and why, for a reviewer skimming it - not a wall of text, not a restatement of the diff, not generated boilerplate.-->
#### Description

Fixes an unhandled promise rejection on the APM service detail page — opening a chart's drilldown menu could throw `syntax errors in expression: [line 1:48 missing {BOOL, NUMBER, QUOTED_TEXT, KEY} at ']']`.

The chain:

- The overview's top-level-operations query keys on `minTime`/`maxTime` with no `keepPreviousData`, so every time-range change blanks the list. The widgets below are then rebuilt with `service.name in ['<service>'] AND operation in []`.
- `valueList` in the filter grammar needs at least one value, so `in []` is a hard parse error. The panel itself is guarded (`isQueryEnabled` requires a non-empty list); the drilldown is not.
- The drilldown menu resolves the widget query through `/substitute_vars` on every click — on this page there are no dashboard variables at all, so it is pure overhead — and the 400 landed on a floating promise with no rejection handler.

What changed:

- `useBaseAggregateOptions` catches the failure, falls back to the unresolved query (already its initial state) and shows the same "Unable to resolve variables" toast `useNavigateToExplorer` uses. `oxlint` was already flagging this line under `no-floating-promises`; that warning is gone.
- `useResolveQuery` short-circuits when there are no variables to substitute, so APM / Celery / API monitoring drilldowns stop making the call at all.
- The overview keeps its previous operations list across a time-range change, so the widget queries are never built with an empty list — which also stopped the bad filter riding into the explorer URL the drilldown opens.

#### Issues Closed
Closes https://github.com/SigNoz/pulse-pod/issues/278


<!--Anything reviewers should keep in mind while reviewing -->
#### Additional Information

- Skipping the round-trip doesn't lose the filter: both consumers of the resolved query rebuild `filter.expression` from `filters.items` themselves (`getViewQuery`, `useGetCompositeQueryParam`), and the APM query factory never sets `filter.expression` to begin with.
- `keepPreviousData` is safe across service navigation — `topLevelOperations[servicename]` already returns `[]` for a mismatched service, and `isQueryEnabled` still guards that case.
- Deliberately left out: dropping empty `IN []` items globally in `convertFiltersToExpression`. It would silence a wider class of 400s but flips the semantics — `IN []` means "match nothing", dropping the clause means "match everything" — and there is an existing test asserting today's behaviour. Happy to do it separately as a match-nothing rewrite if reviewers want the broader guard.
- Sentry: SIGNOZ-UI-5JV.
