### PR TITLE
perf(querier): classify time-series columns once per query

### DIFF
--- a/pkg/querier/consume.go
+++ b/pkg/querier/consume.go
@@ -7,7 +7,6 @@ import (
 	"reflect"
 	"regexp"
 	"slices"
-	"sort"
 	"strconv"
 	"strings"
 	"time"
@@ -91,10 +90,148 @@ func consume(rows driver.Rows, kind qbtypes.RequestType, queryWindow *qbtypes.Ti
 	return payload, err
 }
 
+// labelPair is a label held in per-row scratch, so that rows landing in an existing series do not
+// allocate label objects only to drop them. It keeps the value unboxed — an any field would put
+// every label of every row on the heap — and boxes once, for the row that creates the series.
+type labelPair struct {
+	name    string
+	display string // the form the series key is built from
+	num     float64
+	class   tsColumnClass
+}
+
+func materialiseLabels(pairs []labelPair) []*qbtypes.Label {
+	labels := make([]*qbtypes.Label, len(pairs))
+	for i, pair := range pairs {
+		var value any = pair.display
+		switch pair.class {
+		case tsColumnNumeric:
+			value = pair.num
+		case tsColumnBool:
+			value = pair.num != 0
+		}
+		labels[i] = &qbtypes.Label{
+			Key:   telemetrytypes.TelemetryFieldKey{Name: pair.name},
+			Value: value,
+		}
+	}
+	return labels
+}
+
+// The *FromSlot helpers skip the reflection in derefValue for the types that actually turn up;
+// anything else still goes through it, so a missing width is slower, never dropped.
+func numericFromSlot(ptr any) (float64, bool) {
+	switch v := ptr.(type) {
+	case *float64:
+		return *v, true
+	case *uint64:
+		return float64(*v), true
+	case *int64:
+		return float64(*v), true
+	case *uint32:
+		return float64(*v), true
+	case *int32:
+		return float64(*v), true
+	case *float32:
+		return float64(*v), true
+	case *uint8:
+		return float64(*v), true
+	case *int8:
+		return float64(*v), true
+	}
+	val := derefValue(ptr)
+	if val == nil {
+		return 0, false
+	}
+	return numericAsFloat(val), true
+}
+
+func boolFromSlot(ptr any) bool {
+	if flag, ok := ptr.(*bool); ok {
+		return *flag
+	}
+	flag, _ := derefValue(ptr).(bool)
+	return flag
+}
+
+func stringFromSlot(ptr any) string {
+	switch v := ptr.(type) {
+	case *string:
+		return *v
+	case **string:
+		if *v == nil {
+			return ""
+		}
+		return **v
+	}
+	str, _ := derefValue(ptr).(string)
+	return str
+}
+
+// maxAggregationIndex bounds the __result_<n> indices honored as aggregations; anything past it
+// is read as a plain numeric column.
+const maxAggregationIndex = 1000
+
+type tsColumnClass uint8
+
+const (
+	tsColumnSkip tsColumnClass = iota
+	tsColumnTimestamp
+	tsColumnNumeric
+	tsColumnBool
+	tsColumnString
+	tsColumnDocument // a JSON or Dynamic column, rendered as a label
+)
+
+// tsColumn is what a result column contributes to every row of a time series. The class and the
+// role are the same for all of them, so they are worked out once instead of per cell.
+type tsColumn struct {
+	name          string
+	class         tsColumnClass
+	aggIdx        int // -1 unless the column is aliased as an aggregation
+	isTargetAlias bool
+}
+
+func planColumns(colNames []string, colTypes []driver.ColumnType) []tsColumn {
+	plan := make([]tsColumn, len(colTypes))
+	for i, colType := range colTypes {
+		name := stripKeyAlias(colNames[i])
+		col := tsColumn{
+			name:          name,
+			aggIdx:        -1,
+			isTargetAlias: slices.Contains(legacyReservedColumnTargetAliases, name),
+		}
+		// A raw ClickHouse query writes its own aliases, and aggValues and the result buckets are
+		// sized from this index — an unchecked __result_<n> is an allocation of the user's choosing.
+		if m := aggRe.FindStringSubmatch(name); m != nil {
+			if idx, err := strconv.Atoi(m[1]); err == nil && idx < maxAggregationIndex {
+				col.aggIdx = idx
+			}
+		}
+
+		typ := baseType(colType.ScanType())
+		switch {
+		case typ == timeType:
+			col.class = tsColumnTimestamp
+		case typ == jsonValueType, typ == variantType:
+			col.class = tsColumnDocument
+		case isNumericKind(typ):
+			col.class = tsColumnNumeric
+		case typ.Kind() == reflect.Bool:
+			col.class = tsColumnBool
+		case typ.Kind() == reflect.String:
+			col.class = tsColumnString
+		}
+		plan[i] = col
+	}
+	return plan
+}
+
 func readAsTimeSeries(rows driver.Rows, queryWindow *qbtypes.TimeRange, step qbtypes.Step, queryName string) (*qbtypes.TimeSeriesData, error) {
 	colTypes := rows.ColumnTypes()
 	colNames := rows.Columns()
 
+	plan := planColumns(colNames, colTypes)
 	slots := make([]any, len(colTypes))
 	numericColsCount := 0
 	for i, ct := range colTypes {
@@ -147,117 +284,122 @@ func readAsTimeSeries(rows driver.Rows, queryWindow *qbtypes.TimeRange, step qbt
 		lblValsCapacity = 0
 	}
 
+	// Every row writes into the same scratch: the label objects are materialised only for the row
+	// that creates a series, and aggregation slots are indexed by the alias instead of hashed.
+	aggCount := 1
+	for _, col := range plan {
+		if col.aggIdx >= aggCount {
+			aggCount = col.aggIdx + 1
+		}
+	}
+	var (
+		aggValues = make([]float64, aggCount)
+		aggSeen   = make([]bool, aggCount)
+		lblVals   = make([]string, 0, lblValsCapacity)
+		lblPairs  = make([]labelPair, 0, lblValsCapacity)
+	)
+
 	for rows.Next() {
 		if err := rows.Scan(slots...); err != nil {
 			return nil, err
 		}
 
+		clear(aggSeen)
+		lblVals = lblVals[:0]
+		lblPairs = lblPairs[:0]
+
 		var (
 			ts            int64
-			lblVals       = make([]string, 0, lblValsCapacity)
-			lblObjs       = make([]*qbtypes.Label, 0, lblValsCapacity)
-			aggValues     = map[int]float64{} // all __result_N in this row
-			fallbackValue float64             // value when NO __result_N columns exist
+			anyAgg        bool
+			fallbackValue float64 // value when NO __result_N columns exist
 			fallbackSeen  bool
 		)
 
 		for idx, ptr := range slots {
-			name := stripKeyAlias(colNames[idx])
+			col := plan[idx]
 
-			switch v := ptr.(type) {
-			case *time.Time:
-				ts = v.UnixMilli()
+			switch col.class {
+			case tsColumnTimestamp:
+				if t, ok := ptr.(*time.Time); ok {
+					ts = t.UnixMilli()
+				} else if t, ok := derefValue(ptr).(time.Time); ok {
+					ts = t.UnixMilli()
+				}
 
-			case *float64, *float32, *int64, *int32, *uint64, *uint32:
-				val := numericAsFloat(reflect.ValueOf(ptr).Elem().Interface())
-				if m := aggRe.FindStringSubmatch(name); m != nil {
-					id, _ := strconv.Atoi(m[1])
-					aggValues[id] = val
-				} else if numericColsCount == 1 { // classic single-value query
-					fallbackValue = val
+			case tsColumnNumeric:
+				num, ok := numericFromSlot(ptr)
+				if !ok { // a NULL number is neither a value nor a label
+					continue
+				}
+				switch {
+				case col.aggIdx >= 0:
+					aggValues[col.aggIdx] = num
+					aggSeen[col.aggIdx] = true
+					anyAgg = true
+				case numericColsCount == 1, col.isTargetAlias: // classic single-value query
+					fallbackValue = num
 					fallbackSeen = true
-				} else if slices.Contains(legacyReservedColumnTargetAliases, name) {
-					fallbackValue = val
-					fallbackSeen = true
-				} else {
-					// numeric label
-					lblVals = append(lblVals, fmt.Sprint(val))
-					lblObjs = append(lblObjs, &qbtypes.Label{
-						Key:   telemetrytypes.TelemetryFieldKey{Name: name},
-						Value: val,
+				default:
+					display := strconv.FormatFloat(num, 'g', -1, 64)
+					lblVals = append(lblVals, display)
+					lblPairs = append(lblPairs, labelPair{
+						name:    col.name,
+						display: display,
+						num:     num,
+						class:   tsColumnNumeric,
 					})
 				}
 
-			case **float64, **float32, **int64, **int32, **uint64, **uint32:
-				tempVal := reflect.ValueOf(ptr)
-				if tempVal.IsValid() && !tempVal.IsNil() && !tempVal.Elem().IsNil() {
-					val := numericAsFloat(tempVal.Elem().Elem().Interface())
-					if m := aggRe.FindStringSubmatch(name); m != nil {
-						id, _ := strconv.Atoi(m[1])
-						aggValues[id] = val
-					} else if numericColsCount == 1 { // classic single-value query
-						fallbackValue = val
-						fallbackSeen = true
-					} else if slices.Contains(legacyReservedColumnTargetAliases, name) {
-						fallbackValue = val
-						fallbackSeen = true
-					} else {
-						// numeric label
-						lblVals = append(lblVals, fmt.Sprint(val))
-						lblObjs = append(lblObjs, &qbtypes.Label{
-							Key:   telemetrytypes.TelemetryFieldKey{Name: name},
-							Value: val,
-						})
-					}
+			case tsColumnBool:
+				flag := boolFromSlot(ptr)
+				switch {
+				case col.aggIdx >= 0:
+					aggValues[col.aggIdx] = boolAsFloat(flag)
+					aggSeen[col.aggIdx] = true
+					anyAgg = true
+				case col.isTargetAlias:
+					fallbackValue = boolAsFloat(flag)
+					fallbackSeen = true
+				default:
+					display := strconv.FormatBool(flag)
+					lblVals = append(lblVals, display)
+					lblPairs = append(lblPairs, labelPair{
+						name:    col.name,
+						display: display,
+						num:     boolAsFloat(flag),
+						class:   tsColumnBool,
+					})
 				}
 
-			case *string:
-				lblVals = append(lblVals, *v)
-				lblObjs = append(lblObjs, &qbtypes.Label{
-					Key:   telemetrytypes.TelemetryFieldKey{Name: name},
-					Value: *v,
-				})
+			case tsColumnString:
+				label := stringFromSlot(ptr) // a NULL string labels the series with the empty string
+				lblVals = append(lblVals, label)
+				lblPairs = append(lblPairs, labelPair{name: col.name, display: label, class: tsColumnString})
 
-			case **string:
-				val := *v
-				if val == nil {
-					var empty string
-					val = &empty
-				}
-				lblVals = append(lblVals, *val)
-				lblObjs = append(lblObjs, &qbtypes.Label{
-					Key:   telemetrytypes.TelemetryFieldKey{Name: name},
-					Value: *val,
-				})
-
-			case *telemetrystoretypes.JSONValue, *chcol.Variant:
-				val := labelValue(derefValue(ptr))
-				lblVals = append(lblVals, val)
-				lblObjs = append(lblObjs, &qbtypes.Label{
-					Key:   telemetrytypes.TelemetryFieldKey{Name: name},
-					Value: val,
-				})
-
-			default:
-				continue
+			case tsColumnDocument:
+				label := labelValue(derefValue(ptr))
+				lblVals = append(lblVals, label)
+				lblPairs = append(lblPairs, labelPair{name: col.name, display: label, class: tsColumnDocument})
 			}
 		}
 
 		// Edge-case: no __result_N columns, but a single numeric column present
-		if len(aggValues) == 0 && fallbackSeen {
+		if !anyAgg && fallbackSeen {
 			aggValues[0] = fallbackValue
+			aggSeen[0] = true
+			anyAgg = true
 		}
 
-		if ts == 0 || len(aggValues) == 0 {
+		if ts == 0 || !anyAgg {
 			continue // nothing useful
 		}
 
-		sort.Strings(lblVals)
+		slices.Sort(lblVals)
 		labelsKey := strings.Join(lblVals, ",")
 
 		// one point per aggregation in this row
 		for aggIdx, val := range aggValues {
-			if math.IsNaN(val) || math.IsInf(val, 0) {
+			if !aggSeen[aggIdx] || math.IsNaN(val) || math.IsInf(val, 0) {
 				continue
 			}
 
@@ -265,7 +407,7 @@ func readAsTimeSeries(rows driver.Rows, queryWindow *qbtypes.TimeRange, step qbt
 
 			series, ok := seriesMap[key]
 			if !ok {
-				series = &qbtypes.TimeSeries{Labels: lblObjs}
+				series = &qbtypes.TimeSeries{Labels: materialiseLabels(lblPairs)}
 				seriesMap[key] = series
 			}
 			series.Values = append(series.Values, &qbtypes.TimeSeriesValue{
@@ -313,6 +455,20 @@ func readAsTimeSeries(rows driver.Rows, queryWindow *qbtypes.TimeRange, step qbt
 		QueryName:    queryName,
 		Aggregations: nonEmpty,
 	}, nil
+}
+
+var (
+	timeType      = reflect.TypeFor[time.Time]()
+	jsonValueType = reflect.TypeFor[telemetrystoretypes.JSONValue]()
+	variantType   = reflect.TypeFor[chcol.Variant]()
+)
+
+// baseType unwraps pointer levels, so that a Nullable column is classified like the column it wraps.
+func baseType(t reflect.Type) reflect.Type {
+	for t.Kind() == reflect.Pointer {
+		t = t.Elem()
+	}
+	return t
 }
 
 func isNumericKind(t reflect.Type) bool {
@@ -511,6 +667,13 @@ func mergeSpanAttributeColumns(data map[string]any) {
 	if raw, ok := data["links"]; ok {
 		data["links"] = spantypes.ParseLinks(raw)
 	}
+}
+
+func boolAsFloat(v bool) float64 {
+	if v {
+		return 1
+	}
+	return 0
 }
 
 // numericAsFloat converts numeric types to float64 efficiently.

--- a/pkg/querier/consume.go
+++ b/pkg/querier/consume.go
@@ -134,16 +134,36 @@ func numericFromSlot(ptr any) (float64, bool) {
 		return float64(*v), true
 	case *float32:
 		return float64(*v), true
+	case *uint16:
+		return float64(*v), true
+	case *int16:
+		return float64(*v), true
 	case *uint8:
 		return float64(*v), true
 	case *int8:
 		return float64(*v), true
+	// builder aggregations arrive as Nullable(Float64) — accurateCastOrNull — so the nullable
+	// carriers matter as much as the plain ones
+	case **float64:
+		return nullableAsFloat(v)
+	case **uint64:
+		return nullableAsFloat(v)
+	case **int64:
+		return nullableAsFloat(v)
 	}
 	val := derefValue(ptr)
 	if val == nil {
 		return 0, false
 	}
 	return numericAsFloat(val), true
+}
+
+// nullableAsFloat reads a Nullable column's scan slot; NULL is no value, not a zero.
+func nullableAsFloat[T int64 | uint64 | float64](v **T) (float64, bool) {
+	if *v == nil {
+		return 0, false
+	}
+	return float64(**v), true
 }
 
 func boolFromSlot(ptr any) bool {

--- a/pkg/querier/consume_test.go
+++ b/pkg/querier/consume_test.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/ClickHouse/clickhouse-go/v2/lib/chcol"
+	"github.com/ClickHouse/clickhouse-go/v2/lib/driver"
 	cmock "github.com/SigNoz/clickhouse-go-mock"
 	"github.com/SigNoz/signoz/pkg/telemetrystore"
 	qbtypes "github.com/SigNoz/signoz/pkg/types/querybuildertypes/querybuildertypesv5"
@@ -193,5 +194,116 @@ func TestMergeSpanAttributeColumns_EmptyEventsAndLinks(t *testing.T) {
 	}
 	if links, ok := data["links"].([]spantypes.Link); !ok || len(links) != 0 {
 		t.Fatalf("expected empty []spantypes.Link, got %#v", data["links"])
+	}
+}
+
+// boolRows reports a bool scan type for one column, which cmock cannot do on its own.
+type boolRows struct {
+	driver.Rows
+	col string
+}
+
+func (r boolRows) ColumnTypes() []driver.ColumnType {
+	out := r.Rows.ColumnTypes()
+	for i, colType := range out {
+		if colType.Name() == r.col {
+			out[i] = cmock.NewColumnType(colType.Name(), "Bool", false, reflect.TypeOf(true))
+		}
+	}
+	return out
+}
+
+// A time-series result can carry numeric widths narrower than 32 bits — max(severity_number) is
+// UInt8, kind is Int8, has_error is Bool. Dropping them empties the chart when the column holds the
+// aggregation, and merges every group into one series when it is a group-by key.
+func TestConsume_NarrowNumericWidths(t *testing.T) {
+	ts := time.Date(2026, 8, 19, 10, 0, 0, 0, time.UTC)
+
+	seriesOf := func(t *testing.T, rows driver.Rows) []*qbtypes.TimeSeries {
+		t.Helper()
+		payload, err := consume(rows, qbtypes.RequestTypeTimeSeries, nil, qbtypes.Step{}, "A")
+		require.NoError(t, err)
+		data := payload.(*qbtypes.TimeSeriesData)
+		require.Len(t, data.Aggregations, 1)
+		return data.Aggregations[0].Series
+	}
+
+	t.Run("UInt8 aggregation", func(t *testing.T) {
+		series := seriesOf(t, cmock.NewRows([]cmock.ColumnType{
+			{Name: "ts", Type: "DateTime"},
+			{Name: "__result_0", Type: "UInt8"},
+		}, [][]any{{ts, uint8(17)}}))
+
+		require.Len(t, series, 1)
+		require.Len(t, series[0].Values, 1)
+		assert.Equal(t, float64(17), series[0].Values[0].Value)
+	})
+
+	t.Run("Int8 group-by", func(t *testing.T) {
+		series := seriesOf(t, cmock.NewRows([]cmock.ColumnType{
+			{Name: "ts", Type: "DateTime"},
+			{Name: "kind", Type: "Int8"},
+			{Name: "__result_0", Type: "UInt64"},
+		}, [][]any{{ts, int8(2), uint64(7)}, {ts, int8(3), uint64(2)}}))
+
+		got := map[float64]float64{}
+		for _, s := range series {
+			require.Len(t, s.Labels, 1)
+			require.Len(t, s.Values, 1)
+			got[s.Labels[0].Value.(float64)] = s.Values[0].Value
+		}
+		assert.Equal(t, map[float64]float64{2: 7, 3: 2}, got)
+	})
+
+	t.Run("Bool aggregation", func(t *testing.T) {
+		series := seriesOf(t, boolRows{col: "__result_0", Rows: cmock.NewRows([]cmock.ColumnType{
+			{Name: "ts", Type: "DateTime"},
+			{Name: "__result_0", Type: "UInt8"},
+		}, [][]any{{ts, uint8(1)}})})
+
+		require.Len(t, series, 1)
+		require.Len(t, series[0].Values, 1)
+		assert.Equal(t, float64(1), series[0].Values[0].Value)
+	})
+
+	t.Run("Bool group-by", func(t *testing.T) {
+		series := seriesOf(t, boolRows{col: "has_error", Rows: cmock.NewRows([]cmock.ColumnType{
+			{Name: "ts", Type: "DateTime"},
+			{Name: "has_error", Type: "UInt8"},
+			{Name: "__result_0", Type: "UInt64"},
+		}, [][]any{{ts, uint8(1), uint64(7)}, {ts, uint8(0), uint64(2)}})})
+
+		got := map[bool]float64{}
+		for _, s := range series {
+			require.Len(t, s.Labels, 1)
+			require.Len(t, s.Values, 1)
+			got[s.Labels[0].Value.(bool)] = s.Values[0].Value
+		}
+		assert.Equal(t, map[bool]float64{true: 7, false: 2}, got)
+	})
+}
+
+// A raw ClickHouse query picks its own aliases, so __result_<n> can carry any index — including
+// one that overflows int or would size a slice in the terabytes.
+func TestConsume_HugeAggregationAlias(t *testing.T) {
+	ts := time.Date(2026, 8, 19, 10, 0, 0, 0, time.UTC)
+
+	for _, alias := range []string{"__result_99999999999999999999", "__result_4000000000"} {
+		t.Run(alias, func(t *testing.T) {
+			rows := cmock.NewRows([]cmock.ColumnType{
+				{Name: "ts", Type: "DateTime"},
+				{Name: alias, Type: "UInt64"},
+			}, [][]any{{ts, uint64(7)}})
+
+			payload, err := consume(rows, qbtypes.RequestTypeTimeSeries, nil, qbtypes.Step{}, "A")
+			require.NoError(t, err)
+
+			// the alias is not honored as an aggregation; the single numeric column carries the value
+			data := payload.(*qbtypes.TimeSeriesData)
+			require.Len(t, data.Aggregations, 1)
+			require.Len(t, data.Aggregations[0].Series, 1)
+			require.Len(t, data.Aggregations[0].Series[0].Values, 1)
+			assert.Equal(t, float64(7), data.Aggregations[0].Series[0].Values[0].Value)
+		})
 	}
 }

--- a/pkg/querier/consume_test.go
+++ b/pkg/querier/consume_test.go
@@ -197,20 +197,26 @@ func TestMergeSpanAttributeColumns_EmptyEventsAndLinks(t *testing.T) {
 	}
 }
 
-// boolRows reports a bool scan type for one column, which cmock cannot do on its own.
-type boolRows struct {
+// scanTypeRows reports a scan type for one column that cmock cannot produce on its own.
+type scanTypeRows struct {
 	driver.Rows
-	col string
+	col      string
+	chType   string
+	scanType reflect.Type
 }
 
-func (r boolRows) ColumnTypes() []driver.ColumnType {
+func (r scanTypeRows) ColumnTypes() []driver.ColumnType {
 	out := r.Rows.ColumnTypes()
 	for i, colType := range out {
 		if colType.Name() == r.col {
-			out[i] = cmock.NewColumnType(colType.Name(), "Bool", false, reflect.TypeOf(true))
+			out[i] = cmock.NewColumnType(colType.Name(), r.chType, false, r.scanType)
 		}
 	}
 	return out
+}
+
+func boolRows(col string, rows driver.Rows) driver.Rows {
+	return scanTypeRows{Rows: rows, col: col, chType: "Bool", scanType: reflect.TypeOf(true)}
 }
 
 // A time-series result can carry numeric widths narrower than 32 bits — max(severity_number) is
@@ -256,10 +262,10 @@ func TestConsume_NarrowNumericWidths(t *testing.T) {
 	})
 
 	t.Run("Bool aggregation", func(t *testing.T) {
-		series := seriesOf(t, boolRows{col: "__result_0", Rows: cmock.NewRows([]cmock.ColumnType{
+		series := seriesOf(t, boolRows("__result_0", cmock.NewRows([]cmock.ColumnType{
 			{Name: "ts", Type: "DateTime"},
 			{Name: "__result_0", Type: "UInt8"},
-		}, [][]any{{ts, uint8(1)}})})
+		}, [][]any{{ts, uint8(1)}})))
 
 		require.Len(t, series, 1)
 		require.Len(t, series[0].Values, 1)
@@ -267,11 +273,11 @@ func TestConsume_NarrowNumericWidths(t *testing.T) {
 	})
 
 	t.Run("Bool group-by", func(t *testing.T) {
-		series := seriesOf(t, boolRows{col: "has_error", Rows: cmock.NewRows([]cmock.ColumnType{
+		series := seriesOf(t, boolRows("has_error", cmock.NewRows([]cmock.ColumnType{
 			{Name: "ts", Type: "DateTime"},
 			{Name: "has_error", Type: "UInt8"},
 			{Name: "__result_0", Type: "UInt64"},
-		}, [][]any{{ts, uint8(1), uint64(7)}, {ts, uint8(0), uint64(2)}})})
+		}, [][]any{{ts, uint8(1), uint64(7)}, {ts, uint8(0), uint64(2)}})))
 
 		got := map[bool]float64{}
 		for _, s := range series {
@@ -306,4 +312,34 @@ func TestConsume_HugeAggregationAlias(t *testing.T) {
 			assert.Equal(t, float64(7), data.Aggregations[0].Series[0].Values[0].Value)
 		})
 	}
+}
+
+// A builder aggregation is Nullable(Float64) — accurateCastOrNull — so its scan slot is a double
+// pointer, and a NULL cell must skip the point rather than plot a zero.
+func TestConsume_NullableAggregation(t *testing.T) {
+	ts := time.Date(2026, 8, 24, 10, 0, 0, 0, time.UTC)
+	rows := scanTypeRows{
+		col:      "__result_0",
+		chType:   "Nullable(Float64)",
+		scanType: reflect.TypeOf((*float64)(nil)),
+		Rows: cmock.NewRows([]cmock.ColumnType{
+			{Name: "ts", Type: "DateTime"},
+			{Name: "__result_0", Type: "Nullable(Float64)"},
+		}, [][]any{
+			{ts, float64(4.5)},
+			{ts.Add(time.Minute), nil},
+			{ts.Add(2 * time.Minute), float64(2.5)},
+		}),
+	}
+
+	payload, err := consume(rows, qbtypes.RequestTypeTimeSeries, nil, qbtypes.Step{}, "A")
+	require.NoError(t, err)
+
+	data := payload.(*qbtypes.TimeSeriesData)
+	require.Len(t, data.Aggregations, 1)
+	require.Len(t, data.Aggregations[0].Series, 1)
+	values := data.Aggregations[0].Series[0].Values
+	require.Len(t, values, 2)
+	assert.Equal(t, 4.5, values[0].Value)
+	assert.Equal(t, 2.5, values[1].Value)
 }


### PR DESCRIPTION
#### Description

Stacked on SigNoz/signoz#12555 — the first commit here is that PR; review only the `perf(querier)` commit.

The graph reader decided what each result column was by switching on its Go pointer type, for every cell of every row — and the switch only listed 32- and 64-bit numeric widths. Anything narrower fell through and was silently dropped, so a raw ClickHouse panel aggregating or grouping by a small-integer or boolean column (`max(severity_number)`, `GROUP BY has_error`, `kind`) either rendered an empty chart or merged every group into one unlabelled line.

- Each column is now classified **once per query** — timestamp, numeric, bool, string, or document — and every row just acts on that. Numeric coverage comes from the same helper that already counted numeric columns, so the two can no longer disagree and any width works.
- Rows reuse scratch instead of allocating per row: the aggregation slots, the label slices, and the label objects for rows that land in an already-seen series.
- Values skip the reflection boxing on the way out of the driver for the common types.
- The `__result_<n>` index is bounded before it sizes anything. The alias is user-written in raw SQL, and an overflowing or huge index (`__result_99999999999999999999`) crashed the reader with a panic — on `main` too, where the result buckets are sized from the same number after the rows are read. Indices past 1000 are now read as plain numeric columns.

#### Additional Information

Behaviour before/after, raw SQL panels on a 1M-row stack:

| query | before | after |
| --- | --- | --- |
| `max(severity_number)` over time (UInt8) | 200 but an empty chart | values returned |
| grouped by `severity_number` | 1 unlabelled series, 25 groups merged | 25 labelled series |
| `count() AS __result_99999999999999999999` | panic | value returned |

Cost, measured per request on a `GROUP BY trace_id` query returning 200k series, from pprof allocation deltas on a live server: **25% fewer bytes allocated and 23% less CPU** (35% fewer allocations inside the reader itself). Response time is unchanged — these queries are dominated by ClickHouse and by encoding the response.
