### PR TITLE
fix(dashboard-v2): close menus and modals before the navigation they trigger

### DIFF
--- a/frontend/src/pages/DashboardPageV2/DashboardContainer/PanelsAndSectionsLayout/Panel/hooks/useViewPanel.ts
+++ b/frontend/src/pages/DashboardPageV2/DashboardContainer/PanelsAndSectionsLayout/Panel/hooks/useViewPanel.ts
@@ -1,4 +1,4 @@
-import { useCallback } from 'react';
+import { startTransition, useCallback } from 'react';
 import { useLocation } from 'react-router-dom';
 import logEvent from 'api/common/logEvent';
 import type { DashboardtypesPanelDTO } from 'api/generated/services/sigNoz.schemas';
@@ -57,12 +57,16 @@ export function useViewPanel(): UseViewPanelApi {
 				QueryParams.compositeQuery,
 				encodeURIComponent(JSON.stringify(query)),
 			);
-			// The provider applies the URL in an effect, a tick after the builder's fields have
-			// mounted and read the query they keep. `resetQuery` — not `initQueryBuilderData`:
-			// swapping one staged id for another re-anchors global time and refetches the grid.
-			resetQuery(query);
 			void logEvent(DashboardDetailEvents.PanelViewed, { panelId });
-			safeNavigate(`${pathname}?${next.toString()}`);
+			// Off the urgent lane: mounting the modal re-renders the app-wide query builder
+			// and every grid panel, so let the menu this ran from close and paint first.
+			startTransition(() => {
+				// The provider applies the URL in an effect, a tick after the builder's fields have
+				// mounted and read the query they keep. `resetQuery` — not `initQueryBuilderData`:
+				// swapping one staged id for another re-anchors global time and refetches the grid.
+				resetQuery(query);
+				safeNavigate(`${pathname}?${next.toString()}`);
+			});
 		},
 		[pathname, safeNavigate, urlQuery, resetQuery],
 	);
@@ -74,17 +78,19 @@ export function useViewPanel(): UseViewPanelApi {
 			next.set(QueryParams.graphType, panelType);
 			// A grid drilldown opens on the saved panel, never a stale editor handoff.
 			clearViewPanelHandoff();
-			// As in `openView`. Clearing the staged query matters twice over here: the URL
-			// below carries this query's own id, and a staged query with a matching id
-			// makes the provider skip the hydration that normalises legacy filter fields.
-			resetQuery(query);
 			// Same encoding the query builder uses (see `useGetCompositeQueryParam`): the URL
 			// value is `encodeURIComponent(JSON.stringify(query))`, decoded once on read.
 			next.set(
 				QueryParams.compositeQuery,
 				encodeURIComponent(JSON.stringify(query)),
 			);
-			safeNavigate(`${pathname}?${next.toString()}`);
+			startTransition(() => {
+				// As in `openView`. Clearing the staged query matters twice over here: the URL
+				// below carries this query's own id, and a staged query with a matching id
+				// makes the provider skip the hydration that normalises legacy filter fields.
+				resetQuery(query);
+				safeNavigate(`${pathname}?${next.toString()}`);
+			});
 		},
 		[pathname, safeNavigate, urlQuery, resetQuery],
 	);

--- a/frontend/src/pages/DashboardPageV2/DashboardContainer/hooks/useOpenPanelEditor.ts
+++ b/frontend/src/pages/DashboardPageV2/DashboardContainer/hooks/useOpenPanelEditor.ts
@@ -1,4 +1,4 @@
-import { useCallback } from 'react';
+import { startTransition, useCallback } from 'react';
 import { generatePath } from 'react-router-dom';
 import type { DashboardtypesPanelDTO } from 'api/generated/services/sigNoz.schemas';
 import { QueryParams } from 'constants/query';
@@ -46,23 +46,32 @@ export function useOpenPanelEditor(): (
 			new URLSearchParams(timeSearch).forEach((value, key) => {
 				params.set(key, value);
 			});
-			if (options?.panel) {
-				const query = getPanelBuilderQuery(options.panel);
+			const query = options?.panel
+				? getPanelBuilderQuery(options.panel)
+				: undefined;
+			if (query) {
 				// Single-encoded: `useGetCompositeQueryParam` decodes once on top of the decode
 				// `URLSearchParams` already does.
 				params.set(
 					QueryParams.compositeQuery,
 					encodeURIComponent(JSON.stringify(query)),
 				);
-				// The provider applies the URL in an effect, a tick after the builder's fields
-				// have mounted and read the query they keep (PromQL inputs, add-on rows).
-				resetQuery(query);
 			}
 			const search = params.toString();
-			safeNavigate(
-				search ? `${path}?${search}` : path,
-				options?.handoffState ? { state: options.handoffState } : undefined,
-			);
+			// Leaving the dashboard tears down every panel and re-renders the app-wide
+			// query builder — off the urgent lane so the menu this ran from closes and
+			// paints before that work starts.
+			startTransition(() => {
+				if (query) {
+					// The provider applies the URL in an effect, a tick after the builder's fields
+					// have mounted and read the query they keep (PromQL inputs, add-on rows).
+					resetQuery(query);
+				}
+				safeNavigate(
+					search ? `${path}?${search}` : path,
+					options?.handoffState ? { state: options.handoffState } : undefined,
+				);
+			});
 		},
 		[safeNavigate, dashboardId, timeSearch, resetQuery],
 	);

--- a/frontend/src/pages/DashboardsListPageV2/components/NewDashboardModal/BlankDashboardPanel.tsx
+++ b/frontend/src/pages/DashboardsListPageV2/components/NewDashboardModal/BlankDashboardPanel.tsx
@@ -1,4 +1,4 @@
-import { type ChangeEvent, useState } from 'react';
+import { type ChangeEvent, startTransition, useState } from 'react';
 // eslint-disable-next-line signoz/no-antd-components -- no @signozhq/ui multiline TextArea yet
 import { Input as AntInput } from 'antd';
 import { Button } from '@signozhq/ui/button';
@@ -71,9 +71,13 @@ function BlankDashboardPanel({ onClose }: Props): JSX.Element {
 				hasImage: Boolean(image),
 			});
 			onClose();
-			safeNavigate(
-				generatePath(ROUTES.DASHBOARD, { dashboardId: created.data.id }),
-			);
+			// Off the urgent lane so the modal's close paints before the dashboard page
+			// mounts, instead of the modal sitting over it while that render runs.
+			startTransition(() => {
+				safeNavigate(
+					generatePath(ROUTES.DASHBOARD, { dashboardId: created.data.id }),
+				);
+			});
 		} catch (e) {
 			showErrorModal(e as APIError);
 			toast.error((e as AxiosError).toString() || 'Failed to create dashboard');

--- a/frontend/src/pages/DashboardsListPageV2/components/NewDashboardModal/BlankDashboardPanel.tsx
+++ b/frontend/src/pages/DashboardsListPageV2/components/NewDashboardModal/BlankDashboardPanel.tsx
@@ -158,6 +158,7 @@ function BlankDashboardPanel({ onClose }: Props): JSX.Element {
 					color="primary"
 					size="md"
 					disabled={!canSubmit}
+					loading={submitting}
 					testId="create-dashboard-submit"
 					onClick={(): void => {
 						void handleCreate();

--- a/frontend/src/pages/DashboardsListPageV2/components/NewDashboardModal/ImportJsonPanel.tsx
+++ b/frontend/src/pages/DashboardsListPageV2/components/NewDashboardModal/ImportJsonPanel.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { startTransition, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { generatePath } from 'react-router-dom';
 import { red } from '@ant-design/colors';
@@ -81,9 +81,13 @@ function ImportJsonPanel({ onClose }: Props): JSX.Element {
 			const response = await createDashboardV2(payload);
 			void logEvent(DashboardListEvents.DashboardCreated, { method: 'import' });
 			onClose();
-			safeNavigate(
-				generatePath(ROUTES.DASHBOARD, { dashboardId: response.data.id }),
-			);
+			// As in the blank panel: let the modal's close paint before the dashboard
+			// page mounts.
+			startTransition(() => {
+				safeNavigate(
+					generatePath(ROUTES.DASHBOARD, { dashboardId: response.data.id }),
+				);
+			});
 		} catch (error) {
 			showErrorModal(error as APIError);
 			setIsCreateError(true);


### PR DESCRIPTION
#### Description

Clicking a panel's **Edit**/**View** menu item, or creating a dashboard from the New dashboard modal, left the overlay painted on screen for a noticeable pause before the destination appeared.

- The overlay's own close and the navigation that follows it were batched into a single React commit. Opening the panel editor or the View modal calls `resetQuery` on the app-wide `QueryBuilderProvider` and swaps the route, tearing down every grid panel — so the browser could not paint the closed dropdown until all of that finished. Same shape for the New dashboard modal: `onClose()` and the navigation to the created dashboard were adjacent statements in one batch.
- Fixed by moving the navigation (and the `resetQuery` that rides with it) off the urgent lane with `startTransition`. The close stays urgent and paints first; the route render happens after. URL/query-param construction is left synchronous — it is pure computation.
- `closeView` is deliberately left alone: there the navigation *is* the close, so deferring it would only make it slower.
- The blank-dashboard submit button was only `disabled` for the duration of the create request, with no progress indicator, which made the wait read as a stuck modal. It now passes `loading`, matching the import panel.

#### Issues closed by this PR

Closes https://github.com/SigNoz/pulse-pod/issues/314

#### Additional Information

Because the URL is pushed synchronously while the old frame is still on screen, an impatient second click during the frozen window could land on a grid item whose ref React had already detached, producing an unhandled `<DraggableCore> not mounted on DragStart!` from `react-grid-layout` — reported against the panel-editor URL. Removing the freeze closes that window.

One behavioural note for review: with the navigation in a transition, a not-yet-downloaded route chunk suspends inside the transition, so the dashboard stays visible during the download instead of flashing the route-level spinner.

