### PR TITLE
fix(logs): render log details v2 only on the logs explorer route

### DIFF
--- a/frontend/src/components/LogDetail/__tests__/LogDetail.test.tsx
+++ b/frontend/src/components/LogDetail/__tests__/LogDetail.test.tsx
@@ -18,10 +18,9 @@ jest.mock('periscope/components/DataViewer', () => ({
 	DataViewer: (): JSX.Element => <div data-testid="overview-data-viewer" />,
 }));
 
-// The flag to be removed later
-jest.mock('../constants', () => ({
-	...jest.requireActual('../constants'),
-	isLogDetailsV2: true,
+// Force v2 for these tests regardless of route.
+jest.mock('../useIsLogDetailsV2', () => ({
+	useIsLogDetailsV2: (): boolean => true,
 }));
 
 const mockLog: ILog = {

--- a/frontend/src/components/LogDetail/constants.ts
+++ b/frontend/src/components/LogDetail/constants.ts
@@ -1,6 +1,3 @@
-// temporary flag to be removed with old log details code.
-export const isLogDetailsV2 = true;
-
 export const VIEW_TYPES = {
 	OVERVIEW: 'OVERVIEW',
 	JSON: 'JSON',

--- a/frontend/src/components/LogDetail/index.tsx
+++ b/frontend/src/components/LogDetail/index.tsx
@@ -51,11 +51,12 @@ import { ILogBody } from 'types/api/logs/log';
 import { Query, TagFilter } from 'types/api/queryBuilder/queryBuilderData';
 import { DataSource, StringOperators } from 'types/common/queryBuilder';
 
-import { isLogDetailsV2, RESOURCE_KEYS, VIEW_TYPES, VIEWS } from './constants';
+import { RESOURCE_KEYS, VIEW_TYPES, VIEWS } from './constants';
 import { LogDetailInnerProps, LogDetailProps } from './LogDetail.interfaces';
 import LogDetailsHeader from './LogDetailsHeader/LogDetailsHeader';
 import { useLogNavigation } from './LogDetailsHeader/useLogNavigation';
 import LogHighlights from './LogHighlights/LogHighlights';
+import { useIsLogDetailsV2 } from './useIsLogDetailsV2';
 
 import './LogDetails.styles.scss';
 
@@ -91,6 +92,8 @@ function LogDetailInner({
 	const [filters, setFilters] = useState<TagFilter | null>(null);
 	const [isEdit, setIsEdit] = useState<boolean>(false);
 	const { stagedQuery } = useQueryBuilder();
+
+	const isLogDetailsV2 = useIsLogDetailsV2();
 
 	// Handle clicks outside to close drawer, except on explicitly ignored regions
 	useEffect(() => {

--- a/frontend/src/components/LogDetail/useIsLogDetailsV2.ts
+++ b/frontend/src/components/LogDetail/useIsLogDetailsV2.ts
@@ -1,0 +1,9 @@
+import ROUTES from 'constants/routes';
+import { useLocation } from 'react-router-dom';
+
+// v2 is rolled out only on the logs explorer route for now; every other surface
+// (dashboards, infra monitoring, etc.) keeps the v1 log details view.
+export function useIsLogDetailsV2(): boolean {
+	const { pathname } = useLocation();
+	return pathname === ROUTES.LOGS_EXPLORER;
+}

--- a/frontend/src/container/LogDetailedView/Overview.tsx
+++ b/frontend/src/container/LogDetailedView/Overview.tsx
@@ -13,7 +13,7 @@ import { ChangeViewFunctionType } from 'container/ExplorerOptions/types';
 import { OptionsQuery } from 'container/OptionsMenu/types';
 import { useIsDarkMode } from 'hooks/useDarkMode';
 import { ChevronDown, ChevronRight, Search } from '@signozhq/icons';
-import { isLogDetailsV2 } from 'components/LogDetail/constants';
+import { useIsLogDetailsV2 } from 'components/LogDetail/useIsLogDetailsV2';
 import { DataViewer } from 'periscope/components/DataViewer';
 import { IField } from 'types/api/logs/fields';
 import { ILog } from 'types/api/logs/log';
@@ -68,6 +68,8 @@ function Overview({
 		handleChangeSelectedView,
 		isListViewPanel,
 	});
+
+	const isLogDetailsV2 = useIsLogDetailsV2();
 
 	if (isLogDetailsV2) {
 		const raw = aggregateAttributesResourcesToObject(logData);


### PR DESCRIPTION

<!--A few plain bullets saying what changed and why, for a reviewer skimming it - not a wall of text, not a restatement of the diff, not generated boilerplate.-->
#### Description
Render Log details on log explorer only. disabled on other places for now.

<!--Reference issues using `Closes #issue-number` to enable automatic closure on merge. -->
#### Issues closed by this PR

<!--If applicable, include screenshots or screen recordings that clearly show the behavior before the change and the result after the change. -->
#### Screenshots / Screen Recordings

<!--Anything reviewers should keep in mind while reviewing -->
#### Additional Information

<!--Please delete paragraphs that you did not use before submitting.-->
