### PR TITLE
Fix/pipeline alias varchar length

### DIFF
--- a/pkg/signoz/provider.go
+++ b/pkg/signoz/provider.go
@@ -244,6 +244,7 @@ func NewSQLMigrationProviderFactories(
 		sqlmigration.NewDeleteOrphanUserRolesFactory(),
 		sqlmigration.NewMigrateLambdaDashboardsFactory(),
 		sqlmigration.NewAddAuthDomainTuplesFactory(sqlstore),
+		sqlmigration.NewAlterPipelineAliasLengthFactory(sqlstore),
 	)
 }
 

--- a/pkg/sqlmigration/118_alter_pipeline_alias_length.go
+++ b/pkg/sqlmigration/118_alter_pipeline_alias_length.go
@@ -1,0 +1,44 @@
+package sqlmigration
+
+import (
+	"context"
+
+	"github.com/SigNoz/signoz/pkg/factory"
+	"github.com/SigNoz/signoz/pkg/sqlstore"
+	"github.com/uptrace/bun"
+	"github.com/uptrace/bun/migrate"
+)
+
+type alterPipelineAliasLength struct {
+	store sqlstore.SQLStore
+}
+
+func NewAlterPipelineAliasLengthFactory(sqlstore sqlstore.SQLStore) factory.ProviderFactory[SQLMigration, Config] {
+	return factory.NewProviderFactory(factory.MustNewName("alter_pipeline_alias_length"), func(ctx context.Context, ps factory.ProviderSettings, c Config) (SQLMigration, error) {
+		return &alterPipelineAliasLength{store: sqlstore}, nil
+	})
+}
+
+func (migration *alterPipelineAliasLength) Register(migrations *migrate.Migrations) error {
+	return migrations.Register(migration.Up, migration.Down)
+}
+
+func (migration *alterPipelineAliasLength) Up(ctx context.Context, db *bun.DB) error {
+	tx, err := db.BeginTx(ctx, nil)
+	if err != nil {
+		return err
+	}
+	defer func() {
+		_ = tx.Rollback()
+	}()
+
+	if _, err := tx.ExecContext(ctx, "ALTER TABLE pipelines ALTER COLUMN alias TYPE varchar(400);"); err != nil {
+		return err
+	}
+
+	return tx.Commit()
+}
+
+func (migration *alterPipelineAliasLength) Down(ctx context.Context, db *bun.DB) error {
+	return nil
+}

--- a/pkg/types/pipelinetypes/pipeline.go
+++ b/pkg/types/pipelinetypes/pipeline.go
@@ -49,7 +49,7 @@ type StoreablePipeline struct {
 	OrderID      int    `json:"orderId" bun:"order_id"`
 	Enabled      bool   `json:"enabled" bun:"enabled"`
 	Name         string `json:"name" bun:"name,type:varchar(400),notnull"`
-	Alias        string `json:"alias" bun:"alias,type:varchar(20),notnull"`
+	Alias        string `json:"alias" bun:"alias,type:varchar(400),notnull"`
 	Description  string `json:"description" bun:"description,type:text"`
 	FilterString string `json:"-" bun:"filter,type:text,notnull"`
 	ConfigJSON   string `json:"-" bun:"config_json,type:text"`
@@ -216,6 +216,10 @@ func (p *PostablePipeline) IsValid() error {
 	if p.Alias == "" {
 		return errors.NewInvalidInputf(errors.CodeInvalidInput, "pipeline alias is required")
 	}
+
+    if len(p.Alias) > 400 {
+        return errors.NewInvalidInputf(errors.CodeInvalidInput, "pipeline alias length cannot exceed 400 characters")
+    }
 
 	// check the filter
 	_, err := queryBuilderToExpr.Parse(p.Filter)

--- a/pkg/types/pipelinetypes/postable_pipeline_test.go
+++ b/pkg/types/pipelinetypes/postable_pipeline_test.go
@@ -98,6 +98,17 @@ func TestIsValidPostablePipeline(t *testing.T) {
 			},
 			IsValid: true,
 		},
+        {
+            Name: "Alias length exceeds max allowed length",
+            Pipeline: PostablePipeline{
+                OrderID: 1,
+                Name:    "pipeline 1",
+                Alias:   "this_is_a_very_long_alias_string_that_exceeds_four_hundred_characters_this_is_a_very_long_alias_string_that_exceeds_four_hundred_characters_this_is_a_very_long_alias_string_that_exceeds_four_hundred_characters_this_is_a_very_long_alias_string_that_exceeds_four_hundred_characters_this_is_a_very_long_alias_string_that_exceeds_four_hundred_characters_this_is_a_very_long_alias_string_that_exceeds_four_hundred_characters_extra",
+                Enabled: true,
+                Filter:  validPipelineFilterSet,
+            },
+            IsValid: false,
+        },
 	}
 
 	for _, test := range correctQueriesTest {


### PR DESCRIPTION
#### Description
- Updated log pipeline `Alias` column constraint from `varchar(20)` to `varchar(400)` in `StoreablePipeline` model.
- Added input validation in `PostablePipeline.IsValid()` to return a user-friendly invalid input error if pipeline alias length exceeds 400 characters.
- Added database SQL migration `118` to alter existing `pipelines.alias` column length for PostgreSQL deployments.
- Added unit test for pipeline alias length validation in `postable_pipeline_test.go`.

#### Issues closed by this PR
Closes #12584

#### Screenshots / Screen Recordings
N/A (Backend schema and validation change)

#### Additional Information
- Migration 118 checks `db.Dialect().Name() == dialect.PG` before running `ALTER COLUMN` to ensure compatibility with SQLite/Postgres.