### PR TITLE
refactor(logs): drop the needle term from the logs condition builder

### DIFF
--- a/pkg/telemetryschema/logstelemetryschema/condition_builder.go
+++ b/pkg/telemetryschema/logstelemetryschema/condition_builder.go
@@ -105,14 +105,14 @@ func (c *conditionBuilder) conditionForArrayFunction(
 			"function `%s` supports only body JSON search", operator.FunctionName()).WithUrl(functionBodyJSONSearchDocURL)
 	}
 
-	needle := value
+	element := value
 	if args, ok := value.([]any); ok && len(args) > 0 {
-		needle = args[0]
+		element = args[0]
 	}
 
 	if c.fl.BooleanOrEmpty(ctx, flagger.FeatureUseJSONBody, featuretypes.NewFlaggerEvaluationContext(orgID)) {
 		// JSON access plan: data-type collision handling, nested array paths.
-		valueType, needle := InferDataType(needle, operator, key)
+		valueType, element := InferDataType(element, operator, key)
 		// A not-found (synthesized) body path carries no metadata plan; build an exhaustive
 		// one so the query runs against the underlying data (with the not-found warning)
 		// instead of erroring, matching the regular-operator path.
@@ -123,10 +123,10 @@ func (c *conditionBuilder) conditionForArrayFunction(
 			}
 			key = keyCopy
 		}
-		return NewJSONConditionBuilder(key, valueType).buildArrayFunctionCondition(operator, needle, sb)
+		return NewJSONConditionBuilder(key, valueType).buildArrayFunctionCondition(operator, element, sb)
 	}
 
-	return c.legacyArrayFunctionCondition(key, operator, needle, sb), nil
+	return c.legacyArrayFunctionCondition(key, operator, element, sb), nil
 }
 
 // legacyArrayFunctionCondition builds the has-family comparison over the plain body string, with
@@ -135,29 +135,29 @@ func (c *conditionBuilder) conditionForArrayFunction(
 func (c *conditionBuilder) legacyArrayFunctionCondition(
 	key *telemetrytypes.TelemetryFieldKey,
 	operator qbtypes.FilterOperator,
-	needle any,
+	element any,
 	sb *sqlbuilder.SelectBuilder,
 ) string {
 	// type-matched array extraction, OR-ed with a scalar comparison for a scalar body value
 	// (coalesced to false so NOT has() matches missing-key rows).
-	elemType := legacyElemType(needle)
+	elemType := legacyElemType(element)
 	arrayExpr := getBodyJSONArrayKey(key, elemType)
 	scalarExpr, scalarGuard, hasScalar := getBodyJSONScalarKey(key, elemType)
 
-	elements, isList := needle.([]any)
+	elements, isList := element.([]any)
 	if !isList {
-		elements = []any{needle}
+		elements = []any{element}
 	}
 	vals := make([]any, len(elements))
 	for i, v := range elements {
-		vals[i] = legacyCoerceNeedle(v, elemType)
+		vals[i] = legacyCoerceElement(v, elemType)
 	}
 
 	var cond string
 	switch {
 	case isList:
-		// Pin the needle array type to the haystack; scalar fallback below coerces value-level.
-		arrayCond := fmt.Sprintf("%s(%s, %s)", operator.FunctionName(), arrayExpr, castNeedleArray(elemType, sb.Var(vals)))
+		// Pin the element array type to the array it is tested against; scalar fallback below coerces value-level.
+		arrayCond := fmt.Sprintf("%s(%s, %s)", operator.FunctionName(), arrayExpr, castElementArray(elemType, sb.Var(vals)))
 		if !hasScalar {
 			cond = arrayCond
 			break
@@ -238,9 +238,9 @@ func elementLiterals(operator qbtypes.FilterOperator, elements []any, sb *sqlbui
 	return predicates
 }
 
-// castNeedleArray pins an Int64 needle array to Array(Int64) so it matches the Array(Nullable(Int64))
-// haystack; without it a needle >= 2^32 binds as Array(UInt64) and hasAny/hasAll error (code 386).
-func castNeedleArray(elemType telemetrytypes.FieldDataType, arg string) string {
+// castElementArray pins an Int64 element array to Array(Int64) so it matches the Array(Nullable(Int64))
+// it is tested against; without it an element >= 2^32 binds as Array(UInt64) and hasAny/hasAll error (code 386).
+func castElementArray(elemType telemetrytypes.FieldDataType, arg string) string {
 	if elemType == telemetrytypes.FieldDataTypeInt64 {
 		return fmt.Sprintf("CAST(%s AS Array(Int64))", arg)
 	}
@@ -268,24 +268,24 @@ func (c *conditionBuilder) conditionForHasToken(
 	value any,
 	sb *sqlbuilder.SelectBuilder,
 ) (string, error) {
-	// hasToken takes a single needle; unwrap it from the function-argument slice.
-	needle := value
+	// hasToken takes a single token; unwrap it from the function-argument slice.
+	token := value
 	if args, ok := value.([]any); ok && len(args) > 0 {
-		needle = args[0]
+		token = args[0]
 	}
 
 	// hasToken matches string tokens only.
-	needleStr, ok := needle.(string)
+	tokenStr, ok := token.(string)
 	if !ok {
 		return "", errors.NewInvalidInputf(errors.CodeInvalidInput,
 			"function `hasToken` expects value parameter to be a string").WithUrl(hasTokenFunctionDocURL)
 	}
 
-	// A multi-token needle makes CH hasToken error (code 36); reject up front as a 400. Both modes flow here.
-	if sep, found := firstTokenSeparator(needleStr); found {
+	// A multi-token value makes CH hasToken error (code 36); reject up front as a 400. Both modes flow here.
+	if sep, found := firstTokenSeparator(tokenStr); found {
 		return "", errors.NewInvalidInputf(errors.CodeInvalidInput,
 			"function `hasToken` matches a single whole token, but %q contains the separator %q; use a substring filter (e.g. `body CONTAINS '%s'`) to search across separators",
-			needleStr, sep, needleStr).WithUrl(hasTokenFunctionDocURL)
+			tokenStr, sep, tokenStr).WithUrl(hasTokenFunctionDocURL)
 	}
 
 	bodyJSONEnabled := c.fl.BooleanOrEmpty(ctx, flagger.FeatureUseJSONBody, featuretypes.NewFlaggerEvaluationContext(orgID))
@@ -296,7 +296,7 @@ func (c *conditionBuilder) conditionForHasToken(
 			return "", errors.NewInvalidInputf(errors.CodeInvalidInput,
 				"function `hasToken` only supports body field as first parameter").WithUrl(hasTokenFunctionDocURL)
 		}
-		return fmt.Sprintf("hasToken(LOWER(%s), LOWER(%s))", LogsV2BodyColumn, sb.Var(needle)), nil
+		return fmt.Sprintf("hasToken(LOWER(%s), LOWER(%s))", LogsV2BodyColumn, sb.Var(token)), nil
 	}
 
 	// JSON mode: a bare body/body.message key searches the body.message column; any other body
@@ -305,7 +305,7 @@ func (c *conditionBuilder) conditionForHasToken(
 	// falls through and emits dynamicElement over the already-typed String column, which errors.
 	if key.Name == LogsV2BodyColumn || key.Name == bodyMessageField ||
 		(key.FieldContext == telemetrytypes.FieldContextBody && key.Name == messageSubField) {
-		return fmt.Sprintf("hasToken(LOWER(%s), LOWER(%s))", bodyMessageField, sb.Var(needle)), nil
+		return fmt.Sprintf("hasToken(LOWER(%s), LOWER(%s))", bodyMessageField, sb.Var(token)), nil
 	}
 	if key.FieldContext == telemetrytypes.FieldContextBody {
 		// A not-found (synthesized) body path carries no metadata plan; build an exhaustive
@@ -317,7 +317,7 @@ func (c *conditionBuilder) conditionForHasToken(
 			}
 			key = keyCopy
 		}
-		return NewJSONConditionBuilder(key, telemetrytypes.FieldDataTypeString).buildTokenFunctionCondition(needle, sb)
+		return NewJSONConditionBuilder(key, telemetrytypes.FieldDataTypeString).buildTokenFunctionCondition(token, sb)
 	}
 	return "", errors.NewInvalidInputf(errors.CodeInvalidInput,
 		"function `hasToken` only supports the body field or a body JSON string field as first parameter").WithUrl(hasTokenFunctionDocURL)

--- a/pkg/telemetryschema/logstelemetryschema/filter_expr_logs_body_json_test.go
+++ b/pkg/telemetryschema/logstelemetryschema/filter_expr_logs_body_json_test.go
@@ -105,7 +105,7 @@ func TestFilterExprLogsBodyJSON(t *testing.T) {
 			expectedErrorContains: "",
 		},
 		{
-			// Big-int needle CAST to Array(Int64) to match the haystack (else 386).
+			// Big-int element CAST to Array(Int64) to match the array it is tested against (else 386).
 			category:              "json",
 			query:                 `hasAny(body.ids, ['9007199254740993', '9007199254740994'])`,
 			shouldPass:            true,

--- a/pkg/telemetryschema/logstelemetryschema/filter_expr_logs_test.go
+++ b/pkg/telemetryschema/logstelemetryschema/filter_expr_logs_test.go
@@ -1561,15 +1561,15 @@ func TestFilterExprLogs(t *testing.T) {
 			expectedArgs:          []any{"download"},
 			expectedErrorContains: "function `hasToken` expects value parameter to be a string",
 		},
-		// A multi-token needle (separator/whitespace) is a clean 400, not a CH execution error.
+		// A multi-token value (separator/whitespace) is a clean 400, not a CH execution error.
 		{
-			category:              "hasTokenUnderscoreNeedle",
+			category:              "hasTokenUnderscoreSeparator",
 			query:                 "hasToken(body, \"user_id\")",
 			shouldPass:            false,
 			expectedErrorContains: "function `hasToken` matches a single whole token",
 		},
 		{
-			category:              "hasTokenWhitespaceNeedle",
+			category:              "hasTokenWhitespaceSeparator",
 			query:                 "hasToken(body, \"production node\")",
 			shouldPass:            false,
 			expectedErrorContains: "function `hasToken` matches a single whole token",

--- a/pkg/telemetryschema/logstelemetryschema/json_condition_builder.go
+++ b/pkg/telemetryschema/logstelemetryschema/json_condition_builder.go
@@ -439,27 +439,27 @@ func (c *jsonConditionBuilder) arrayFuncScalarLeaf(node *telemetrytypes.JSONAcce
 // buildTokenFunctionCondition builds a hasToken search over a body JSON string field:
 // hasToken(LOWER(<elem>), LOWER(?)) wrapped in arrayExists over any array hops between the
 // root and the terminal. The field must resolve to a String leaf or a String array.
-func (c *jsonConditionBuilder) buildTokenFunctionCondition(needle any, sb *sqlbuilder.SelectBuilder) (string, error) {
+func (c *jsonConditionBuilder) buildTokenFunctionCondition(token any, sb *sqlbuilder.SelectBuilder) (string, error) {
 	if len(c.key.JSONPlan) == 0 {
 		return "", errors.NewInvalidInputf(errors.CodeInvalidInput, "function `hasToken` could not resolve a JSON access plan for field `%s`", c.key.Name)
 	}
 
 	return c.buildOredRootChains(func(node *telemetrytypes.JSONAccessNode) (string, error) {
-		return c.tokenLeaf(node, needle, sb)
+		return c.tokenLeaf(node, token, sb)
 	}, sb)
 }
 
 // tokenLeaf builds the hasToken match at a terminal node: a direct match for a String leaf
 // (coalesced to false, as in arrayFuncScalarLeaf), or an arrayExists over the elements for a
 // String array leaf. hasToken is string-only, so any other element type is rejected.
-func (c *jsonConditionBuilder) tokenLeaf(node *telemetrytypes.JSONAccessNode, needle any, sb *sqlbuilder.SelectBuilder) (string, error) {
+func (c *jsonConditionBuilder) tokenLeaf(node *telemetrytypes.JSONAccessNode, token any, sb *sqlbuilder.SelectBuilder) (string, error) {
 	switch node.TerminalConfig.ElemType {
 	case telemetrytypes.String:
 		fieldExpr := fmt.Sprintf("dynamicElement(%s, 'String')", node.FieldPath())
-		return fmt.Sprintf("ifNull(hasToken(LOWER(%s), LOWER(%s)), false)", fieldExpr, sb.Var(needle)), nil
+		return fmt.Sprintf("ifNull(hasToken(LOWER(%s), LOWER(%s)), false)", fieldExpr, sb.Var(token)), nil
 	case telemetrytypes.ArrayString:
 		arrayExpr := fmt.Sprintf("dynamicElement(%s, '%s')", node.FieldPath(), node.TerminalConfig.ElemType.StringValue())
-		return fmt.Sprintf("arrayExists(x -> hasToken(LOWER(x), LOWER(%s)), %s)", sb.Var(needle), arrayExpr), nil
+		return fmt.Sprintf("arrayExists(x -> hasToken(LOWER(x), LOWER(%s)), %s)", sb.Var(token), arrayExpr), nil
 	default:
 		return "", errors.NewInvalidInputf(errors.CodeInvalidInput, "function `hasToken` only supports string fields; field `%s` is `%s`", c.key.Name, node.TerminalConfig.Key.FieldDataType.StringValue())
 	}

--- a/pkg/telemetryschema/logstelemetryschema/json_string.go
+++ b/pkg/telemetryschema/logstelemetryschema/json_string.go
@@ -249,14 +249,14 @@ func GetBodyJSONKeyForExists(_ context.Context, key *telemetrytypes.TelemetryFie
 	return fmt.Sprintf("JSON_EXISTS(body, '$.%s')", getBodyJSONPath(key))
 }
 
-// legacyElemType infers the has-family element type from the needle (legacy has no schema). It
-// scans EVERY value so the chosen array type and all coerced needles agree — else ClickHouse
+// legacyElemType infers the has-family element type from the arg (legacy has no schema). It
+// scans EVERY value so the chosen array type and all coerced args agree — else ClickHouse
 // raises "no supertype ... String" (code 386). Int64 stays distinct from Float64 so a quoted
 // integer is exact past 2^53 (unquoted literals already arrive as float64, parsed upstream).
-func legacyElemType(needle any) telemetrytypes.FieldDataType {
-	list, ok := needle.([]any)
+func legacyElemType(arg any) telemetrytypes.FieldDataType {
+	list, ok := arg.([]any)
 	if !ok {
-		list = []any{needle}
+		list = []any{arg}
 	}
 	if len(list) == 0 {
 		return telemetrytypes.FieldDataTypeString
@@ -277,7 +277,7 @@ func legacyElemType(needle any) telemetrytypes.FieldDataType {
 			}
 		default:
 			// booleans (and anything else) -> String; a bool renders to 'true'/'false', so a
-			// bool needle only matches genuine JSON booleans, not truthy numbers/strings.
+			// bool arg only matches genuine JSON booleans, not truthy numbers/strings.
 			allInt, allNumeric = false, false
 		}
 	}
@@ -291,9 +291,9 @@ func legacyElemType(needle any) telemetrytypes.FieldDataType {
 	}
 }
 
-// legacyCoerceNeedle coerces a needle to elem type dt so its bound-arg type matches the
+// legacyCoerceElement coerces an element to elem type dt so its bound-arg type matches the
 // extracted column (legacyElemType guarantees it's coercible).
-func legacyCoerceNeedle(v any, dt telemetrytypes.FieldDataType) any {
+func legacyCoerceElement(v any, dt telemetrytypes.FieldDataType) any {
 	switch dt {
 	case telemetrytypes.FieldDataTypeInt64:
 		if s, ok := v.(string); ok {
@@ -309,7 +309,7 @@ func legacyCoerceNeedle(v any, dt telemetrytypes.FieldDataType) any {
 		}
 		return v
 	default:
-		return bodyArrayNeedleString(v)
+		return bodyArrayElementString(v)
 	}
 }
 
@@ -352,7 +352,7 @@ func getBodyJSONScalarKey(key *telemetrytypes.TelemetryFieldKey, dt telemetrytyp
 	return expr, guard, true
 }
 
-func bodyArrayNeedleString(v any) string {
+func bodyArrayElementString(v any) string {
 	switch t := v.(type) {
 	case string:
 		return t


### PR DESCRIPTION
#### Description

- `needle` carried three different meanings in one package: the substring a filter asserts over the indexed text, the value a has-family filter looks for in an array, and the single token `hasToken` matches. Each is now named for what it is — `literal`, `element`, `token`.
- Renames only, no behaviour change: `castNeedleArray` and `legacyCoerceNeedle` follow their parameters, and the `hasToken` error keeps its wording, which was always about tokens.

#### Additional Information

- Stacked on #12629 — review that first; this PR's diff is the rename on top of it.
