### PR TITLE
feat: configurable table row limit (visibleRows)

### DIFF
--- a/frontend/src/container/GridTableComponent/types.ts
+++ b/frontend/src/container/GridTableComponent/types.ts
@@ -33,6 +33,7 @@ export type GridTableComponentProps = {
 	panelType?: PANEL_TYPES;
 	queryRangeRequest?: QueryRangeRequestV5;
 	hiddenColumns?: string[];
+	visibleRows?: number | 'auto';
 } & Pick<LogsExplorerTableProps, 'data'> &
 	Omit<TableProps<RowData>, 'columns' | 'dataSource'>;
 

--- a/frontend/src/container/PanelWrapper/TablePanelWrapper.tsx
+++ b/frontend/src/container/PanelWrapper/TablePanelWrapper.tsx
@@ -44,6 +44,7 @@ function TablePanelWrapper({
 			queryRangeRequest={queryRangeRequest}
 			decimalPrecision={widget.decimalPrecision}
 			hiddenColumns={widget.hiddenColumns}
+				visibleRows={widget.visibleRows}
 			{...GRID_TABLE_CONFIG}
 		/>
 	);

--- a/frontend/src/container/QueryTable/QueryTable.intefaces.ts
+++ b/frontend/src/container/QueryTable/QueryTable.intefaces.ts
@@ -30,4 +30,5 @@ export type QueryTableProps = Omit<
 	contextLinks?: ContextLinksData;
 	panelType?: PANEL_TYPES;
 	queryRangeRequest?: QueryRangeRequestV5;
+	visibleRows?: number | 'auto';
 };

--- a/frontend/src/container/QueryTable/QueryTable.tsx
+++ b/frontend/src/container/QueryTable/QueryTable.tsx
@@ -31,6 +31,7 @@ export function QueryTable({
 	columnWidths,
 	onColumnWidthsChange,
 	panelType,
+	visibleRows,
 	...props
 }: QueryTableProps): JSX.Element {
 	const { isDownloadEnabled = false, fileName = '' } = downloadOption || {};
@@ -133,7 +134,7 @@ export function QueryTable({
 	);
 
 	const paginationConfig = {
-		pageSize: 10,
+		pageSize: visibleRows === 'auto' ? 9999 : (typeof visibleRows === 'number' ? visibleRows : 10),
 		showSizeChanger: false,
 		hideOnSinglePage: true,
 	};

--- a/frontend/src/types/api/dashboard/getAll.ts
+++ b/frontend/src/types/api/dashboard/getAll.ts
@@ -142,6 +142,8 @@ export interface IBaseWidget {
 	lineStyle?: LineStyle;
 	fillMode?: FillMode;
 	spanGaps?: boolean | number;
+	/** Number of visible rows in table panels. 'auto' shows all rows. Default: 10 */
+	visibleRows?: number | 'auto';
 }
 export interface Widgets extends IBaseWidget {
 	query: Query;


### PR DESCRIPTION
## Summary

Add a `visibleRows` configuration option to table panels that controls how many rows are visible without scrolling. Previously hardcoded to 10 rows regardless of panel height.

## Changes

- Add `visibleRows?: number | 'auto'` field to `IBaseWidget` type
- Add prop to `GridTableComponentProps` and `QueryTableProps`
- Pass `visibleRows` through the component chain to `QueryTable`
- `QueryTable` uses it as `pageSize` in pagination config
- When set to `'auto'`, pagination is disabled (all rows shown)
- Default remains 10 rows for backward compatibility

## Use Case

When monitoring 23 services in a table panel, the default 10-row limit forces scrolling. Setting `visibleRows: 'auto'` or `visibleRows: 25` allows the table to fill available space.

## Configuration

```json
{
  "panelTypes": "table",
  "visibleRows": "auto"
}
```

## Related

Closes https://github.com/SigNoz/signoz/discussions/11691