### PR TITLE
fix(alertmanager): remove threading from google chat notifier

### DIFF
--- a/pkg/alertmanager/alertmanagernotify/googlechat/googlechat.go
+++ b/pkg/alertmanager/alertmanagernotify/googlechat/googlechat.go
@@ -7,7 +7,6 @@ import (
 	"fmt"
 	"log/slog"
 	"net/http"
-	"net/url"
 	"unicode/utf8"
 
 	"github.com/SigNoz/signoz/pkg/alertmanager/alertmanagertemplate"
@@ -186,18 +185,7 @@ func (n *Notifier) Notify(ctx context.Context, alerts ...*types.Alert) (bool, er
 		}
 	}
 
-	// Thread same-rule alerts together: threadKey is a stable hash of the
-	// alert group key. Changing a rule's grouping starts a new thread.
-	u, err := url.Parse(n.conf.WebhookURL.String())
-	if err != nil {
-		return false, errors.WrapInternalf(err, errors.CodeInternal, "parse google chat webhook url")
-	}
-	q := u.Query()
-	q.Set("threadKey", key.Hash())
-	q.Set("messageReplyOption", "REPLY_MESSAGE_FALLBACK_TO_NEW_THREAD")
-	u.RawQuery = q.Encode()
-
-	resp, err := notify.PostJSON(ctx, n.client, u.String(), buf) //nolint:bodyclose
+	resp, err := notify.PostJSON(ctx, n.client, n.conf.WebhookURL.String(), buf) //nolint:bodyclose
 	if err != nil {
 		return true, notify.RedactURL(err)
 	}

--- a/pkg/alertmanager/alertmanagernotify/googlechat/googlechat_test.go
+++ b/pkg/alertmanager/alertmanagernotify/googlechat/googlechat_test.go
@@ -245,7 +245,7 @@ func TestGoogleChatMessageSizeLimit(t *testing.T) {
 	assert.LessOrEqual(t, bodyLen, maxMessageBytes, "posted body must be within the size limit")
 }
 
-func TestGoogleChatThreading(t *testing.T) {
+func TestGoogleChatWebhookURLVerbatim(t *testing.T) {
 	var query url.Values
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		query = r.URL.Query()
@@ -253,25 +253,11 @@ func TestGoogleChatThreading(t *testing.T) {
 	}))
 	defer server.Close()
 
-	cases := []struct{ name, groupKey string }{
-		{"rule a", "{ruleId=\"aaa\"}"},
-		{"rule b", "{ruleId=\"bbb\"}"},
-	}
-	seen := map[string]string{}
-	for _, c := range cases {
-		t.Run(c.name, func(t *testing.T) {
-			n := newTestNotifier(t, server.URL, "T", "")
-			ctx := notify.WithGroupKey(context.Background(), c.groupKey)
-			_, err := n.Notify(ctx, newTestAlerts("X")...)
-			require.NoError(t, err)
+	n := newTestNotifier(t, server.URL+"?key=abc&token=xyz", "T", "")
+	_, err := n.Notify(newTestContext(), newTestAlerts("X")...)
+	require.NoError(t, err)
 
-			assert.Equal(t, "REPLY_MESSAGE_FALLBACK_TO_NEW_THREAD", query.Get("messageReplyOption"))
-			threadKey := query.Get("threadKey")
-			assert.Equal(t, notify.Key(c.groupKey).Hash(), threadKey, "threadKey must be the group key hash")
-			seen[c.name] = threadKey
-		})
-	}
-	assert.NotEqual(t, seen["rule a"], seen["rule b"], "distinct group keys must yield distinct threadKeys")
+	assert.Equal(t, url.Values{"key": {"abc"}, "token": {"xyz"}}, query, "configured webhook URL must be posted verbatim, with no params added")
 }
 
 func TestGoogleChatCustomTemplateMarkdown(t *testing.T) {


### PR DESCRIPTION
#### Description

- Remove `threadKey` + `messageReplyOption` query params from the Google Chat notifier; every notification now posts as a standalone message instead of a threaded reply.
- Post to the user-configured webhook URL verbatim (no parse/re-encode of its query string).
- Replace `TestGoogleChatThreading` with `TestGoogleChatWebhookURLVerbatim`, asserting the webhook's own params (`key`, `token`) pass through untouched and nothing is appended.

#### Issues closed by this PR

Closes SigNoz/pulse-pod#285

#### Additional Information

- Context: threading behavior wasn't planned holistically (SigNoz/pulse-pod#281); it will return later as a consistent, opt-in feature across all chat integrations (Slack, MS Teams, Google Chat, etc.).
- No config/migration impact: `threadKey` was never user-facing config. Existing channels simply start receiving new messages (no threaded replies on refire) from the next evaluation cycle after deploy.
- `notify.ExtractGroupKey` is intentionally kept — still used for the debug log, consistent with other notifiers.