### PR TITLE
feat: add override can edit dashboard

### DIFF
--- a/frontend/src/container/LLMObservability/Overview/Overview.tsx
+++ b/frontend/src/container/LLMObservability/Overview/Overview.tsx
@@ -12,7 +12,7 @@ function Overview(): JSX.Element {
 			<DashboardContainer
 				dashboard={dashboard}
 				refetch={refetch}
-				overrideCanEditDashboard={false}
+				canEditDashboardOverride={false}
 			/>
 		</div>
 	);

--- a/frontend/src/container/LLMObservability/Overview/Overview.tsx
+++ b/frontend/src/container/LLMObservability/Overview/Overview.tsx
@@ -12,7 +12,7 @@ function Overview(): JSX.Element {
 			<DashboardContainer
 				dashboard={dashboard}
 				refetch={refetch}
-				OverrideCanEditDashboard={false}
+				overrideCanEditDashboard={false}
 			/>
 		</div>
 	);

--- a/frontend/src/container/LLMObservability/Overview/Overview.tsx
+++ b/frontend/src/container/LLMObservability/Overview/Overview.tsx
@@ -9,7 +9,11 @@ function Overview(): JSX.Element {
 
 	return (
 		<div className={styles.overview} data-testid="llm-observability-overview">
-			<DashboardContainer dashboard={dashboard} refetch={refetch} />
+			<DashboardContainer
+				dashboard={dashboard}
+				refetch={refetch}
+				OverrideCanEditDashboard={false}
+			/>
 		</div>
 	);
 }

--- a/frontend/src/container/LLMObservability/Overview/json/dashboard.json
+++ b/frontend/src/container/LLMObservability/Overview/json/dashboard.json
@@ -1,7 +1,7 @@
 {
   "id": "llm-observability-overview",
   "orgId": "",
-  "locked": true,
+  "locked": false,
   "name": "AI Observability Overview",
   "schemaVersion": "v6",
   "source": "system",

--- a/frontend/src/pages/DashboardPageV2/DashboardContainer/DashboardPageToolbar/DashboardActions/DashboardActions.tsx
+++ b/frontend/src/pages/DashboardPageV2/DashboardContainer/DashboardPageToolbar/DashboardActions/DashboardActions.tsx
@@ -189,7 +189,8 @@ function DashboardActions({
 				onClick: (): void => void handleClone(),
 			});
 		}
-		if (isAuthor || user.role === USER_ROLES.ADMIN) {
+
+		if (canEditDashboard && (isAuthor || user.role === USER_ROLES.ADMIN)) {
 			dashboardGroup.push({
 				key: 'lock',
 				label: isDashboardLocked ? 'Unlock dashboard' : 'Lock dashboard',

--- a/frontend/src/pages/DashboardPageV2/DashboardContainer/index.tsx
+++ b/frontend/src/pages/DashboardPageV2/DashboardContainer/index.tsx
@@ -19,11 +19,19 @@ import { resolveDashboardImage } from 'pages/DashboardPageV2/DashboardContainer/
 interface DashboardContainerProps {
 	dashboard: DashboardtypesGettableDashboardV2DTO;
 	refetch: () => void;
+	/**
+	 * @deprecated
+	 * LLM Observability only. The only legal value is `false` (read-only embed).
+	 * Omitting the prop keeps permission-derived editability. Does not change `isLocked`.
+	 *  Temporary — TODO: @Ashwin / @Abhi — remove when embeds have their own surface.
+	 */
+	OverrideCanEditDashboard?: false;
 }
 
 function DashboardContainer({
 	dashboard,
 	refetch,
+	OverrideCanEditDashboard,
 }: DashboardContainerProps): JSX.Element {
 	const spec = dashboard.spec;
 	const image = resolveDashboardImage(dashboard.image);
@@ -45,10 +53,11 @@ function DashboardContainer({
 	// Seed during render (not an effect) so the first Panel render already sees the id —
 	// useDashboardFetchRequired throws on a missing id. setEditContext self-guards.
 	const setEditContext = useDashboardStore((s) => s.setEditContext);
+
 	setEditContext({
 		dashboardId: dashboard.id,
 		isLocked,
-		canEditDashboard,
+		canEditDashboard: OverrideCanEditDashboard ?? canEditDashboard,
 		refetch,
 	});
 

--- a/frontend/src/pages/DashboardPageV2/DashboardContainer/index.tsx
+++ b/frontend/src/pages/DashboardPageV2/DashboardContainer/index.tsx
@@ -21,9 +21,10 @@ interface DashboardContainerProps {
 	refetch: () => void;
 	/**
 	 * @deprecated
-	 * LLM Observability only. The only legal value is `false` (read-only embed).
-	 * Omitting the prop keeps permission-derived editability. Does not change `isLocked`.
-	 *  Temporary — TODO: @Ashwin / @Abhi — remove when embeds have their own surface.
+	 * `overrideCanEditDashboard` is a temporary solution to allow the dashboard to be view only.
+	 * This is only used for LLM Observability. that's why the type is `false`.
+	 * It will be removed in the future.
+	 *  TODO: @Ashwin / @Abhi — remove when the final solution is implemented.
 	 */
 	overrideCanEditDashboard?: false;
 }

--- a/frontend/src/pages/DashboardPageV2/DashboardContainer/index.tsx
+++ b/frontend/src/pages/DashboardPageV2/DashboardContainer/index.tsx
@@ -25,13 +25,13 @@ interface DashboardContainerProps {
 	 * Omitting the prop keeps permission-derived editability. Does not change `isLocked`.
 	 *  Temporary — TODO: @Ashwin / @Abhi — remove when embeds have their own surface.
 	 */
-	OverrideCanEditDashboard?: false;
+	overrideCanEditDashboard?: false;
 }
 
 function DashboardContainer({
 	dashboard,
 	refetch,
-	OverrideCanEditDashboard,
+	overrideCanEditDashboard,
 }: DashboardContainerProps): JSX.Element {
 	const spec = dashboard.spec;
 	const image = resolveDashboardImage(dashboard.image);
@@ -57,7 +57,7 @@ function DashboardContainer({
 	setEditContext({
 		dashboardId: dashboard.id,
 		isLocked,
-		canEditDashboard: OverrideCanEditDashboard ?? canEditDashboard,
+		canEditDashboard: overrideCanEditDashboard ?? canEditDashboard,
 		refetch,
 	});
 

--- a/frontend/src/pages/DashboardPageV2/DashboardContainer/index.tsx
+++ b/frontend/src/pages/DashboardPageV2/DashboardContainer/index.tsx
@@ -21,18 +21,18 @@ interface DashboardContainerProps {
 	refetch: () => void;
 	/**
 	 * @deprecated
-	 * `overrideCanEditDashboard` is a temporary solution to allow the dashboard to be view only.
-	 * This is only used for LLM Observability. that's why the type is `false`.
+	 * `canEditDashboardOverride` is a temporary solution to allow the dashboard to be view only.
+	 * This is only used for LLM Observability.
 	 * It will be removed in the future.
 	 *  TODO: @Ashwin / @Abhi — remove when the final solution is implemented.
 	 */
-	overrideCanEditDashboard?: false;
+	canEditDashboardOverride?: boolean;
 }
 
 function DashboardContainer({
 	dashboard,
 	refetch,
-	overrideCanEditDashboard,
+	canEditDashboardOverride,
 }: DashboardContainerProps): JSX.Element {
 	const spec = dashboard.spec;
 	const image = resolveDashboardImage(dashboard.image);
@@ -58,7 +58,7 @@ function DashboardContainer({
 	setEditContext({
 		dashboardId: dashboard.id,
 		isLocked,
-		canEditDashboard: overrideCanEditDashboard ?? canEditDashboard,
+		canEditDashboard: canEditDashboardOverride ?? canEditDashboard,
 		refetch,
 	});
 


### PR DESCRIPTION
#### Description

- `DashboardContainer` now takes an optional `overrideCanEditDashboard` prop that forces a dashboard into read-only mode, independent of the viewer's role o
- It is typed as `false` on purpose: the prop can only take edit rights away, never grant them, so it can't be used to slip past the existing permission checks. When it isn't passed, behaviour is unchanged (`overrideCanEditDashboard ?? canEditDashboard`), so no other dashboard is affected.
- LLM Observability's Overview passes `overrideCanEditDashboard={false}` so its built-in dashboard stays view-only, and the dashboard JSON's `locked` flag goes back to `false` since the lock is no longer what makes it read-only.
- `DashboardActions` also gates the Lock / Unlock menu item behind `canEditDashboard`, so a read-only dashboard no longer offers an action that would let the viewer flip its lock state.
- The prop is marked `@deprecated` with a TODO 

#### Issues closed by this PR

Covers the read-only dashboard requirement discussed in SigNoz/engineering-pod#5920.

#### Screenshots / Screen Recordings

https://github.com/user-attachments/assets/e49bf5f7-ca36-4353-be47-f6ca80a2f0d2


#### Additional Information

