### PR TITLE
fix(alerts): route scheduled alert notifications via rule org, not first org in DB

### DIFF
--- a/ee/query-service/rules/manager_test.go
+++ b/ee/query-service/rules/manager_test.go
@@ -15,8 +15,6 @@ import (
 	"github.com/SigNoz/signoz/pkg/prometheus"
 	"github.com/SigNoz/signoz/pkg/prometheus/prometheustest"
 	"github.com/SigNoz/signoz/pkg/query-service/rules"
-	"github.com/SigNoz/signoz/pkg/sqlstore"
-	"github.com/SigNoz/signoz/pkg/sqlstore/sqlstoretest"
 	"github.com/SigNoz/signoz/pkg/telemetrystore"
 	"github.com/SigNoz/signoz/pkg/telemetrystore/telemetrystoretest"
 	"github.com/SigNoz/signoz/pkg/types/alertmanagertypes"
@@ -62,14 +60,6 @@ func TestManager_TestNotification_SendUnmatched_ThresholdRule(t *testing.T) {
 				},
 				ManagerOptionsHook: func(opts *rules.ManagerOptions) {
 					opts.PrepareTestRuleFunc = TestNotification
-				},
-				SqlStoreHook: func(store sqlstore.SQLStore) {
-					mockStore := store.(*sqlstoretest.Provider)
-					// Mock the organizations query that SendAlerts makes
-					// Bun generates: SELECT id FROM organizations LIMIT 1 (or SELECT "id" FROM "organizations" LIMIT 1)
-					orgRows := mockStore.Mock().NewRows([]string{"id"}).AddRow(orgID.StringValue())
-					// Match bun's generated query pattern - bun may quote identifiers
-					mockStore.Mock().ExpectQuery("SELECT (.+) FROM (.+)organizations(.+) LIMIT (.+)").WillReturnRows(orgRows)
 				},
 				TelemetryStoreHook: func(store telemetrystore.TelemetryStore) {
 					telemetryStore := store.(*telemetrystoretest.Provider)
@@ -175,12 +165,6 @@ func TestManager_TestNotification_SendUnmatched_PromRule(t *testing.T) {
 							triggeredTestAlerts = append(triggeredTestAlerts, args.Get(3).(map[*alertmanagertypes.PostableAlert][]string))
 						}).Return(nil).Times(tc.ExpectAlerts)
 					}
-				},
-				SqlStoreHook: func(store sqlstore.SQLStore) {
-					mockStore := store.(*sqlstoretest.Provider)
-					// Mock the organizations query that SendAlerts makes
-					orgRows := mockStore.Mock().NewRows([]string{"id"}).AddRow(orgID.StringValue())
-					mockStore.Mock().ExpectQuery("SELECT (.+) FROM (.+)organizations(.+) LIMIT (.+)").WillReturnRows(orgRows)
 				},
 				TelemetryStoreHook: func(store telemetrystore.TelemetryStore) {
 					mockStore := store.(*telemetrystoretest.Provider)

--- a/pkg/query-service/rules/base_rule.go
+++ b/pkg/query-service/rules/base_rule.go
@@ -358,20 +358,6 @@ func (r *BaseRule) ActiveAlerts() []*ruletypes.Alert {
 }
 
 func (r *BaseRule) SendAlerts(ctx context.Context, ts time.Time, resendDelay time.Duration, interval time.Duration, notifyFunc NotifyFunc) {
-	var orgID string
-	err := r.
-		sqlstore.
-		BunDB().
-		NewSelect().
-		Table("organizations").
-		ColumnExpr("id").
-		Limit(1).
-		Scan(ctx, &orgID)
-	if err != nil {
-		r.logger.ErrorContext(ctx, "failed to get org ids", errors.Attr(err))
-		return
-	}
-
 	alerts := []*ruletypes.Alert{}
 	r.ForEachActiveAlert(func(alert *ruletypes.Alert) {
 		if alert.NeedsSending(ts, resendDelay) {
@@ -385,7 +371,7 @@ func (r *BaseRule) SendAlerts(ctx context.Context, ts time.Time, resendDelay tim
 			alerts = append(alerts, &anew)
 		}
 	})
-	notifyFunc(ctx, orgID, alerts...)
+	notifyFunc(ctx, r.orgID.StringValue(), alerts...)
 }
 
 func (r *BaseRule) ForEachActiveAlert(f func(*ruletypes.Alert)) {

--- a/pkg/query-service/rules/base_rule_test.go
+++ b/pkg/query-service/rules/base_rule_test.go
@@ -7,10 +7,13 @@ import (
 	"testing"
 	"time"
 
+	"github.com/DATA-DOG/go-sqlmock"
 	"github.com/stretchr/testify/require"
 
 	"github.com/SigNoz/signoz/pkg/instrumentation/instrumentationtest"
 	"github.com/SigNoz/signoz/pkg/queryparser"
+	"github.com/SigNoz/signoz/pkg/sqlstore"
+	"github.com/SigNoz/signoz/pkg/sqlstore/sqlstoretest"
 	"github.com/SigNoz/signoz/pkg/types/metrictypes"
 	qbtypes "github.com/SigNoz/signoz/pkg/types/querybuildertypes/querybuildertypesv5"
 	"github.com/SigNoz/signoz/pkg/types/ruletypes"
@@ -800,6 +803,31 @@ func TestBaseRule_GeneratorURL(t *testing.T) {
 			require.Equal(t, tc.want, r.GeneratorURL())
 		})
 	}
+}
+
+func TestBaseRule_SendAlerts_UsesRuleOrgID(t *testing.T) {
+	p := createPostableRule(&ruletypes.AlertCompositeQuery{})
+	ruleOrgID := valuer.GenerateUUID()
+	otherOrgID := valuer.GenerateUUID()
+
+	// Simulate a multi-org deployment where some other org happens to be
+	// the "first" row in the organizations table.
+	sqlStore := sqlstoretest.New(sqlstore.Config{Provider: "sqlite"}, sqlmock.QueryMatcherRegexp)
+	orgRows := sqlStore.Mock().NewRows([]string{"id"}).AddRow(otherOrgID.StringValue())
+	sqlStore.Mock().ExpectQuery("SELECT (.+) FROM (.+)organizations(.+) LIMIT (.+)").WillReturnRows(orgRows)
+
+	r, err := NewBaseRule("rule-id", ruleOrgID, &p, mustParseURL(t, "http://localhost:8080"), WithSQLStore(sqlStore))
+	require.NoError(t, err)
+
+	r.Active[1] = &ruletypes.Alert{State: ruletypes.StateFiring}
+
+	var gotOrgID string
+	r.SendAlerts(context.Background(), time.Now(), time.Minute, time.Minute, func(_ context.Context, orgID string, _ ...*ruletypes.Alert) {
+		gotOrgID = orgID
+	})
+
+	require.Equal(t, ruleOrgID.StringValue(), gotOrgID)
+	require.NotEqual(t, otherOrgID.StringValue(), gotOrgID)
 }
 
 // labelsKey creates a deterministic string key from a labels map

--- a/pkg/query-service/rules/manager_test.go
+++ b/pkg/query-service/rules/manager_test.go
@@ -14,8 +14,6 @@ import (
 	"github.com/SigNoz/signoz/pkg/instrumentation/instrumentationtest"
 	"github.com/SigNoz/signoz/pkg/prometheus"
 	"github.com/SigNoz/signoz/pkg/prometheus/prometheustest"
-	"github.com/SigNoz/signoz/pkg/sqlstore"
-	"github.com/SigNoz/signoz/pkg/sqlstore/sqlstoretest"
 	"github.com/SigNoz/signoz/pkg/telemetrystore"
 	"github.com/SigNoz/signoz/pkg/telemetrystore/telemetrystoretest"
 	"github.com/SigNoz/signoz/pkg/types/alertmanagertypes"
@@ -58,14 +56,6 @@ func TestManager_TestNotification_SendUnmatched_ThresholdRule(t *testing.T) {
 							triggeredTestAlerts = append(triggeredTestAlerts, args.Get(3).(map[*alertmanagertypes.PostableAlert][]string))
 						}).Return(nil).Times(tc.ExpectAlerts)
 					}
-				},
-				SqlStoreHook: func(store sqlstore.SQLStore) {
-					mockStore := store.(*sqlstoretest.Provider)
-					// Mock the organizations query that SendAlerts makes
-					// Bun generates: SELECT id FROM organizations LIMIT 1 (or SELECT "id" FROM "organizations" LIMIT 1)
-					orgRows := mockStore.Mock().NewRows([]string{"id"}).AddRow(orgID.StringValue())
-					// Match bun's generated query pattern - bun may quote identifiers
-					mockStore.Mock().ExpectQuery("SELECT (.+) FROM (.+)organizations(.+) LIMIT (.+)").WillReturnRows(orgRows)
 				},
 				TelemetryStoreHook: func(store telemetrystore.TelemetryStore) {
 					mockStore := store.(*telemetrystoretest.Provider)
@@ -171,12 +161,6 @@ func TestManager_TestNotification_SendUnmatched_PromRule(t *testing.T) {
 							triggeredTestAlerts = append(triggeredTestAlerts, args.Get(3).(map[*alertmanagertypes.PostableAlert][]string))
 						}).Return(nil).Times(tc.ExpectAlerts)
 					}
-				},
-				SqlStoreHook: func(store sqlstore.SQLStore) {
-					mockStore := store.(*sqlstoretest.Provider)
-					// Mock the organizations query that SendAlerts makes
-					orgRows := mockStore.Mock().NewRows([]string{"id"}).AddRow(orgID.StringValue())
-					mockStore.Mock().ExpectQuery("SELECT (.+) FROM (.+)organizations(.+) LIMIT (.+)").WillReturnRows(orgRows)
 				},
 				TelemetryStoreHook: func(store telemetrystore.TelemetryStore) {
 					mockStore := store.(*telemetrystoretest.Provider)

--- a/pkg/query-service/rules/managertestfactory.go
+++ b/pkg/query-service/rules/managertestfactory.go
@@ -141,7 +141,7 @@ func NewTestManager(t *testing.T, testOpts *TestManagerOptions) *Manager {
 		Alertmanager:   fAlert,
 		Querier:        mockQuerier,
 		TelemetryStore: telemetryStore,
-		SQLStore:       sqlStore, // SQLStore needed for SendAlerts to query organizations
+		SQLStore:       sqlStore,
 	}
 
 	// Call the ManagerOptions hook if provided to allow customization


### PR DESCRIPTION
#### Description

- `BaseRule.SendAlerts` picked the notification org by running `SELECT id FROM organizations LIMIT 1` instead of using the rule's own `orgID`, which is already stored on the struct.
- In multi-org deployments this could misroute scheduled/maintenance-window alert notifications to an arbitrary org's alertmanager config instead of the org that owns the rule.
- Fix: use `r.orgID` directly, removing the DB query entirely.
- Added `TestBaseRule_SendAlerts_UsesRuleOrgID`, which mocks the organizations table to return a different org than the rule's own and asserts the notification still goes to the rule's org.
- Removed now-dead `SqlStoreHook` mocks (and their now-unused imports) in `manager_test.go` for both the community and EE packages, since they only existed to stub the query this PR removes.

#### Issues closed by this PR

Closes #11351

#### Additional Information

- Left `BaseRule.sqlstore` / `WithSQLStore` in place since it's still used to construct rules elsewhere; removing it is a separate, unrelated cleanup.