### PR TITLE
fix(explorer): stop the panelTypes URL param crashing the logs and traces explorers

### DIFF
--- a/frontend/src/container/Home/AlertRules/AlertRules.tsx
+++ b/frontend/src/container/Home/AlertRules/AlertRules.tsx
@@ -139,11 +139,6 @@ export default function AlertRules({
 			encodeURIComponent(JSON.stringify(compositeQuery)),
 		);
 
-		const panelType = record.condition.compositeQuery.panelType;
-		if (panelType) {
-			params.set(QueryParams.panelTypes, panelType);
-		}
-
 		params.set(QueryParams.ruleId, record.id);
 
 		history.push(`${ROUTES.ALERT_OVERVIEW}?${params.toString()}`);

--- a/frontend/src/container/ListAlertRules/__tests__/ListAlertRules.rowClick.test.tsx
+++ b/frontend/src/container/ListAlertRules/__tests__/ListAlertRules.rowClick.test.tsx
@@ -26,7 +26,7 @@ describe('ListAlertRules — row click navigation', () => {
 		const [url] = safeNavigateMock.mock.calls[0];
 		expect(url).toContain('/alerts/overview?');
 		expect(url).toContain('ruleId=rule-1');
-		expect(url).toContain('panelTypes=graph');
+		expect(url).not.toContain('panelTypes');
 		expect(url).toContain('compositeQuery=');
 	});
 

--- a/frontend/src/container/ListAlertRules/useAlertRulesHandlers.ts
+++ b/frontend/src/container/ListAlertRules/useAlertRulesHandlers.ts
@@ -36,11 +36,6 @@ export function useAlertRulesHandlers(
 				encodeURIComponent(JSON.stringify(compositeQuery)),
 			);
 
-			const panelType = rule.condition.compositeQuery.panelType;
-			if (panelType) {
-				params.set(QueryParams.panelTypes, panelType);
-			}
-
 			params.set(QueryParams.ruleId, rule.id);
 
 			return `${ROUTES.ALERT_OVERVIEW}?${params.toString()}`;

--- a/frontend/src/hooks/queryBuilder/useCreateAlerts.tsx
+++ b/frontend/src/hooks/queryBuilder/useCreateAlerts.tsx
@@ -95,7 +95,6 @@ const useCreateAlerts = (widget?: Widgets, caller?: string): VoidFunction => {
 					QueryParams.compositeQuery,
 					encodeURIComponent(JSON.stringify(updatedQuery)),
 				);
-				params.set(QueryParams.panelTypes, widget.panelTypes);
 				params.set(QueryParams.version, ENTITY_VERSION_V5);
 				params.set(QueryParams.source, YAxisSource.DASHBOARDS);
 

--- a/frontend/src/hooks/queryBuilder/useGetPanelTypesQueryParam.test.tsx
+++ b/frontend/src/hooks/queryBuilder/useGetPanelTypesQueryParam.test.tsx
@@ -1,0 +1,54 @@
+import { Router } from 'react-router-dom';
+import { renderHook } from '@testing-library/react';
+import { PANEL_TYPES } from 'constants/queryBuilder';
+import { createMemoryHistory } from 'history';
+
+import { useGetPanelTypesQueryParam } from './useGetPanelTypesQueryParam';
+
+const renderWithSearch = (
+	search: string,
+	defaultPanelType?: PANEL_TYPES,
+): PANEL_TYPES | null => {
+	const history = createMemoryHistory({
+		initialEntries: [`/logs/logs-explorer${search}`],
+	});
+
+	const { result } = renderHook(
+		() => useGetPanelTypesQueryParam(defaultPanelType),
+		{
+			wrapper: ({ children }) => <Router history={history}>{children}</Router>,
+		},
+	);
+
+	return result.current;
+};
+
+describe('useGetPanelTypesQueryParam', () => {
+	it('reads a JSON encoded panel type, as written by the explorers', () => {
+		expect(renderWithSearch('?panelTypes=%22table%22', PANEL_TYPES.LIST)).toBe(
+			PANEL_TYPES.TABLE,
+		);
+	});
+
+	it('reads a plain string panel type, as written by the alerts flow', () => {
+		expect(renderWithSearch('?panelTypes=graph', PANEL_TYPES.LIST)).toBe(
+			PANEL_TYPES.TIME_SERIES,
+		);
+	});
+
+	it('falls back to the default for an unparseable panel type', () => {
+		expect(renderWithSearch('?panelTypes=%7Bfoo', PANEL_TYPES.LIST)).toBe(
+			PANEL_TYPES.LIST,
+		);
+	});
+
+	it('falls back to the default for a value that is not a panel type', () => {
+		expect(renderWithSearch('?panelTypes=%22nope%22', PANEL_TYPES.LIST)).toBe(
+			PANEL_TYPES.LIST,
+		);
+	});
+
+	it('falls back to the default when the param is absent', () => {
+		expect(renderWithSearch('', PANEL_TYPES.LIST)).toBe(PANEL_TYPES.LIST);
+	});
+});

--- a/frontend/src/hooks/queryBuilder/useGetPanelTypesQueryParam.ts
+++ b/frontend/src/hooks/queryBuilder/useGetPanelTypesQueryParam.ts
@@ -3,6 +3,24 @@ import { QueryParams } from 'constants/query';
 import { PANEL_TYPES } from 'constants/queryBuilder';
 import useUrlQuery from 'hooks/useUrlQuery';
 
+const PANEL_TYPE_VALUES = new Set<string>(Object.values(PANEL_TYPES));
+
+// The param is JSON encoded by the explorers and written as a plain string by the
+// alerts flow, so accept both and treat anything unrecognised as absent.
+const parsePanelType = (value: string): PANEL_TYPES | null => {
+	let parsed: unknown = value;
+
+	try {
+		parsed = JSON.parse(value);
+	} catch {
+		parsed = value;
+	}
+
+	return typeof parsed === 'string' && PANEL_TYPE_VALUES.has(parsed)
+		? (parsed as PANEL_TYPES)
+		: null;
+};
+
 export const useGetPanelTypesQueryParam = <T extends PANEL_TYPES | undefined>(
 	defaultPanelType?: T,
 ): T extends undefined ? PANEL_TYPES | null : PANEL_TYPES => {
@@ -11,6 +29,10 @@ export const useGetPanelTypesQueryParam = <T extends PANEL_TYPES | undefined>(
 	return useMemo(() => {
 		const panelTypeQuery = urlQuery.get(QueryParams.panelTypes);
 
-		return panelTypeQuery ? JSON.parse(panelTypeQuery) : defaultPanelType;
-	}, [urlQuery, defaultPanelType]);
+		return (
+			(panelTypeQuery ? parsePanelType(panelTypeQuery) : null) ?? defaultPanelType
+		);
+	}, [urlQuery, defaultPanelType]) as T extends undefined
+		? PANEL_TYPES | null
+		: PANEL_TYPES;
 };

--- a/frontend/src/pages/DashboardPageV2/DashboardContainer/PanelsAndSectionsLayout/Panel/hooks/__tests__/useCreateAlertFromPanel.test.ts
+++ b/frontend/src/pages/DashboardPageV2/DashboardContainer/PanelsAndSectionsLayout/Panel/hooks/__tests__/useCreateAlertFromPanel.test.ts
@@ -168,7 +168,6 @@ describe('useCreateAlertFromPanel', () => {
 			// The resolved query is seeded with the panel-derived alert prefill.
 			expect(mockBuildAlertUrl).toHaveBeenCalledWith(
 				{ resolved: 'query' },
-				PANEL_TYPES.TIME_SERIES,
 				undefined,
 				mockPrefill,
 			);

--- a/frontend/src/pages/DashboardPageV2/DashboardContainer/PanelsAndSectionsLayout/Panel/hooks/useCreateAlertFromPanel.ts
+++ b/frontend/src/pages/DashboardPageV2/DashboardContainer/PanelsAndSectionsLayout/Panel/hooks/useCreateAlertFromPanel.ts
@@ -79,7 +79,6 @@ export function useCreateAlertFromPanel(): (
 						const unit = readPanelUnit(panel.spec.plugin);
 						const url = buildAlertUrl(
 							query,
-							panelType,
 							unit,
 							deriveAlertPrefill(panel, query, unit),
 						);

--- a/frontend/src/pages/DashboardPageV2/DashboardContainer/PanelsAndSectionsLayout/Panel/utils/__tests__/buildCreateAlertUrl.test.ts
+++ b/frontend/src/pages/DashboardPageV2/DashboardContainer/PanelsAndSectionsLayout/Panel/utils/__tests__/buildCreateAlertUrl.test.ts
@@ -65,12 +65,17 @@ describe('buildCreateAlertUrl', () => {
 		);
 	});
 
-	it('tags the URL with panel type, v5 version, and the dashboards source', () => {
+	it('tags the URL with the v5 version and the dashboards source', () => {
 		const params = parse(buildCreateAlertUrl(makePanel()));
 
-		expect(params.get(QueryParams.panelTypes)).toBe(PANEL_TYPES.TIME_SERIES);
 		expect(params.get(QueryParams.version)).toBe(ENTITY_VERSION_V5);
 		expect(params.get(QueryParams.source)).toBe('dashboards');
+	});
+
+	it('does not tag the URL with a panel type, which the alert page ignores', () => {
+		const params = parse(buildCreateAlertUrl(makePanel()));
+
+		expect(params.get(QueryParams.panelTypes)).toBeNull();
 	});
 
 	it('encodes the translated query as the compositeQuery param', () => {

--- a/frontend/src/pages/DashboardPageV2/DashboardContainer/PanelsAndSectionsLayout/Panel/utils/buildCreateAlertUrl.ts
+++ b/frontend/src/pages/DashboardPageV2/DashboardContainer/PanelsAndSectionsLayout/Panel/utils/buildCreateAlertUrl.ts
@@ -5,7 +5,6 @@ import type {
 import { YAxisSource } from 'components/YAxisUnitSelector/types';
 import { ENTITY_VERSION_V5 } from 'constants/app';
 import { QueryParams } from 'constants/query';
-import { PANEL_TYPES } from 'constants/queryBuilder';
 import ROUTES from 'constants/routes';
 import { PANEL_KIND_TO_PANEL_TYPE } from 'pages/DashboardPageV2/DashboardContainer/Panels/types/panelKind';
 import { fromPerses } from 'pages/DashboardPageV2/DashboardContainer/queryV5/persesQueryAdapters';
@@ -34,7 +33,6 @@ export function readPanelUnit(
  */
 export function buildAlertUrl(
 	query: Query,
-	panelType: PANEL_TYPES,
 	unit?: string,
 	prefill?: PanelAlertPrefill,
 ): string {
@@ -48,7 +46,6 @@ export function buildAlertUrl(
 		QueryParams.compositeQuery,
 		encodeURIComponent(JSON.stringify(query)),
 	);
-	params.set(QueryParams.panelTypes, panelType);
 	params.set(QueryParams.version, ENTITY_VERSION_V5);
 	params.set(QueryParams.source, YAxisSource.DASHBOARDS);
 
@@ -76,10 +73,5 @@ export function buildCreateAlertUrl(panel: DashboardtypesPanelDTO): string {
 	const panelType = PANEL_KIND_TO_PANEL_TYPE[panel.spec.plugin.kind];
 	const query = fromPerses(panel.spec.queries, panelType);
 	const unit = readPanelUnit(panel.spec.plugin);
-	return buildAlertUrl(
-		query,
-		panelType,
-		unit,
-		deriveAlertPrefill(panel, query, unit),
-	);
+	return buildAlertUrl(query, unit, deriveAlertPrefill(panel, query, unit));
 }


### PR DESCRIPTION
#### Description

Opening Logs Explorer or Traces Explorer from an alert crashed the page with `SyntaxError: JSON.parse: unexpected character at line 1 column 1 of the JSON data`.

`panelTypes` is written two different ways. The explorers write it JSON encoded (`panelTypes=%22list%22`, via `redirectWithQueryBuilderData`); the alert URL builders write it as a plain string (`panelTypes=graph`). Opening an alert put the plain value in the URL, it rode along into the explorer, and the unguarded `JSON.parse` in `useGetPanelTypesQueryParam` threw and took the page down through the error boundary. Both explorers share that hook, so both were affected.

Fixed at both ends, one commit each:

- **The alert URL builders no longer write the param at all.** `FormAlertRules` stopped reading `panelTypes` off the URL in #5251, which pinned the alert panel type to graph ("In case of alert the panel types should always be Graph only"). Nothing on the alert pages has read it since — every consumer there either hardcodes `TIME_SERIES` or falls back to it — so the four builders were emitting a param with no reader, which only ever got picked up by whatever page the user navigated to next. Dropping it removes the source. This also drops the now-unused `panelType` argument from `buildAlertUrl`.
- **`useGetPanelTypesQueryParam` accepts either encoding.** It validates the result against `PANEL_TYPES` and falls back to the caller's default for anything unrecognised, instead of throwing. Needed independently of the above, because URLs carrying `panelTypes=graph` are already out there in bookmarks and shared links. Same tolerance the time picker already applies to this param.

#### Issues closed by this PR

Closes https://github.com/SigNoz/engineering-pod/issues/5923

#### Additional Information

Sentry: https://signoz-io.sentry.io/issues/SIGNOZ-UI-5C4

Tests: new unit tests on the hook cover both encodings, an unparseable value, a well-formed value that isn't a panel type, and an absent param. Existing assertions that pinned the old URL shape (`ListAlertRules.rowClick`, `buildCreateAlertUrl`, `useCreateAlertFromPanel`) are updated to expect no `panelTypes`.

Not touched: `QueryBuilder.tsx` seeds its initial `panelType` state by reading the same param raw, so a JSON-encoded URL seeds it with a quoted string. Harmless today — the explorer pages immediately overwrite it via the hook — but it is the same mismatch and worth a separate look.
