### PR TITLE
chore(serviceaccount): migrate role provisioning to service_account_roles API

### DIFF
--- a/frontend/src/components/ServiceAccountDrawer/__tests__/ServiceAccountDrawer.authz.test.tsx
+++ b/frontend/src/components/ServiceAccountDrawer/__tests__/ServiceAccountDrawer.authz.test.tsx
@@ -1,4 +1,7 @@
-import { listRolesSuccessResponse } from 'mocks-server/__mockdata__/roles';
+import {
+	listRolesSuccessResponse,
+	managedRoles,
+} from 'mocks-server/__mockdata__/roles';
 import { rest, server } from 'mocks-server/server';
 import { NuqsTestingAdapter } from 'nuqs/adapters/testing';
 import { fireEvent, render, screen, waitFor } from 'tests/test-utils';
@@ -18,17 +21,24 @@ const ROLES_ENDPOINT = '*/api/v1/roles';
 const SA_KEYS_ENDPOINT = '*/api/v1/service_accounts/:id/keys';
 const SA_ENDPOINT = '*/api/v1/service_accounts/sa-1';
 const SA_DELETE_ENDPOINT = '*/api/v1/service_accounts/sa-1';
-const SA_ROLES_ENDPOINT = '*/api/v1/service_accounts/:id/roles';
-const SA_ROLE_DELETE_ENDPOINT = '*/api/v1/service_accounts/:id/roles/:rid';
+const SA_ROLES_ENDPOINT = '*/api/v1/service_account_roles';
+const SA_ROLE_DELETE_ENDPOINT = '*/api/v1/service_account_roles/:id';
 
 const activeAccountResponse = {
 	id: 'sa-1',
 	name: 'CI Bot',
 	email: 'ci-bot@signoz.io',
-	roles: ['signoz-admin'],
 	status: 'ACTIVE',
 	createdAt: '2026-01-01T00:00:00Z',
 	updatedAt: '2026-01-02T00:00:00Z',
+	serviceAccountRoles: [
+		{
+			id: 'sar-admin-1',
+			serviceAccountId: 'sa-1',
+			roleId: managedRoles[0].id,
+			role: { ...managedRoles[0], transactionGroups: [] },
+		},
+	],
 };
 
 function renderDrawer(
@@ -58,22 +68,13 @@ function setupBaseHandlers(): void {
 		rest.delete(SA_DELETE_ENDPOINT, (_, res, ctx) =>
 			res(ctx.status(200), ctx.json({ status: 'success', data: {} })),
 		),
-		rest.get(SA_ROLES_ENDPOINT, (_, res, ctx) =>
+		rest.post(SA_ROLES_ENDPOINT, (_, res, ctx) =>
 			res(
-				ctx.status(200),
-				ctx.json({
-					data: listRolesSuccessResponse.data.filter(
-						(r) => r.name === 'signoz-admin',
-					),
-				}),
+				ctx.status(201),
+				ctx.json({ status: 'success', data: { id: 'sar-new' } }),
 			),
 		),
-		rest.post(SA_ROLES_ENDPOINT, (_, res, ctx) =>
-			res(ctx.status(200), ctx.json({ status: 'success', data: {} })),
-		),
-		rest.delete(SA_ROLE_DELETE_ENDPOINT, (_, res, ctx) =>
-			res(ctx.status(200), ctx.json({ status: 'success', data: {} })),
-		),
+		rest.delete(SA_ROLE_DELETE_ENDPOINT, (_, res, ctx) => res(ctx.status(204))),
 	);
 }
 

--- a/frontend/src/components/ServiceAccountDrawer/__tests__/ServiceAccountDrawer.test.tsx
+++ b/frontend/src/components/ServiceAccountDrawer/__tests__/ServiceAccountDrawer.test.tsx
@@ -1,4 +1,7 @@
-import { listRolesSuccessResponse } from 'mocks-server/__mockdata__/roles';
+import {
+	listRolesSuccessResponse,
+	managedRoles,
+} from 'mocks-server/__mockdata__/roles';
 import { rest, server } from 'mocks-server/server';
 import { NuqsTestingAdapter } from 'nuqs/adapters/testing';
 import { render, screen, userEvent, waitFor } from 'tests/test-utils';
@@ -10,23 +13,33 @@ const ROLES_ENDPOINT = '*/api/v1/roles';
 const SA_KEYS_ENDPOINT = '*/api/v1/service_accounts/:id/keys';
 const SA_ENDPOINT = '*/api/v1/service_accounts/sa-1';
 const SA_DELETE_ENDPOINT = '*/api/v1/service_accounts/sa-1';
-const SA_ROLES_ENDPOINT = '*/api/v1/service_accounts/:id/roles';
-const SA_ROLE_DELETE_ENDPOINT = '*/api/v1/service_accounts/:id/roles/:rid';
+const SA_ROLES_ENDPOINT = '*/api/v1/service_account_roles';
+const SA_ROLE_DELETE_ENDPOINT = '*/api/v1/service_account_roles/:id';
+
+const ADMIN_ASSIGNMENT_ID = 'sar-admin-1';
 
 const activeAccountResponse = {
 	id: 'sa-1',
 	name: 'CI Bot',
 	email: 'ci-bot@signoz.io',
-	roles: ['signoz-admin'],
 	status: 'ACTIVE',
 	createdAt: '2026-01-01T00:00:00Z',
 	updatedAt: '2026-01-02T00:00:00Z',
+	serviceAccountRoles: [
+		{
+			id: ADMIN_ASSIGNMENT_ID,
+			serviceAccountId: 'sa-1',
+			roleId: managedRoles[0].id,
+			role: { ...managedRoles[0], transactionGroups: [] },
+		},
+	],
 };
 
 const deletedAccountResponse = {
 	...activeAccountResponse,
 	id: 'sa-2',
 	status: 'DELETED',
+	serviceAccountRoles: [],
 };
 
 function renderDrawer(
@@ -58,22 +71,13 @@ describe('ServiceAccountDrawer', () => {
 			rest.delete(SA_DELETE_ENDPOINT, (_, res, ctx) =>
 				res(ctx.status(200), ctx.json({ status: 'success', data: {} })),
 			),
-			rest.get(SA_ROLES_ENDPOINT, (_, res, ctx) =>
+			rest.post(SA_ROLES_ENDPOINT, (_, res, ctx) =>
 				res(
-					ctx.status(200),
-					ctx.json({
-						data: listRolesSuccessResponse.data.filter(
-							(r) => r.name === 'signoz-admin',
-						),
-					}),
+					ctx.status(201),
+					ctx.json({ status: 'success', data: { id: 'sar-new' } }),
 				),
 			),
-			rest.post(SA_ROLES_ENDPOINT, (_, res, ctx) =>
-				res(ctx.status(200), ctx.json({ status: 'success', data: {} })),
-			),
-			rest.delete(SA_ROLE_DELETE_ENDPOINT, (_, res, ctx) =>
-				res(ctx.status(200), ctx.json({ status: 'success', data: {} })),
-			),
+			rest.delete(SA_ROLE_DELETE_ENDPOINT, (_, res, ctx) => res(ctx.status(204))),
 			setupAuthzAdmin(),
 		);
 	});
@@ -136,11 +140,14 @@ describe('ServiceAccountDrawer', () => {
 		server.use(
 			rest.post(SA_ROLES_ENDPOINT, async (req, res, ctx) => {
 				roleSpy(await req.json());
-				return res(ctx.status(200), ctx.json({ status: 'success', data: {} }));
+				return res(
+					ctx.status(201),
+					ctx.json({ status: 'success', data: { id: 'sar-new' } }),
+				);
 			}),
 			rest.delete(SA_ROLE_DELETE_ENDPOINT, (_, res, ctx) => {
 				deleteSpy();
-				return res(ctx.status(200), ctx.json({ status: 'success', data: {} }));
+				return res(ctx.status(204));
 			}),
 		);
 
@@ -159,7 +166,8 @@ describe('ServiceAccountDrawer', () => {
 		await waitFor(() => {
 			expect(roleSpy).toHaveBeenCalledWith(
 				expect.objectContaining({
-					id: '019c24aa-2248-7585-a129-4188b3473c27',
+					serviceAccountId: 'sa-1',
+					roleId: '019c24aa-2248-7585-a129-4188b3473c27',
 				}),
 			);
 			expect(deleteSpy).not.toHaveBeenCalled();
@@ -174,11 +182,14 @@ describe('ServiceAccountDrawer', () => {
 		server.use(
 			rest.post(SA_ROLES_ENDPOINT, async (req, res, ctx) => {
 				roleSpy(await req.json());
-				return res(ctx.status(200), ctx.json({ status: 'success', data: {} }));
+				return res(
+					ctx.status(201),
+					ctx.json({ status: 'success', data: { id: 'sar-new' } }),
+				);
 			}),
-			rest.delete(SA_ROLE_DELETE_ENDPOINT, (_, res, ctx) => {
-				deleteSpy();
-				return res(ctx.status(200), ctx.json({ status: 'success', data: {} }));
+			rest.delete(SA_ROLE_DELETE_ENDPOINT, (req, res, ctx) => {
+				deleteSpy(req.params.id);
+				return res(ctx.status(204));
 			}),
 		);
 
@@ -198,7 +209,7 @@ describe('ServiceAccountDrawer', () => {
 		await user.click(saveBtn);
 
 		await waitFor(() => {
-			expect(deleteSpy).toHaveBeenCalled();
+			expect(deleteSpy).toHaveBeenCalledWith(ADMIN_ASSIGNMENT_ID);
 			expect(roleSpy).not.toHaveBeenCalled();
 		});
 	});
@@ -244,9 +255,6 @@ describe('ServiceAccountDrawer', () => {
 				res(ctx.status(200), ctx.json({ data: deletedAccountResponse })),
 			),
 			rest.get('*/api/v1/service_accounts/sa-2/keys', (_, res, ctx) =>
-				res(ctx.status(200), ctx.json({ data: [] })),
-			),
-			rest.get('*/api/v1/service_accounts/sa-2/roles', (_, res, ctx) =>
 				res(ctx.status(200), ctx.json({ data: [] })),
 			),
 		);
@@ -312,22 +320,13 @@ describe('ServiceAccountDrawer – save-error UX', () => {
 			rest.delete(SA_DELETE_ENDPOINT, (_, res, ctx) =>
 				res(ctx.status(200), ctx.json({ status: 'success', data: {} })),
 			),
-			rest.get(SA_ROLES_ENDPOINT, (_, res, ctx) =>
+			rest.post(SA_ROLES_ENDPOINT, (_, res, ctx) =>
 				res(
-					ctx.status(200),
-					ctx.json({
-						data: listRolesSuccessResponse.data.filter(
-							(r) => r.name === 'signoz-admin',
-						),
-					}),
+					ctx.status(201),
+					ctx.json({ status: 'success', data: { id: 'sar-new' } }),
 				),
 			),
-			rest.post(SA_ROLES_ENDPOINT, (_, res, ctx) =>
-				res(ctx.status(200), ctx.json({ status: 'success', data: {} })),
-			),
-			rest.delete(SA_ROLE_DELETE_ENDPOINT, (_, res, ctx) =>
-				res(ctx.status(200), ctx.json({ status: 'success', data: {} })),
-			),
+			rest.delete(SA_ROLE_DELETE_ENDPOINT, (_, res, ctx) => res(ctx.status(204))),
 			setupAuthzAdmin(),
 		);
 	});
@@ -410,14 +409,17 @@ describe('ServiceAccountDrawer – save-error UX', () => {
 		const user = userEvent.setup({ pointerEventsCheck: 0 });
 		let roleAddCallCount = 0;
 
-		// First call → 429, second call → 200
+		// First call → 429, second call → 201
 		server.use(
 			rest.post(SA_ROLES_ENDPOINT, (_, res, ctx) => {
 				roleAddCallCount += 1;
 				if (roleAddCallCount === 1) {
 					return res(ctx.status(429), ctx.json({ message: 'Too Many Requests' }));
 				}
-				return res(ctx.status(200), ctx.json({ status: 'success', data: {} }));
+				return res(
+					ctx.status(201),
+					ctx.json({ status: 'success', data: { id: 'sar-new' } }),
+				);
 			}),
 		);
 

--- a/frontend/src/container/ServiceAccountsSettings/__tests__/ServiceAccountsSettings.authz.integration.test.tsx
+++ b/frontend/src/container/ServiceAccountsSettings/__tests__/ServiceAccountsSettings.authz.integration.test.tsx
@@ -10,7 +10,6 @@ import ServiceAccountsSettings from '../ServiceAccountsSettings';
 const SA_LIST_ENDPOINT = '*/api/v1/service_accounts';
 const SA_ENDPOINT = '*/api/v1/service_accounts/:id';
 const SA_KEYS_ENDPOINT = '*/api/v1/service_accounts/:id/keys';
-const SA_ROLES_ENDPOINT = '*/api/v1/service_accounts/:id/roles';
 const ROLES_ENDPOINT = '*/api/v1/roles';
 
 const mockServiceAccountsAPI = [
@@ -18,7 +17,7 @@ const mockServiceAccountsAPI = [
 		id: 'sa-1',
 		name: 'CI Bot',
 		email: 'ci-bot@signoz.io',
-		roles: ['signoz-admin'],
+		serviceAccountRoles: [],
 		status: 'ACTIVE',
 		createdAt: 1700000000,
 		updatedAt: 1700000001,
@@ -27,7 +26,7 @@ const mockServiceAccountsAPI = [
 		id: 'sa-2',
 		name: 'Monitoring Agent',
 		email: 'monitor@signoz.io',
-		roles: ['signoz-viewer'],
+		serviceAccountRoles: [],
 		status: 'ACTIVE',
 		createdAt: 1700000002,
 		updatedAt: 1700000003,
@@ -36,7 +35,7 @@ const mockServiceAccountsAPI = [
 		id: 'sa-3',
 		name: 'Legacy Bot',
 		email: 'legacy@signoz.io',
-		roles: ['signoz-editor'],
+		serviceAccountRoles: [],
 		status: 'DISABLED',
 		createdAt: 1700000004,
 		updatedAt: 1700000005,
@@ -59,9 +58,6 @@ describe('ServiceAccountsSettings (integration)', () => {
 					: res(ctx.status(404), ctx.json({ message: 'Not found' }));
 			}),
 			rest.get(SA_KEYS_ENDPOINT, (_, res, ctx) =>
-				res(ctx.status(200), ctx.json({ data: [] })),
-			),
-			rest.get(SA_ROLES_ENDPOINT, (_, res, ctx) =>
 				res(ctx.status(200), ctx.json({ data: [] })),
 			),
 			rest.get(ROLES_ENDPOINT, (_, res, ctx) =>

--- a/frontend/src/hooks/serviceAccount/useServiceAccountRoleManager.ts
+++ b/frontend/src/hooks/serviceAccount/useServiceAccountRoleManager.ts
@@ -1,18 +1,22 @@
 import { useCallback, useMemo } from 'react';
-import { useQueryClient } from 'react-query';
 import {
-	getGetServiceAccountRolesQueryKey,
-	useCreateServiceAccountRoleDeprecated,
-	useDeleteServiceAccountRoleDeprecated,
-	useGetServiceAccountRoles,
+	useCreateServiceAccountRole,
+	useDeleteServiceAccountRole,
+	useGetServiceAccount,
 } from 'api/generated/services/serviceaccount';
-import type { AuthtypesGettableRoleDTO } from 'api/generated/services/sigNoz.schemas';
+import type {
+	AuthtypesGettableRoleDTO,
+	ServiceaccounttypesServiceAccountRoleDTO,
+} from 'api/generated/services/sigNoz.schemas';
 import { retryOn429 } from 'utils/errorUtils';
 
 const enum PromiseStatus {
-	Fulfilled = 'fulfilled',
 	Rejected = 'rejected',
 }
+
+// Stable identity so the memos below do not recompute on every render.
+const EMPTY_SERVICE_ACCOUNT_ROLES: ServiceaccounttypesServiceAccountRoleDTO[] =
+	[];
 
 export interface RoleUpdateFailure {
 	roleName: string;
@@ -33,33 +37,39 @@ export function useServiceAccountRoleManager(
 	accountId: string,
 	options?: { enabled?: boolean },
 ): UseServiceAccountRoleManagerResult {
-	const queryClient = useQueryClient();
-
-	const { data, isLoading } = useGetServiceAccountRoles(
+	const { data, isLoading } = useGetServiceAccount(
 		{ id: accountId },
 		{ query: { enabled: options?.enabled ?? true } },
 	);
 
+	const serviceAccountRoles =
+		data?.data?.serviceAccountRoles ?? EMPTY_SERVICE_ACCOUNT_ROLES;
+
 	const currentRoles = useMemo<AuthtypesGettableRoleDTO[]>(
-		() => data?.data ?? [],
-		[data?.data],
+		() =>
+			serviceAccountRoles.map((serviceAccountRole) => serviceAccountRole.role),
+		[serviceAccountRoles],
+	);
+
+	// DELETE /api/v1/service_account_roles/{id} is keyed by the join row, not the role.
+	const assignmentIdByRoleId = useMemo(
+		() =>
+			new Map(
+				serviceAccountRoles.map((serviceAccountRole) => [
+					serviceAccountRole.roleId,
+					serviceAccountRole.id,
+				]),
+			),
+		[serviceAccountRoles],
 	);
 
 	// the retry for these mutations is safe due to being idempotent on backend
-	const { mutateAsync: createRole } = useCreateServiceAccountRoleDeprecated({
+	const { mutateAsync: createRole } = useCreateServiceAccountRole({
 		mutation: { retry: retryOn429 },
 	});
-	const { mutateAsync: deleteRole } = useDeleteServiceAccountRoleDeprecated({
+	const { mutateAsync: deleteRole } = useDeleteServiceAccountRole({
 		mutation: { retry: retryOn429 },
 	});
-
-	const invalidateRoles = useCallback(
-		() =>
-			queryClient.invalidateQueries(
-				getGetServiceAccountRolesQueryKey({ id: accountId }),
-			),
-		[accountId, queryClient],
-	);
 
 	const applyDiff = useCallback(
 		async (
@@ -84,25 +94,33 @@ export function useServiceAccountRoleManager(
 				...addedRoles.map((role) => ({
 					role,
 					run: (): ReturnType<typeof createRole> =>
-						createRole({ pathParams: { id: accountId }, data: { id: role.id } }),
+						createRole({
+							data: { serviceAccountId: accountId, roleId: role.id ?? '' },
+						}),
 				})),
-				...removedRoles.map((role) => ({
-					role,
-					run: (): ReturnType<typeof deleteRole> =>
-						deleteRole({ pathParams: { id: accountId, rid: role.id ?? '' } }),
-				})),
+				...removedRoles
+					.map((role) => ({
+						role,
+						assignmentId: assignmentIdByRoleId.get(role.id ?? ''),
+					}))
+					.filter(
+						(
+							entry,
+						): entry is {
+							role: AuthtypesGettableRoleDTO;
+							assignmentId: string;
+						} => !!entry.assignmentId,
+					)
+					.map(({ role, assignmentId }) => ({
+						role,
+						run: (): ReturnType<typeof deleteRole> =>
+							deleteRole({ pathParams: { id: assignmentId } }),
+					})),
 			];
 
 			const results = await Promise.allSettled(
 				allOperations.map((op) => op.run()),
 			);
-
-			const successCount = results.filter(
-				(r) => r.status === PromiseStatus.Fulfilled,
-			).length;
-			if (successCount > 0) {
-				await invalidateRoles();
-			}
 
 			const failures: RoleUpdateFailure[] = [];
 			results.forEach((result, index) => {
@@ -113,7 +131,6 @@ export function useServiceAccountRoleManager(
 						error: result.reason,
 						onRetry: async (): Promise<void> => {
 							await run();
-							await invalidateRoles();
 						},
 					});
 				}
@@ -121,7 +138,7 @@ export function useServiceAccountRoleManager(
 
 			return failures;
 		},
-		[accountId, currentRoles, createRole, deleteRole, invalidateRoles],
+		[accountId, currentRoles, assignmentIdByRoleId, createRole, deleteRole],
 	);
 
 	return {

--- a/tests/fixtures/serviceaccount.py
+++ b/tests/fixtures/serviceaccount.py
@@ -9,6 +9,7 @@ from fixtures.role import find_role_by_name
 logger = setup_logger(__name__)
 
 SERVICE_ACCOUNT_BASE = "/api/v1/service_accounts"
+SERVICE_ACCOUNT_ROLES_BASE = "/api/v1/service_account_roles"
 
 
 def create_service_account(signoz: types.SigNoz, token: str, name: str, role: str = "signoz-viewer") -> str:
@@ -24,12 +25,12 @@ def create_service_account(signoz: types.SigNoz, token: str, name: str, role: st
 
     role_id = find_role_by_name(signoz, token, role)
     role_resp = requests.post(
-        signoz.self.host_configs["8080"].get(f"{SERVICE_ACCOUNT_BASE}/{service_account_id}/roles"),
-        json={"id": role_id},
+        signoz.self.host_configs["8080"].get(SERVICE_ACCOUNT_ROLES_BASE),
+        json={"serviceAccountId": service_account_id, "roleId": role_id},
         headers={"Authorization": f"Bearer {token}"},
         timeout=5,
     )
-    assert role_resp.status_code == HTTPStatus.NO_CONTENT, role_resp.text
+    assert role_resp.status_code == HTTPStatus.CREATED, role_resp.text
 
     return service_account_id
 
@@ -85,12 +86,12 @@ def create_service_account_with_roles(signoz: types.SigNoz, token: str, name: st
     for role in roles:
         role_id = find_role_by_name(signoz, token, role)
         role_resp = requests.post(
-            signoz.self.host_configs["8080"].get(f"{SERVICE_ACCOUNT_BASE}/{service_account_id}/roles"),
-            json={"id": role_id},
+            signoz.self.host_configs["8080"].get(SERVICE_ACCOUNT_ROLES_BASE),
+            json={"serviceAccountId": service_account_id, "roleId": role_id},
             headers={"Authorization": f"Bearer {token}"},
             timeout=5,
         )
-        assert role_resp.status_code == HTTPStatus.NO_CONTENT, role_resp.text
+        assert role_resp.status_code == HTTPStatus.CREATED, role_resp.text
 
     return service_account_id
 

--- a/tests/integration/tests/serviceaccount/04_roles.py
+++ b/tests/integration/tests/serviceaccount/04_roles.py
@@ -8,6 +8,7 @@ from fixtures.auth import USER_ADMIN_EMAIL, USER_ADMIN_PASSWORD
 from fixtures.logger import setup_logger
 from fixtures.serviceaccount import (
     SERVICE_ACCOUNT_BASE,
+    SERVICE_ACCOUNT_ROLES_BASE,
     create_service_account,
     create_service_account_with_key,
     find_role_by_name,
@@ -44,7 +45,7 @@ def test_assign_role_to_service_account(
     create_user_admin: types.Operation,  # pylint: disable=unused-argument
     get_token: Callable[[str, str], str],
 ):
-    """POST /{id}/roles adds a role alongside existing ones."""
+    """POST /service_account_roles adds a role alongside existing ones."""
     token = get_token(USER_ADMIN_EMAIL, USER_ADMIN_PASSWORD)
 
     # create service account with viewer role
@@ -53,12 +54,13 @@ def test_assign_role_to_service_account(
     # assign editor role (additive — viewer stays)
     editor_role_id = find_role_by_name(signoz, token, "signoz-editor")
     assign_resp = requests.post(
-        signoz.self.host_configs["8080"].get(f"{SERVICE_ACCOUNT_BASE}/{service_account_id}/roles"),
-        json={"id": editor_role_id},
+        signoz.self.host_configs["8080"].get(SERVICE_ACCOUNT_ROLES_BASE),
+        json={"serviceAccountId": service_account_id, "roleId": editor_role_id},
         headers={"Authorization": f"Bearer {token}"},
         timeout=5,
     )
-    assert assign_resp.status_code == HTTPStatus.NO_CONTENT, assign_resp.text
+    assert assign_resp.status_code == HTTPStatus.CREATED, assign_resp.text
+    assert assign_resp.json()["data"]["id"]
 
     # verify both viewer and editor roles are present
     roles_resp = requests.get(
@@ -75,12 +77,12 @@ def test_assign_role_to_service_account(
     # assign admin role — all three should be present
     admin_role_id = find_role_by_name(signoz, token, "signoz-admin")
     assign_resp = requests.post(
-        signoz.self.host_configs["8080"].get(f"{SERVICE_ACCOUNT_BASE}/{service_account_id}/roles"),
-        json={"id": admin_role_id},
+        signoz.self.host_configs["8080"].get(SERVICE_ACCOUNT_ROLES_BASE),
+        json={"serviceAccountId": service_account_id, "roleId": admin_role_id},
         headers={"Authorization": f"Bearer {token}"},
         timeout=5,
     )
-    assert assign_resp.status_code == HTTPStatus.NO_CONTENT, assign_resp.text
+    assert assign_resp.status_code == HTTPStatus.CREATED, assign_resp.text
 
     roles_resp = requests.get(
         signoz.self.host_configs["8080"].get(f"{SERVICE_ACCOUNT_BASE}/{service_account_id}/roles"),
@@ -100,7 +102,7 @@ def test_assign_role_idempotent(
     create_user_admin: types.Operation,  # pylint: disable=unused-argument
     get_token: Callable[[str, str], str],
 ):
-    """POST same role twice succeeds (replace with same role is idempotent)."""
+    """POST same role twice returns the same assignment (idempotent)."""
     token = get_token(USER_ADMIN_EMAIL, USER_ADMIN_PASSWORD)
     service_account_id = create_service_account(signoz, token, "sa-role-idempotent", role="signoz-viewer")
 
@@ -108,12 +110,12 @@ def test_assign_role_idempotent(
 
     # assign the same role again
     resp = requests.post(
-        signoz.self.host_configs["8080"].get(f"{SERVICE_ACCOUNT_BASE}/{service_account_id}/roles"),
-        json={"id": viewer_role_id},
+        signoz.self.host_configs["8080"].get(SERVICE_ACCOUNT_ROLES_BASE),
+        json={"serviceAccountId": service_account_id, "roleId": viewer_role_id},
         headers={"Authorization": f"Bearer {token}"},
         timeout=5,
     )
-    assert resp.status_code == HTTPStatus.NO_CONTENT, resp.text
+    assert resp.status_code == HTTPStatus.CREATED, resp.text
 
     # verify only one instance of the role
     roles_resp = requests.get(
@@ -147,12 +149,12 @@ def test_assign_role_expands_access(
     # assign admin role (additive — viewer stays)
     admin_role_id = find_role_by_name(signoz, token, "signoz-admin")
     assign_resp = requests.post(
-        signoz.self.host_configs["8080"].get(f"{SERVICE_ACCOUNT_BASE}/{service_account_id}/roles"),
-        json={"id": admin_role_id},
+        signoz.self.host_configs["8080"].get(SERVICE_ACCOUNT_ROLES_BASE),
+        json={"serviceAccountId": service_account_id, "roleId": admin_role_id},
         headers={"Authorization": f"Bearer {token}"},
         timeout=5,
     )
-    assert assign_resp.status_code == HTTPStatus.NO_CONTENT, assign_resp.text
+    assert assign_resp.status_code == HTTPStatus.CREATED, assign_resp.text
 
     # SA should now have admin access
     resp = requests.get(
@@ -180,24 +182,32 @@ def test_remove_role_from_service_account(
     create_user_admin: types.Operation,  # pylint: disable=unused-argument
     get_token: Callable[[str, str], str],
 ):
-    """DELETE /{id}/roles/{rid} revokes one role while keeping others."""
+    """DELETE /service_account_roles/{id} revokes one role while keeping others."""
     token = get_token(USER_ADMIN_EMAIL, USER_ADMIN_PASSWORD)
     service_account_id = create_service_account(signoz, token, "sa-remove-role", role="signoz-editor")
 
     # add admin role (now has editor + admin)
     admin_role_id = find_role_by_name(signoz, token, "signoz-admin")
     assign_resp = requests.post(
-        signoz.self.host_configs["8080"].get(f"{SERVICE_ACCOUNT_BASE}/{service_account_id}/roles"),
-        json={"id": admin_role_id},
+        signoz.self.host_configs["8080"].get(SERVICE_ACCOUNT_ROLES_BASE),
+        json={"serviceAccountId": service_account_id, "roleId": admin_role_id},
         headers={"Authorization": f"Bearer {token}"},
         timeout=5,
     )
-    assert assign_resp.status_code == HTTPStatus.NO_CONTENT, assign_resp.text
+    assert assign_resp.status_code == HTTPStatus.CREATED, assign_resp.text
+
+    # find the editor assignment entry id from the service account detail
+    detail_resp = requests.get(
+        signoz.self.host_configs["8080"].get(f"{SERVICE_ACCOUNT_BASE}/{service_account_id}"),
+        headers={"Authorization": f"Bearer {token}"},
+        timeout=5,
+    )
+    assert detail_resp.status_code == HTTPStatus.OK, detail_resp.text
+    editor_entry_id = next(entry["id"] for entry in detail_resp.json()["data"]["serviceAccountRoles"] if entry["role"]["name"] == "signoz-editor")
 
     # remove editor role
-    editor_role_id = find_role_by_name(signoz, token, "signoz-editor")
     resp = requests.delete(
-        signoz.self.host_configs["8080"].get(f"{SERVICE_ACCOUNT_BASE}/{service_account_id}/roles/{editor_role_id}"),
+        signoz.self.host_configs["8080"].get(f"{SERVICE_ACCOUNT_ROLES_BASE}/{editor_entry_id}"),
         headers={"Authorization": f"Bearer {token}"},
         timeout=5,
     )
@@ -232,10 +242,18 @@ def test_remove_role_verify_access_lost(
     )
     assert resp.status_code == HTTPStatus.OK, resp.text
 
+    # find the admin assignment entry id from the service account detail
+    detail_resp = requests.get(
+        signoz.self.host_configs["8080"].get(f"{SERVICE_ACCOUNT_BASE}/{service_account_id}"),
+        headers={"Authorization": f"Bearer {token}"},
+        timeout=5,
+    )
+    assert detail_resp.status_code == HTTPStatus.OK, detail_resp.text
+    admin_entry_id = next(entry["id"] for entry in detail_resp.json()["data"]["serviceAccountRoles"] if entry["role"]["name"] == "signoz-admin")
+
     # remove admin role
-    admin_role_id = find_role_by_name(signoz, token, "signoz-admin")
     del_resp = requests.delete(
-        signoz.self.host_configs["8080"].get(f"{SERVICE_ACCOUNT_BASE}/{service_account_id}/roles/{admin_role_id}"),
+        signoz.self.host_configs["8080"].get(f"{SERVICE_ACCOUNT_ROLES_BASE}/{admin_entry_id}"),
         headers={"Authorization": f"Bearer {token}"},
         timeout=5,
     )

--- a/tests/integration/tests/serviceaccount/06_fga.py
+++ b/tests/integration/tests/serviceaccount/06_fga.py
@@ -16,6 +16,7 @@ from fixtures.auth import (
 from fixtures.role import find_role_by_name, transaction_group
 from fixtures.serviceaccount import (
     SERVICE_ACCOUNT_BASE,
+    SERVICE_ACCOUNT_ROLES_BASE,
     create_service_account,
     find_service_account_by_name,
 )
@@ -131,8 +132,8 @@ def test_write_forbidden_without_grant(
     assert resp.status_code == HTTPStatus.FORBIDDEN, f"update SA: expected 403, got {resp.status_code}: {resp.text}"
 
     resp = requests.post(
-        signoz.self.host_configs["8080"].get(f"{SERVICE_ACCOUNT_BASE}/{target_id}/roles"),
-        json={"id": viewer_role_id},
+        signoz.self.host_configs["8080"].get(SERVICE_ACCOUNT_ROLES_BASE),
+        json={"serviceAccountId": target_id, "roleId": viewer_role_id},
         headers={"Authorization": f"Bearer {token}"},
         timeout=5,
     )
@@ -220,17 +221,18 @@ def test_attach_detach_dual_scoped(
 
     # Both SA-attach (target id) and role-attach (editor) present -> allowed.
     resp = requests.post(
-        signoz.self.host_configs["8080"].get(f"{SERVICE_ACCOUNT_BASE}/{target_id}/roles"),
-        json={"id": editor_role_id},
+        signoz.self.host_configs["8080"].get(SERVICE_ACCOUNT_ROLES_BASE),
+        json={"serviceAccountId": target_id, "roleId": editor_role_id},
         headers={"Authorization": f"Bearer {token}"},
         timeout=5,
     )
-    assert resp.status_code == HTTPStatus.NO_CONTENT, f"assign editor to target: {resp.text}"
+    assert resp.status_code == HTTPStatus.CREATED, f"assign editor to target: {resp.text}"
+    editor_entry_id = resp.json()["data"]["id"]
 
     # SA-attach not held for the other SA id -> forbidden.
     resp = requests.post(
-        signoz.self.host_configs["8080"].get(f"{SERVICE_ACCOUNT_BASE}/{other_id}/roles"),
-        json={"id": editor_role_id},
+        signoz.self.host_configs["8080"].get(SERVICE_ACCOUNT_ROLES_BASE),
+        json={"serviceAccountId": other_id, "roleId": editor_role_id},
         headers={"Authorization": f"Bearer {token}"},
         timeout=5,
     )
@@ -238,8 +240,8 @@ def test_attach_detach_dual_scoped(
 
     # role-attach not held for viewer -> forbidden even on the target SA.
     resp = requests.post(
-        signoz.self.host_configs["8080"].get(f"{SERVICE_ACCOUNT_BASE}/{target_id}/roles"),
-        json={"id": viewer_role_id},
+        signoz.self.host_configs["8080"].get(SERVICE_ACCOUNT_ROLES_BASE),
+        json={"serviceAccountId": target_id, "roleId": viewer_role_id},
         headers={"Authorization": f"Bearer {token}"},
         timeout=5,
     )
@@ -247,7 +249,7 @@ def test_attach_detach_dual_scoped(
 
     # Both SA-detach (target id) and role-detach (editor) present -> remove allowed.
     resp = requests.delete(
-        signoz.self.host_configs["8080"].get(f"{SERVICE_ACCOUNT_BASE}/{target_id}/roles/{editor_role_id}"),
+        signoz.self.host_configs["8080"].get(f"{SERVICE_ACCOUNT_ROLES_BASE}/{editor_entry_id}"),
         headers={"Authorization": f"Bearer {token}"},
         timeout=5,
     )


### PR DESCRIPTION
#### Description

- Migrates the service account role consumers off the deprecated nested `/api/v1/service_accounts/{id}/roles` endpoints onto `/api/v1/service_account_roles`, mirroring the earlier user → `user_roles` migration.
- `useServiceAccountRoleManager` now reads role assignments from the service account detail (`serviceAccountRoles` join rows), creates with `{serviceAccountId, roleId}`, and deletes by the join-row id; the manual query invalidation is dropped since the drawer already refetches the same query.
- Integration fixtures and the `serviceaccount` suites assign via `POST /service_account_roles` (201) and revoke via `DELETE /service_account_roles/{id}` (204).

#### Additional Information

- Part of SigNoz/platform-pod#2919. This is the consumer-migration half; removing the deprecated endpoints and regenerating the OpenAPI spec + frontend client follows in a separate PR once this merges.