### PR TITLE
test(serviceaccount): move role provisioning to the service_account_roles API

### DIFF
--- a/tests/fixtures/serviceaccount.py
+++ b/tests/fixtures/serviceaccount.py
@@ -9,6 +9,7 @@ from fixtures.role import find_role_by_name
 logger = setup_logger(__name__)
 
 SERVICE_ACCOUNT_BASE = "/api/v1/service_accounts"
+SERVICE_ACCOUNT_ROLES_BASE = "/api/v1/service_account_roles"
 
 
 def create_service_account(signoz: types.SigNoz, token: str, name: str, role: str = "signoz-viewer") -> str:
@@ -24,12 +25,12 @@ def create_service_account(signoz: types.SigNoz, token: str, name: str, role: st
 
     role_id = find_role_by_name(signoz, token, role)
     role_resp = requests.post(
-        signoz.self.host_configs["8080"].get(f"{SERVICE_ACCOUNT_BASE}/{service_account_id}/roles"),
-        json={"id": role_id},
+        signoz.self.host_configs["8080"].get(SERVICE_ACCOUNT_ROLES_BASE),
+        json={"serviceAccountId": service_account_id, "roleId": role_id},
         headers={"Authorization": f"Bearer {token}"},
         timeout=5,
     )
-    assert role_resp.status_code == HTTPStatus.NO_CONTENT, role_resp.text
+    assert role_resp.status_code == HTTPStatus.CREATED, role_resp.text
 
     return service_account_id
 
@@ -85,12 +86,12 @@ def create_service_account_with_roles(signoz: types.SigNoz, token: str, name: st
     for role in roles:
         role_id = find_role_by_name(signoz, token, role)
         role_resp = requests.post(
-            signoz.self.host_configs["8080"].get(f"{SERVICE_ACCOUNT_BASE}/{service_account_id}/roles"),
-            json={"id": role_id},
+            signoz.self.host_configs["8080"].get(SERVICE_ACCOUNT_ROLES_BASE),
+            json={"serviceAccountId": service_account_id, "roleId": role_id},
             headers={"Authorization": f"Bearer {token}"},
             timeout=5,
         )
-        assert role_resp.status_code == HTTPStatus.NO_CONTENT, role_resp.text
+        assert role_resp.status_code == HTTPStatus.CREATED, role_resp.text
 
     return service_account_id
 

--- a/tests/fixtures/serviceaccount.py
+++ b/tests/fixtures/serviceaccount.py
@@ -9,7 +9,6 @@ from fixtures.role import find_role_by_name
 logger = setup_logger(__name__)
 
 SERVICE_ACCOUNT_BASE = "/api/v1/service_accounts"
-SERVICE_ACCOUNT_ROLES_BASE = "/api/v1/service_account_roles"
 
 
 def create_service_account(signoz: types.SigNoz, token: str, name: str, role: str = "signoz-viewer") -> str:
@@ -25,7 +24,7 @@ def create_service_account(signoz: types.SigNoz, token: str, name: str, role: st
 
     role_id = find_role_by_name(signoz, token, role)
     role_resp = requests.post(
-        signoz.self.host_configs["8080"].get(SERVICE_ACCOUNT_ROLES_BASE),
+        signoz.self.host_configs["8080"].get("/api/v1/service_account_roles"),
         json={"serviceAccountId": service_account_id, "roleId": role_id},
         headers={"Authorization": f"Bearer {token}"},
         timeout=5,
@@ -86,7 +85,7 @@ def create_service_account_with_roles(signoz: types.SigNoz, token: str, name: st
     for role in roles:
         role_id = find_role_by_name(signoz, token, role)
         role_resp = requests.post(
-            signoz.self.host_configs["8080"].get(SERVICE_ACCOUNT_ROLES_BASE),
+            signoz.self.host_configs["8080"].get("/api/v1/service_account_roles"),
             json={"serviceAccountId": service_account_id, "roleId": role_id},
             headers={"Authorization": f"Bearer {token}"},
             timeout=5,

--- a/tests/integration/tests/serviceaccount/04_roles.py
+++ b/tests/integration/tests/serviceaccount/04_roles.py
@@ -8,7 +8,6 @@ from fixtures.auth import USER_ADMIN_EMAIL, USER_ADMIN_PASSWORD
 from fixtures.logger import setup_logger
 from fixtures.serviceaccount import (
     SERVICE_ACCOUNT_BASE,
-    SERVICE_ACCOUNT_ROLES_BASE,
     create_service_account,
     create_service_account_with_key,
     find_role_by_name,
@@ -54,7 +53,7 @@ def test_assign_role_to_service_account(
     # assign editor role (additive — viewer stays)
     editor_role_id = find_role_by_name(signoz, token, "signoz-editor")
     assign_resp = requests.post(
-        signoz.self.host_configs["8080"].get(SERVICE_ACCOUNT_ROLES_BASE),
+        signoz.self.host_configs["8080"].get("/api/v1/service_account_roles"),
         json={"serviceAccountId": service_account_id, "roleId": editor_role_id},
         headers={"Authorization": f"Bearer {token}"},
         timeout=5,
@@ -77,7 +76,7 @@ def test_assign_role_to_service_account(
     # assign admin role — all three should be present
     admin_role_id = find_role_by_name(signoz, token, "signoz-admin")
     assign_resp = requests.post(
-        signoz.self.host_configs["8080"].get(SERVICE_ACCOUNT_ROLES_BASE),
+        signoz.self.host_configs["8080"].get("/api/v1/service_account_roles"),
         json={"serviceAccountId": service_account_id, "roleId": admin_role_id},
         headers={"Authorization": f"Bearer {token}"},
         timeout=5,
@@ -110,7 +109,7 @@ def test_assign_role_idempotent(
 
     # assign the same role again
     resp = requests.post(
-        signoz.self.host_configs["8080"].get(SERVICE_ACCOUNT_ROLES_BASE),
+        signoz.self.host_configs["8080"].get("/api/v1/service_account_roles"),
         json={"serviceAccountId": service_account_id, "roleId": viewer_role_id},
         headers={"Authorization": f"Bearer {token}"},
         timeout=5,
@@ -149,7 +148,7 @@ def test_assign_role_expands_access(
     # assign admin role (additive — viewer stays)
     admin_role_id = find_role_by_name(signoz, token, "signoz-admin")
     assign_resp = requests.post(
-        signoz.self.host_configs["8080"].get(SERVICE_ACCOUNT_ROLES_BASE),
+        signoz.self.host_configs["8080"].get("/api/v1/service_account_roles"),
         json={"serviceAccountId": service_account_id, "roleId": admin_role_id},
         headers={"Authorization": f"Bearer {token}"},
         timeout=5,
@@ -189,7 +188,7 @@ def test_remove_role_from_service_account(
     # add admin role (now has editor + admin)
     admin_role_id = find_role_by_name(signoz, token, "signoz-admin")
     assign_resp = requests.post(
-        signoz.self.host_configs["8080"].get(SERVICE_ACCOUNT_ROLES_BASE),
+        signoz.self.host_configs["8080"].get("/api/v1/service_account_roles"),
         json={"serviceAccountId": service_account_id, "roleId": admin_role_id},
         headers={"Authorization": f"Bearer {token}"},
         timeout=5,
@@ -207,7 +206,7 @@ def test_remove_role_from_service_account(
 
     # remove editor role
     resp = requests.delete(
-        signoz.self.host_configs["8080"].get(f"{SERVICE_ACCOUNT_ROLES_BASE}/{editor_entry_id}"),
+        signoz.self.host_configs["8080"].get(f"/api/v1/service_account_roles/{editor_entry_id}"),
         headers={"Authorization": f"Bearer {token}"},
         timeout=5,
     )
@@ -253,7 +252,7 @@ def test_remove_role_verify_access_lost(
 
     # remove admin role
     del_resp = requests.delete(
-        signoz.self.host_configs["8080"].get(f"{SERVICE_ACCOUNT_ROLES_BASE}/{admin_entry_id}"),
+        signoz.self.host_configs["8080"].get(f"/api/v1/service_account_roles/{admin_entry_id}"),
         headers={"Authorization": f"Bearer {token}"},
         timeout=5,
     )

--- a/tests/integration/tests/serviceaccount/04_roles.py
+++ b/tests/integration/tests/serviceaccount/04_roles.py
@@ -8,6 +8,7 @@ from fixtures.auth import USER_ADMIN_EMAIL, USER_ADMIN_PASSWORD
 from fixtures.logger import setup_logger
 from fixtures.serviceaccount import (
     SERVICE_ACCOUNT_BASE,
+    SERVICE_ACCOUNT_ROLES_BASE,
     create_service_account,
     create_service_account_with_key,
     find_role_by_name,
@@ -44,7 +45,7 @@ def test_assign_role_to_service_account(
     create_user_admin: types.Operation,  # pylint: disable=unused-argument
     get_token: Callable[[str, str], str],
 ):
-    """POST /{id}/roles adds a role alongside existing ones."""
+    """POST /service_account_roles adds a role alongside existing ones."""
     token = get_token(USER_ADMIN_EMAIL, USER_ADMIN_PASSWORD)
 
     # create service account with viewer role
@@ -53,12 +54,13 @@ def test_assign_role_to_service_account(
     # assign editor role (additive — viewer stays)
     editor_role_id = find_role_by_name(signoz, token, "signoz-editor")
     assign_resp = requests.post(
-        signoz.self.host_configs["8080"].get(f"{SERVICE_ACCOUNT_BASE}/{service_account_id}/roles"),
-        json={"id": editor_role_id},
+        signoz.self.host_configs["8080"].get(SERVICE_ACCOUNT_ROLES_BASE),
+        json={"serviceAccountId": service_account_id, "roleId": editor_role_id},
         headers={"Authorization": f"Bearer {token}"},
         timeout=5,
     )
-    assert assign_resp.status_code == HTTPStatus.NO_CONTENT, assign_resp.text
+    assert assign_resp.status_code == HTTPStatus.CREATED, assign_resp.text
+    assert assign_resp.json()["data"]["id"]
 
     # verify both viewer and editor roles are present
     roles_resp = requests.get(
@@ -75,12 +77,12 @@ def test_assign_role_to_service_account(
     # assign admin role — all three should be present
     admin_role_id = find_role_by_name(signoz, token, "signoz-admin")
     assign_resp = requests.post(
-        signoz.self.host_configs["8080"].get(f"{SERVICE_ACCOUNT_BASE}/{service_account_id}/roles"),
-        json={"id": admin_role_id},
+        signoz.self.host_configs["8080"].get(SERVICE_ACCOUNT_ROLES_BASE),
+        json={"serviceAccountId": service_account_id, "roleId": admin_role_id},
         headers={"Authorization": f"Bearer {token}"},
         timeout=5,
     )
-    assert assign_resp.status_code == HTTPStatus.NO_CONTENT, assign_resp.text
+    assert assign_resp.status_code == HTTPStatus.CREATED, assign_resp.text
 
     roles_resp = requests.get(
         signoz.self.host_configs["8080"].get(f"{SERVICE_ACCOUNT_BASE}/{service_account_id}/roles"),
@@ -100,7 +102,7 @@ def test_assign_role_idempotent(
     create_user_admin: types.Operation,  # pylint: disable=unused-argument
     get_token: Callable[[str, str], str],
 ):
-    """POST same role twice succeeds (replace with same role is idempotent)."""
+    """POST same role twice returns the same assignment (idempotent)."""
     token = get_token(USER_ADMIN_EMAIL, USER_ADMIN_PASSWORD)
     service_account_id = create_service_account(signoz, token, "sa-role-idempotent", role="signoz-viewer")
 
@@ -108,12 +110,12 @@ def test_assign_role_idempotent(
 
     # assign the same role again
     resp = requests.post(
-        signoz.self.host_configs["8080"].get(f"{SERVICE_ACCOUNT_BASE}/{service_account_id}/roles"),
-        json={"id": viewer_role_id},
+        signoz.self.host_configs["8080"].get(SERVICE_ACCOUNT_ROLES_BASE),
+        json={"serviceAccountId": service_account_id, "roleId": viewer_role_id},
         headers={"Authorization": f"Bearer {token}"},
         timeout=5,
     )
-    assert resp.status_code == HTTPStatus.NO_CONTENT, resp.text
+    assert resp.status_code == HTTPStatus.CREATED, resp.text
 
     # verify only one instance of the role
     roles_resp = requests.get(
@@ -147,12 +149,12 @@ def test_assign_role_expands_access(
     # assign admin role (additive — viewer stays)
     admin_role_id = find_role_by_name(signoz, token, "signoz-admin")
     assign_resp = requests.post(
-        signoz.self.host_configs["8080"].get(f"{SERVICE_ACCOUNT_BASE}/{service_account_id}/roles"),
-        json={"id": admin_role_id},
+        signoz.self.host_configs["8080"].get(SERVICE_ACCOUNT_ROLES_BASE),
+        json={"serviceAccountId": service_account_id, "roleId": admin_role_id},
         headers={"Authorization": f"Bearer {token}"},
         timeout=5,
     )
-    assert assign_resp.status_code == HTTPStatus.NO_CONTENT, assign_resp.text
+    assert assign_resp.status_code == HTTPStatus.CREATED, assign_resp.text
 
     # SA should now have admin access
     resp = requests.get(
@@ -180,24 +182,32 @@ def test_remove_role_from_service_account(
     create_user_admin: types.Operation,  # pylint: disable=unused-argument
     get_token: Callable[[str, str], str],
 ):
-    """DELETE /{id}/roles/{rid} revokes one role while keeping others."""
+    """DELETE /service_account_roles/{id} revokes one role while keeping others."""
     token = get_token(USER_ADMIN_EMAIL, USER_ADMIN_PASSWORD)
     service_account_id = create_service_account(signoz, token, "sa-remove-role", role="signoz-editor")
 
     # add admin role (now has editor + admin)
     admin_role_id = find_role_by_name(signoz, token, "signoz-admin")
     assign_resp = requests.post(
-        signoz.self.host_configs["8080"].get(f"{SERVICE_ACCOUNT_BASE}/{service_account_id}/roles"),
-        json={"id": admin_role_id},
+        signoz.self.host_configs["8080"].get(SERVICE_ACCOUNT_ROLES_BASE),
+        json={"serviceAccountId": service_account_id, "roleId": admin_role_id},
         headers={"Authorization": f"Bearer {token}"},
         timeout=5,
     )
-    assert assign_resp.status_code == HTTPStatus.NO_CONTENT, assign_resp.text
+    assert assign_resp.status_code == HTTPStatus.CREATED, assign_resp.text
+
+    # find the editor assignment entry id from the service account detail
+    detail_resp = requests.get(
+        signoz.self.host_configs["8080"].get(f"{SERVICE_ACCOUNT_BASE}/{service_account_id}"),
+        headers={"Authorization": f"Bearer {token}"},
+        timeout=5,
+    )
+    assert detail_resp.status_code == HTTPStatus.OK, detail_resp.text
+    editor_entry_id = next(entry["id"] for entry in detail_resp.json()["data"]["serviceAccountRoles"] if entry["role"]["name"] == "signoz-editor")
 
     # remove editor role
-    editor_role_id = find_role_by_name(signoz, token, "signoz-editor")
     resp = requests.delete(
-        signoz.self.host_configs["8080"].get(f"{SERVICE_ACCOUNT_BASE}/{service_account_id}/roles/{editor_role_id}"),
+        signoz.self.host_configs["8080"].get(f"{SERVICE_ACCOUNT_ROLES_BASE}/{editor_entry_id}"),
         headers={"Authorization": f"Bearer {token}"},
         timeout=5,
     )
@@ -232,10 +242,18 @@ def test_remove_role_verify_access_lost(
     )
     assert resp.status_code == HTTPStatus.OK, resp.text
 
+    # find the admin assignment entry id from the service account detail
+    detail_resp = requests.get(
+        signoz.self.host_configs["8080"].get(f"{SERVICE_ACCOUNT_BASE}/{service_account_id}"),
+        headers={"Authorization": f"Bearer {token}"},
+        timeout=5,
+    )
+    assert detail_resp.status_code == HTTPStatus.OK, detail_resp.text
+    admin_entry_id = next(entry["id"] for entry in detail_resp.json()["data"]["serviceAccountRoles"] if entry["role"]["name"] == "signoz-admin")
+
     # remove admin role
-    admin_role_id = find_role_by_name(signoz, token, "signoz-admin")
     del_resp = requests.delete(
-        signoz.self.host_configs["8080"].get(f"{SERVICE_ACCOUNT_BASE}/{service_account_id}/roles/{admin_role_id}"),
+        signoz.self.host_configs["8080"].get(f"{SERVICE_ACCOUNT_ROLES_BASE}/{admin_entry_id}"),
         headers={"Authorization": f"Bearer {token}"},
         timeout=5,
     )

--- a/tests/integration/tests/serviceaccount/06_fga.py
+++ b/tests/integration/tests/serviceaccount/06_fga.py
@@ -16,6 +16,7 @@ from fixtures.auth import (
 from fixtures.role import find_role_by_name, transaction_group
 from fixtures.serviceaccount import (
     SERVICE_ACCOUNT_BASE,
+    SERVICE_ACCOUNT_ROLES_BASE,
     create_service_account,
     find_service_account_by_name,
 )
@@ -131,8 +132,8 @@ def test_write_forbidden_without_grant(
     assert resp.status_code == HTTPStatus.FORBIDDEN, f"update SA: expected 403, got {resp.status_code}: {resp.text}"
 
     resp = requests.post(
-        signoz.self.host_configs["8080"].get(f"{SERVICE_ACCOUNT_BASE}/{target_id}/roles"),
-        json={"id": viewer_role_id},
+        signoz.self.host_configs["8080"].get(SERVICE_ACCOUNT_ROLES_BASE),
+        json={"serviceAccountId": target_id, "roleId": viewer_role_id},
         headers={"Authorization": f"Bearer {token}"},
         timeout=5,
     )
@@ -220,17 +221,18 @@ def test_attach_detach_dual_scoped(
 
     # Both SA-attach (target id) and role-attach (editor) present -> allowed.
     resp = requests.post(
-        signoz.self.host_configs["8080"].get(f"{SERVICE_ACCOUNT_BASE}/{target_id}/roles"),
-        json={"id": editor_role_id},
+        signoz.self.host_configs["8080"].get(SERVICE_ACCOUNT_ROLES_BASE),
+        json={"serviceAccountId": target_id, "roleId": editor_role_id},
         headers={"Authorization": f"Bearer {token}"},
         timeout=5,
     )
-    assert resp.status_code == HTTPStatus.NO_CONTENT, f"assign editor to target: {resp.text}"
+    assert resp.status_code == HTTPStatus.CREATED, f"assign editor to target: {resp.text}"
+    editor_entry_id = resp.json()["data"]["id"]
 
     # SA-attach not held for the other SA id -> forbidden.
     resp = requests.post(
-        signoz.self.host_configs["8080"].get(f"{SERVICE_ACCOUNT_BASE}/{other_id}/roles"),
-        json={"id": editor_role_id},
+        signoz.self.host_configs["8080"].get(SERVICE_ACCOUNT_ROLES_BASE),
+        json={"serviceAccountId": other_id, "roleId": editor_role_id},
         headers={"Authorization": f"Bearer {token}"},
         timeout=5,
     )
@@ -238,8 +240,8 @@ def test_attach_detach_dual_scoped(
 
     # role-attach not held for viewer -> forbidden even on the target SA.
     resp = requests.post(
-        signoz.self.host_configs["8080"].get(f"{SERVICE_ACCOUNT_BASE}/{target_id}/roles"),
-        json={"id": viewer_role_id},
+        signoz.self.host_configs["8080"].get(SERVICE_ACCOUNT_ROLES_BASE),
+        json={"serviceAccountId": target_id, "roleId": viewer_role_id},
         headers={"Authorization": f"Bearer {token}"},
         timeout=5,
     )
@@ -247,7 +249,7 @@ def test_attach_detach_dual_scoped(
 
     # Both SA-detach (target id) and role-detach (editor) present -> remove allowed.
     resp = requests.delete(
-        signoz.self.host_configs["8080"].get(f"{SERVICE_ACCOUNT_BASE}/{target_id}/roles/{editor_role_id}"),
+        signoz.self.host_configs["8080"].get(f"{SERVICE_ACCOUNT_ROLES_BASE}/{editor_entry_id}"),
         headers={"Authorization": f"Bearer {token}"},
         timeout=5,
     )

--- a/tests/integration/tests/serviceaccount/06_fga.py
+++ b/tests/integration/tests/serviceaccount/06_fga.py
@@ -16,7 +16,6 @@ from fixtures.auth import (
 from fixtures.role import find_role_by_name, transaction_group
 from fixtures.serviceaccount import (
     SERVICE_ACCOUNT_BASE,
-    SERVICE_ACCOUNT_ROLES_BASE,
     create_service_account,
     find_service_account_by_name,
 )
@@ -132,7 +131,7 @@ def test_write_forbidden_without_grant(
     assert resp.status_code == HTTPStatus.FORBIDDEN, f"update SA: expected 403, got {resp.status_code}: {resp.text}"
 
     resp = requests.post(
-        signoz.self.host_configs["8080"].get(SERVICE_ACCOUNT_ROLES_BASE),
+        signoz.self.host_configs["8080"].get("/api/v1/service_account_roles"),
         json={"serviceAccountId": target_id, "roleId": viewer_role_id},
         headers={"Authorization": f"Bearer {token}"},
         timeout=5,
@@ -221,7 +220,7 @@ def test_attach_detach_dual_scoped(
 
     # Both SA-attach (target id) and role-attach (editor) present -> allowed.
     resp = requests.post(
-        signoz.self.host_configs["8080"].get(SERVICE_ACCOUNT_ROLES_BASE),
+        signoz.self.host_configs["8080"].get("/api/v1/service_account_roles"),
         json={"serviceAccountId": target_id, "roleId": editor_role_id},
         headers={"Authorization": f"Bearer {token}"},
         timeout=5,
@@ -231,7 +230,7 @@ def test_attach_detach_dual_scoped(
 
     # SA-attach not held for the other SA id -> forbidden.
     resp = requests.post(
-        signoz.self.host_configs["8080"].get(SERVICE_ACCOUNT_ROLES_BASE),
+        signoz.self.host_configs["8080"].get("/api/v1/service_account_roles"),
         json={"serviceAccountId": other_id, "roleId": editor_role_id},
         headers={"Authorization": f"Bearer {token}"},
         timeout=5,
@@ -240,7 +239,7 @@ def test_attach_detach_dual_scoped(
 
     # role-attach not held for viewer -> forbidden even on the target SA.
     resp = requests.post(
-        signoz.self.host_configs["8080"].get(SERVICE_ACCOUNT_ROLES_BASE),
+        signoz.self.host_configs["8080"].get("/api/v1/service_account_roles"),
         json={"serviceAccountId": target_id, "roleId": viewer_role_id},
         headers={"Authorization": f"Bearer {token}"},
         timeout=5,
@@ -249,7 +248,7 @@ def test_attach_detach_dual_scoped(
 
     # Both SA-detach (target id) and role-detach (editor) present -> remove allowed.
     resp = requests.delete(
-        signoz.self.host_configs["8080"].get(f"{SERVICE_ACCOUNT_ROLES_BASE}/{editor_entry_id}"),
+        signoz.self.host_configs["8080"].get(f"/api/v1/service_account_roles/{editor_entry_id}"),
         headers={"Authorization": f"Bearer {token}"},
         timeout=5,
     )


### PR DESCRIPTION
#### Description

- Moves the `serviceaccount` integration fixtures and suites off the deprecated nested `/api/v1/service_accounts/{id}/roles` endpoints onto `/api/v1/service_account_roles`.
- Roles are assigned via `POST /api/v1/service_account_roles` (201) and revoked via `DELETE /api/v1/service_account_roles/{id}` (204), reading join-row ids from the service account detail.

#### Additional Information

- Part of SigNoz/platform-pod#2919 — the integration-test half of the consumer migration. The frontend migration and the deprecated-endpoint removal are separate PRs.