### PR TITLE
fix(querybuilder): remove LogIfStatementIsNotValid wrapper

### DIFF
--- a/pkg/querier/clickhouse_query.go
+++ b/pkg/querier/clickhouse_query.go
@@ -106,7 +106,9 @@ func (q *chSQLQuery) render(ctx context.Context) (string, error) {
 		return "", err
 	}
 
-	querybuilder.LogIfStatementIsNotValid(ctx, q.logger, rendered)
+	if err := querybuilder.ErrIfStatementIsNotValid(rendered); err != nil {
+		return "", err
+	}
 
 	return rendered, nil
 }

--- a/pkg/query-service/app/http_handler.go
+++ b/pkg/query-service/app/http_handler.go
@@ -991,7 +991,10 @@ func (aH *APIHandler) queryDashboardVarsV2(w http.ResponseWriter, r *http.Reques
 		return
 	}
 
-	querybuilder.LogIfStatementIsNotValid(r.Context(), aH.logger, query)
+	if err := querybuilder.ErrIfStatementIsNotValid(query); err != nil {
+		RespondError(w, &model.ApiError{Typ: model.ErrorBadData, Err: err}, nil)
+		return
+	}
 
 	dashboardVars, err := aH.reader.QueryDashboardVars(r.Context(), query)
 	if err != nil {

--- a/pkg/querybuilder/clickhouse_sql.go
+++ b/pkg/querybuilder/clickhouse_sql.go
@@ -1,8 +1,6 @@
 package querybuilder
 
 import (
-	"context"
-	"log/slog"
 	"maps"
 	"slices"
 	"strings"
@@ -155,14 +153,6 @@ func ErrIfStatementIsNotValid(query string) (err error) {
 
 	return selectQuery.Accept(visitor)
 }
-
-// TODO(@therealpandey): remove this and move to ErrIfStatementIsNotValid.
-func LogIfStatementIsNotValid(ctx context.Context, logger *slog.Logger, query string) {
-	if err := ErrIfStatementIsNotValid(query); err != nil {
-		logger.WarnContext(ctx, "clickhouse sql is not valid", errors.Attr(err), slog.String("query", query))
-	}
-}
-
 func errIfFunctionReads(name string) error {
 	lowered := strings.ToLower(name)
 	if _, ok := readingFunctions[lowered]; !ok && !strings.HasPrefix(lowered, dictionaryFunctionPrefix) {


### PR DESCRIPTION
## Summary

Removes the `LogIfStatementIsNotValid` wrapper from `pkg/querybuilder/clickhouse_sql.go` and has both callers use `ErrIfStatementIsNotValid` directly, as the maintainer TODO asked.

The wrapper only logged a warning when the SQL was invalid. Both callers (`pkg/querier/clickhouse_query.go:103` and `pkg/query-service/app/http_handler.go:987`) swallowed the result and continued with the potentially invalid query. The new code returns the validation error to the caller, which is the safer failure mode for an HTTP/JSON render path.

## Changes

- `pkg/querybuilder/clickhouse_sql.go`: drop the `LogIfStatementIsNotValid` function and the now-unused `context` and `log/slog` imports.
- `pkg/querier/clickhouse_query.go`: `chSQLQuery.render` now returns the validation error instead of logging and continuing.
- `pkg/query-service/app/http_handler.go`: `queryDashboardVarsV2` now surfaces the validation error to the HTTP caller instead of logging and continuing.

## Diff stat

```
 pkg/querier/clickhouse_query.go       |  4 +++-
 pkg/query-service/app/http_handler.go |  5 ++++-
 pkg/querybuilder/clickhouse_sql.go    | 10 ----------
 3 files changed, 7 insertions(+), 12 deletions(-)
```

## Testing

- `go build ./...` — passes
- `go test ./pkg/querybuilder/...` — passes (existing test file `clickhouse_sql_test.go` covers `ErrIfStatementIsNotValid` directly)
- `go test ./pkg/querier/...` — passes
- `go test ./pkg/query-service/app/...` — passes

No test currently references `LogIfStatementIsNotValid`, so the wrapper had no test pin to preserve.

## Backward compatibility

Internal package change. The removed function had no external callers. The two call sites change behavior from silent warning to surfaced error, which is the safer failure mode for an HTTP path.

## Out of scope

The known parser gaps referenced in `clickhouse_sql.go:108` (`TestErrIfStatementIsNotValid_ShouldPassButFails`) are not addressed by this PR.

Fixes #12581
