### PR TITLE
fix: support for query type in cache fingerprint

### DIFF
--- a/pkg/querier/builder_query.go
+++ b/pkg/querier/builder_query.go
@@ -29,6 +29,7 @@ type builderQuery[T any] struct {
 	telemetryStore telemetrystore.TelemetryStore
 	orgID          valuer.UUID
 	stmtBuilder    qbtypes.StatementBuilder[T]
+	queryType      qbtypes.QueryType
 	spec           qbtypes.QueryBuilderQuery[T]
 	variables      map[string]qbtypes.VariableItem
 
@@ -51,6 +52,7 @@ func newBuilderQuery[T any](
 	telemetryStore telemetrystore.TelemetryStore,
 	orgID valuer.UUID,
 	stmtBuilder qbtypes.StatementBuilder[T],
+	queryType qbtypes.QueryType,
 	spec qbtypes.QueryBuilderQuery[T],
 	tr qbtypes.TimeRange,
 	kind qbtypes.RequestType,
@@ -62,6 +64,7 @@ func newBuilderQuery[T any](
 		telemetryStore: telemetryStore,
 		orgID:          orgID,
 		stmtBuilder:    stmtBuilder,
+		queryType:      queryType,
 		spec:           spec,
 		variables:      variables,
 		fromMS:         tr.From,
@@ -81,7 +84,7 @@ func (q *builderQuery[T]) Fingerprint() string {
 
 	// Create a deterministic fingerprint for builder queries
 	// This needs to include all fields that affect the query results
-	parts := []string{"builder"}
+	parts := []string{q.queryType.StringValue()}
 
 	// Add signal type
 	parts = append(parts, fmt.Sprintf("signal=%s", q.spec.Signal.StringValue()))

--- a/pkg/querier/builder_query_test.go
+++ b/pkg/querier/builder_query_test.go
@@ -3,6 +3,7 @@ package querier
 import (
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/SigNoz/signoz/pkg/querybuilder"
 	qbtypes "github.com/SigNoz/signoz/pkg/types/querybuildertypes/querybuildertypesv5"
@@ -20,7 +21,8 @@ func TestBuilderQueryFingerprint(t *testing.T) {
 		{
 			name: "fingerprint includes shiftby when ShiftBy field is set",
 			query: &builderQuery[qbtypes.MetricAggregation]{
-				kind: qbtypes.RequestTypeTimeSeries,
+				queryType: qbtypes.QueryTypeBuilder,
+				kind:      qbtypes.RequestTypeTimeSeries,
 				spec: qbtypes.QueryBuilderQuery[qbtypes.MetricAggregation]{
 					Signal:  telemetrytypes.SignalMetrics,
 					ShiftBy: 3600,
@@ -40,7 +42,8 @@ func TestBuilderQueryFingerprint(t *testing.T) {
 		{
 			name: "fingerprint includes shiftby but not other functions",
 			query: &builderQuery[qbtypes.MetricAggregation]{
-				kind: qbtypes.RequestTypeTimeSeries,
+				queryType: qbtypes.QueryTypeBuilder,
+				kind:      qbtypes.RequestTypeTimeSeries,
 				spec: qbtypes.QueryBuilderQuery[qbtypes.MetricAggregation]{
 					Signal:  telemetrytypes.SignalMetrics,
 					ShiftBy: 3600,
@@ -63,7 +66,8 @@ func TestBuilderQueryFingerprint(t *testing.T) {
 		{
 			name: "no shiftby in fingerprint when ShiftBy is zero",
 			query: &builderQuery[qbtypes.MetricAggregation]{
-				kind: qbtypes.RequestTypeTimeSeries,
+				queryType: qbtypes.QueryTypeBuilder,
+				kind:      qbtypes.RequestTypeTimeSeries,
 				spec: qbtypes.QueryBuilderQuery[qbtypes.MetricAggregation]{
 					Signal:  telemetrytypes.SignalMetrics,
 					ShiftBy: 0,
@@ -92,6 +96,29 @@ func TestBuilderQueryFingerprint(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestBuilderQueryFingerprintQueryType(t *testing.T) {
+	spec := qbtypes.QueryBuilderQuery[qbtypes.TraceAggregation]{
+		Signal:       telemetrytypes.SignalTraces,
+		StepInterval: qbtypes.Step{Duration: 60 * time.Second},
+		Aggregations: []qbtypes.TraceAggregation{{Expression: "count()"}},
+		Filter:       &qbtypes.Filter{Expression: "gen_ai.request.model EXISTS"},
+	}
+	regular := &builderQuery[qbtypes.TraceAggregation]{
+		queryType: qbtypes.QueryTypeBuilder,
+		kind:      qbtypes.RequestTypeTimeSeries,
+		spec:      spec,
+	}
+	ai := &builderQuery[qbtypes.TraceAggregation]{
+		queryType: qbtypes.QueryTypeBuilderAI,
+		kind:      qbtypes.RequestTypeTimeSeries,
+		spec:      spec,
+	}
+
+	assert.True(t, strings.HasPrefix(regular.Fingerprint(), qbtypes.QueryTypeBuilder.StringValue()+"&"))
+	assert.True(t, strings.HasPrefix(ai.Fingerprint(), qbtypes.QueryTypeBuilderAI.StringValue()+"&"))
+	assert.NotEqual(t, regular.Fingerprint(), ai.Fingerprint())
 }
 
 func TestMakeBucketsOrder(t *testing.T) {

--- a/pkg/querier/querier.go
+++ b/pkg/querier/querier.go
@@ -305,7 +305,7 @@ func (q *querier) buildQueries(
 			}
 			spec.ShiftBy = extractShiftFromBuilderQuery(spec)
 			timeRange := adjustTimeRangeForShift(spec, qbtypes.TimeRange{From: req.Start, To: req.End}, req.RequestType)
-			bq := newBuilderQuery(q.logger, q.telemetryStore, orgID, q.aiTraceStmtBuilder, spec, timeRange, req.RequestType, tmplVars, builderConfig{})
+			bq := newBuilderQuery(q.logger, q.telemetryStore, orgID, q.aiTraceStmtBuilder, qbtypes.QueryTypeBuilderAI, spec, timeRange, req.RequestType, tmplVars, builderConfig{})
 			queries[spec.Name] = bq
 			steps[spec.Name] = spec.StepInterval
 		case qbtypes.QueryTypeBuilder:
@@ -313,7 +313,7 @@ func (q *querier) buildQueries(
 			case qbtypes.QueryBuilderQuery[qbtypes.TraceAggregation]:
 				spec.ShiftBy = extractShiftFromBuilderQuery(spec)
 				timeRange := adjustTimeRangeForShift(spec, qbtypes.TimeRange{From: req.Start, To: req.End}, req.RequestType)
-				bq := newBuilderQuery(q.logger, q.telemetryStore, orgID, q.traceStmtBuilder, spec, timeRange, req.RequestType, tmplVars, builderConfig{})
+				bq := newBuilderQuery(q.logger, q.telemetryStore, orgID, q.traceStmtBuilder, qbtypes.QueryTypeBuilder, spec, timeRange, req.RequestType, tmplVars, builderConfig{})
 				queries[spec.Name] = bq
 				steps[spec.Name] = spec.StepInterval
 			case qbtypes.QueryBuilderQuery[qbtypes.LogAggregation]:
@@ -323,7 +323,7 @@ func (q *querier) buildQueries(
 				if spec.Source == telemetrytypes.SourceAudit {
 					stmtBuilder = q.auditStmtBuilder
 				}
-				bq := newBuilderQuery(q.logger, q.telemetryStore, orgID, stmtBuilder, spec, timeRange, req.RequestType, tmplVars, q.builderConfig)
+				bq := newBuilderQuery(q.logger, q.telemetryStore, orgID, stmtBuilder, qbtypes.QueryTypeBuilder, spec, timeRange, req.RequestType, tmplVars, q.builderConfig)
 				queries[spec.Name] = bq
 				steps[spec.Name] = spec.StepInterval
 			case qbtypes.QueryBuilderQuery[qbtypes.MetricAggregation]:
@@ -340,9 +340,9 @@ func (q *querier) buildQueries(
 
 				if spec.Source == telemetrytypes.SourceMeter {
 					event.Source = telemetrytypes.SourceMeter.StringValue()
-					bq = newBuilderQuery(q.logger, q.telemetryStore, orgID, q.meterStmtBuilder, spec, timeRange, req.RequestType, tmplVars, builderConfig{})
+					bq = newBuilderQuery(q.logger, q.telemetryStore, orgID, q.meterStmtBuilder, qbtypes.QueryTypeBuilder, spec, timeRange, req.RequestType, tmplVars, builderConfig{})
 				} else {
-					bq = newBuilderQuery(q.logger, q.telemetryStore, orgID, q.metricStmtBuilder, spec, timeRange, req.RequestType, tmplVars, builderConfig{})
+					bq = newBuilderQuery(q.logger, q.telemetryStore, orgID, q.metricStmtBuilder, qbtypes.QueryTypeBuilder, spec, timeRange, req.RequestType, tmplVars, builderConfig{})
 				}
 
 				queries[spec.Name] = bq
@@ -618,7 +618,7 @@ func (q *querier) QueryRawStream(ctx context.Context, orgID valuer.UUID, req *qb
 			if spec.Source == telemetrytypes.SourceAudit {
 				liveTailStmtBuilder = q.auditStmtBuilder
 			}
-			bq := newBuilderQuery(q.logger, q.telemetryStore, orgID, liveTailStmtBuilder, spec, timeRange, req.RequestType, map[string]qbtypes.VariableItem{
+			bq := newBuilderQuery(q.logger, q.telemetryStore, orgID, liveTailStmtBuilder, qbtypes.QueryTypeBuilder, spec, timeRange, req.RequestType, map[string]qbtypes.VariableItem{
 				"id": {
 					Value: updatedLogID,
 				},
@@ -941,8 +941,9 @@ func (q *querier) createRangedQuery(_ valuer.UUID, originalQuery qbtypes.Query, 
 		specCopy := qt.spec.Copy()
 		specCopy.ShiftBy = extractShiftFromBuilderQuery(specCopy)
 		adjustedTimeRange := adjustTimeRangeForShift(specCopy, timeRange, qt.kind)
-		// reuse the original query's statement builder so an AI query keeps its AI builder
-		return newBuilderQuery(q.logger, q.telemetryStore, qt.orgID, qt.stmtBuilder, specCopy, adjustedTimeRange, qt.kind, qt.variables, builderConfig{})
+		// reuse the original query's statement builder and type so an AI query
+		// keeps its AI builder and cache key
+		return newBuilderQuery(q.logger, q.telemetryStore, qt.orgID, qt.stmtBuilder, qt.queryType, specCopy, adjustedTimeRange, qt.kind, qt.variables, qt.builderConfig)
 
 	case *builderQuery[qbtypes.LogAggregation]:
 		specCopy := qt.spec.Copy()
@@ -952,16 +953,16 @@ func (q *querier) createRangedQuery(_ valuer.UUID, originalQuery qbtypes.Query, 
 		if qt.spec.Source == telemetrytypes.SourceAudit {
 			shiftStmtBuilder = q.auditStmtBuilder
 		}
-		return newBuilderQuery(q.logger, q.telemetryStore, qt.orgID, shiftStmtBuilder, specCopy, adjustedTimeRange, qt.kind, qt.variables, q.builderConfig)
+		return newBuilderQuery(q.logger, q.telemetryStore, qt.orgID, shiftStmtBuilder, qt.queryType, specCopy, adjustedTimeRange, qt.kind, qt.variables, q.builderConfig)
 
 	case *builderQuery[qbtypes.MetricAggregation]:
 		specCopy := qt.spec.Copy()
 		specCopy.ShiftBy = extractShiftFromBuilderQuery(specCopy)
 		adjustedTimeRange := adjustTimeRangeForShift(specCopy, timeRange, qt.kind)
 		if qt.spec.Source == telemetrytypes.SourceMeter {
-			return newBuilderQuery(q.logger, q.telemetryStore, qt.orgID, q.meterStmtBuilder, specCopy, adjustedTimeRange, qt.kind, qt.variables, builderConfig{})
+			return newBuilderQuery(q.logger, q.telemetryStore, qt.orgID, q.meterStmtBuilder, qt.queryType, specCopy, adjustedTimeRange, qt.kind, qt.variables, builderConfig{})
 		}
-		return newBuilderQuery(q.logger, q.telemetryStore, qt.orgID, q.metricStmtBuilder, specCopy, adjustedTimeRange, qt.kind, qt.variables, builderConfig{})
+		return newBuilderQuery(q.logger, q.telemetryStore, qt.orgID, q.metricStmtBuilder, qt.queryType, specCopy, adjustedTimeRange, qt.kind, qt.variables, builderConfig{})
 	case *traceOperatorQuery:
 		specCopy := qt.spec.Copy()
 		return &traceOperatorQuery{

--- a/pkg/querier/querier.go
+++ b/pkg/querier/querier.go
@@ -305,7 +305,7 @@ func (q *querier) buildQueries(
 			}
 			spec.ShiftBy = extractShiftFromBuilderQuery(spec)
 			timeRange := adjustTimeRangeForShift(spec, qbtypes.TimeRange{From: req.Start, To: req.End}, req.RequestType)
-			bq := newBuilderQuery(q.logger, q.telemetryStore, orgID, q.aiTraceStmtBuilder, qbtypes.QueryTypeBuilderAI, spec, timeRange, req.RequestType, tmplVars, builderConfig{})
+			bq := newBuilderQuery(q.logger, q.telemetryStore, orgID, q.aiTraceStmtBuilder, query.Type, spec, timeRange, req.RequestType, tmplVars, builderConfig{})
 			queries[spec.Name] = bq
 			steps[spec.Name] = spec.StepInterval
 		case qbtypes.QueryTypeBuilder:
@@ -313,7 +313,7 @@ func (q *querier) buildQueries(
 			case qbtypes.QueryBuilderQuery[qbtypes.TraceAggregation]:
 				spec.ShiftBy = extractShiftFromBuilderQuery(spec)
 				timeRange := adjustTimeRangeForShift(spec, qbtypes.TimeRange{From: req.Start, To: req.End}, req.RequestType)
-				bq := newBuilderQuery(q.logger, q.telemetryStore, orgID, q.traceStmtBuilder, qbtypes.QueryTypeBuilder, spec, timeRange, req.RequestType, tmplVars, builderConfig{})
+				bq := newBuilderQuery(q.logger, q.telemetryStore, orgID, q.traceStmtBuilder, query.Type, spec, timeRange, req.RequestType, tmplVars, builderConfig{})
 				queries[spec.Name] = bq
 				steps[spec.Name] = spec.StepInterval
 			case qbtypes.QueryBuilderQuery[qbtypes.LogAggregation]:
@@ -323,7 +323,7 @@ func (q *querier) buildQueries(
 				if spec.Source == telemetrytypes.SourceAudit {
 					stmtBuilder = q.auditStmtBuilder
 				}
-				bq := newBuilderQuery(q.logger, q.telemetryStore, orgID, stmtBuilder, qbtypes.QueryTypeBuilder, spec, timeRange, req.RequestType, tmplVars, q.builderConfig)
+				bq := newBuilderQuery(q.logger, q.telemetryStore, orgID, stmtBuilder, query.Type, spec, timeRange, req.RequestType, tmplVars, q.builderConfig)
 				queries[spec.Name] = bq
 				steps[spec.Name] = spec.StepInterval
 			case qbtypes.QueryBuilderQuery[qbtypes.MetricAggregation]:
@@ -340,9 +340,9 @@ func (q *querier) buildQueries(
 
 				if spec.Source == telemetrytypes.SourceMeter {
 					event.Source = telemetrytypes.SourceMeter.StringValue()
-					bq = newBuilderQuery(q.logger, q.telemetryStore, orgID, q.meterStmtBuilder, qbtypes.QueryTypeBuilder, spec, timeRange, req.RequestType, tmplVars, builderConfig{})
+					bq = newBuilderQuery(q.logger, q.telemetryStore, orgID, q.meterStmtBuilder, query.Type, spec, timeRange, req.RequestType, tmplVars, builderConfig{})
 				} else {
-					bq = newBuilderQuery(q.logger, q.telemetryStore, orgID, q.metricStmtBuilder, qbtypes.QueryTypeBuilder, spec, timeRange, req.RequestType, tmplVars, builderConfig{})
+					bq = newBuilderQuery(q.logger, q.telemetryStore, orgID, q.metricStmtBuilder, query.Type, spec, timeRange, req.RequestType, tmplVars, builderConfig{})
 				}
 
 				queries[spec.Name] = bq
@@ -618,7 +618,7 @@ func (q *querier) QueryRawStream(ctx context.Context, orgID valuer.UUID, req *qb
 			if spec.Source == telemetrytypes.SourceAudit {
 				liveTailStmtBuilder = q.auditStmtBuilder
 			}
-			bq := newBuilderQuery(q.logger, q.telemetryStore, orgID, liveTailStmtBuilder, qbtypes.QueryTypeBuilder, spec, timeRange, req.RequestType, map[string]qbtypes.VariableItem{
+			bq := newBuilderQuery(q.logger, q.telemetryStore, orgID, liveTailStmtBuilder, query.Type, spec, timeRange, req.RequestType, map[string]qbtypes.VariableItem{
 				"id": {
 					Value: updatedLogID,
 				},


### PR DESCRIPTION
#### Description
We have added a new query type "builder_ai_query" , now previously the cache fingerprint didn't consider type because of which ai query cache and builder query cache might result in same fingerprint leading to cache issue.

#### Issues closed by this PR
Part of https://github.com/SigNoz/engineering-pod/issues/5602 and https://github.com/SigNoz/engineering-pod/issues/5603
