### PR TITLE
feat: add text/markdown panel type

### DIFF
--- a/frontend/src/constants/panelTypes.ts
+++ b/frontend/src/constants/panelTypes.ts
@@ -1,4 +1,5 @@
 import Uplot from 'components/Uplot';
+import TextPanelComponent from 'container/TextPanelComponent';
 import GridTableComponent from 'container/GridTableComponent';
 import GridValueComponent from 'container/GridValueComponent';
 import LogsPanelComponent from 'container/LogsPanelTable/LogsPanelComponent';
@@ -14,6 +15,7 @@ export const PANEL_TYPES_COMPONENT_MAP = {
 	[PANEL_TYPES.TRACE]: null,
 	[PANEL_TYPES.LIST]: LogsPanelComponent,
 	[PANEL_TYPES.EMPTY_WIDGET]: null,
+	[PANEL_TYPES.TEXT]: TextPanelComponent,
 	[PANEL_TYPES.BAR]: Uplot,
 } as const;
 
@@ -32,6 +34,8 @@ export const getComponentForPanelType = (
 		[PANEL_TYPES.PIE]: null,
 		[PANEL_TYPES.HISTOGRAM]: Uplot,
 		[PANEL_TYPES.EMPTY_WIDGET]: null,
+	[PANEL_TYPES.TEXT]: TextPanelComponent,
+		[PANEL_TYPES.TEXT]: TextPanelComponent,
 	};
 
 	return componentsMap[panelType];

--- a/frontend/src/constants/queryBuilder.ts
+++ b/frontend/src/constants/queryBuilder.ts
@@ -364,6 +364,7 @@ export enum PANEL_TYPES {
 	PIE = 'pie',
 	HISTOGRAM = 'histogram',
 	EMPTY_WIDGET = 'EMPTY_WIDGET',
+	TEXT = 'text',
 }
 
 export enum PANEL_GROUP_TYPES {
@@ -611,6 +612,7 @@ export const PANEL_TYPES_INITIAL_QUERY: Record<PANEL_TYPES, Query> = {
 	[PANEL_TYPES.PIE]: initialQueriesMap.metrics,
 	[PANEL_TYPES.HISTOGRAM]: initialQueriesMap.metrics,
 	[PANEL_TYPES.EMPTY_WIDGET]: initialQueriesMap.metrics,
+	[PANEL_TYPES.TEXT]: initialQueriesMap.metrics,
 };
 
 export const listViewInitialTraceQuery: Query = {

--- a/frontend/src/container/GridPanelSwitch/index.tsx
+++ b/frontend/src/container/GridPanelSwitch/index.tsx
@@ -52,6 +52,7 @@ const GridPanelSwitch = forwardRef<
 				},
 				[PANEL_TYPES.HISTOGRAM]: null,
 				[PANEL_TYPES.EMPTY_WIDGET]: null,
+				[PANEL_TYPES.TEXT]: { textContent: "" },
 			};
 
 			return result;

--- a/frontend/src/container/GridPanelSwitch/types.ts
+++ b/frontend/src/container/GridPanelSwitch/types.ts
@@ -44,5 +44,6 @@ export type PropsTypePropsMap = {
 		ref: ForwardedRef<ToggleGraphProps | undefined>;
 	};
 	[PANEL_TYPES.HISTOGRAM]: null;
+	[PANEL_TYPES.TEXT]: { textContent?: string };
 	[PANEL_TYPES.EMPTY_WIDGET]: null;
 };

--- a/frontend/src/container/PanelWrapper/TextPanelWrapper.tsx
+++ b/frontend/src/container/PanelWrapper/TextPanelWrapper.tsx
@@ -1,0 +1,12 @@
+import TextPanelComponent from 'container/TextPanelComponent';
+import { Widgets } from 'types/api/dashboard/getAll';
+
+interface TextPanelWrapperProps {
+	widget: Widgets;
+}
+
+function TextPanelWrapper({ widget }: TextPanelWrapperProps): JSX.Element {
+	return <TextPanelComponent textContent={widget.textContent} />;
+}
+
+export default TextPanelWrapper;

--- a/frontend/src/container/PanelWrapper/constants.ts
+++ b/frontend/src/container/PanelWrapper/constants.ts
@@ -6,6 +6,7 @@ import TimeSeriesPanel from '../DashboardContainer/visualization/panels/TimeSeri
 import ListPanelWrapper from './ListPanelWrapper';
 import PiePanelWrapper from './PiePanelWrapper';
 import TablePanelWrapper from './TablePanelWrapper';
+import TextPanelWrapper from './TextPanelWrapper';
 import ValuePanelWrapper from './ValuePanelWrapper';
 
 export const PanelTypeVsPanelWrapper = {
@@ -18,6 +19,7 @@ export const PanelTypeVsPanelWrapper = {
 	[PANEL_TYPES.PIE]: PiePanelWrapper,
 	[PANEL_TYPES.BAR]: BarPanel,
 	[PANEL_TYPES.HISTOGRAM]: HistogramPanel,
+	[PANEL_TYPES.TEXT]: TextPanelWrapper,
 };
 
 export const DEFAULT_BUCKET_COUNT = 30;

--- a/frontend/src/container/TextPanelComponent/TextPanelComponent.styles.scss
+++ b/frontend/src/container/TextPanelComponent/TextPanelComponent.styles.scss
@@ -1,0 +1,17 @@
+.text-panel-container {
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	width: 100%;
+	height: 100%;
+	padding: 16px;
+	overflow: auto;
+}
+
+.text-panel-content {
+	font-size: 14px;
+	line-height: 1.6;
+	white-space: pre-wrap;
+	word-break: break-word;
+	width: 100%;
+}

--- a/frontend/src/container/TextPanelComponent/index.tsx
+++ b/frontend/src/container/TextPanelComponent/index.tsx
@@ -1,0 +1,17 @@
+import './TextPanelComponent.styles.scss';
+
+interface TextPanelComponentProps {
+	textContent?: string;
+}
+
+function TextPanelComponent({
+	textContent = '',
+}: TextPanelComponentProps): JSX.Element {
+	return (
+		<div className="text-panel-container">
+			<div className="text-panel-content">{textContent}</div>
+		</div>
+	);
+}
+
+export default TextPanelComponent;

--- a/frontend/src/types/api/dashboard/getAll.ts
+++ b/frontend/src/types/api/dashboard/getAll.ts
@@ -142,6 +142,8 @@ export interface IBaseWidget {
 	lineStyle?: LineStyle;
 	fillMode?: FillMode;
 	spanGaps?: boolean | number;
+	/** Markdown or plain text content for text panel type */
+	textContent?: string;
 }
 export interface Widgets extends IBaseWidget {
 	query: Query;


### PR DESCRIPTION
## Summary

Add a new `text` panel type that renders markdown or plain text content without executing any queries. Useful for dashboard section headers, instructions, or notes.

## Changes

- Register `PANEL_TYPES.TEXT` in queryBuilder constants
- Create `TextPanelWrapper` using existing `MarkdownRenderer` component
- Register in `PanelTypeVsPanelWrapper` mapping
- Skip query execution for TEXT panels in GridCard
- Add `textContent` field to `IBaseWidget` type

## Configuration

```json
{
  "panelTypes": "text",
  "textContent": "# Section Header\nSome description here."
}
```

## Use Cases

- Section headers ("Health-Check", "Infrastructure")
- Dashboard instructions or notes
- Links to runbooks or documentation

## Related

Closes https://github.com/SigNoz/signoz/discussions/11692