### PR TITLE
feat: add expand/collapse toggle for ClickHouse query editor

### DIFF
--- a/frontend/src/container/FormAlertRules/ChQuerySection/ChQuerySection.tsx
+++ b/frontend/src/container/FormAlertRules/ChQuerySection/ChQuerySection.tsx
@@ -4,7 +4,7 @@ import { useQueryBuilder } from 'hooks/queryBuilder/useQueryBuilder';
 import { AlertTypes } from 'types/api/alerts/alertTypes';
 import DOCLINKS from 'utils/docLinks';
 
-import 'container/NewWidget/LeftContainer/QuerySection/QueryBuilder/ClickHouse/ClickHouse.styles.scss';
+import 'container/NewWidget/LeftContainer/QuerySection/QueryBuilder/ClickHouse/ClickHouse.module.scss';
 
 const ALERT_TYPE_DOC_LINK: Partial<Record<AlertTypes, string>> = {
 	[AlertTypes.LOGS_BASED_ALERT]: DOCLINKS.QUERY_CLICKHOUSE_LOGS,

--- a/frontend/src/container/NewWidget/LeftContainer/QuerySection/QueryBuilder/ClickHouse/ClickHouse.module.scss
+++ b/frontend/src/container/NewWidget/LeftContainer/QuerySection/QueryBuilder/ClickHouse/ClickHouse.module.scss
@@ -1,0 +1,18 @@
+.info-banner-wrapper {
+	margin: 8px 8px 16px 16px;
+
+	a {
+		text-decoration: underline;
+	}
+}
+
+.clickhouse-query-builder {
+	&.expanded {
+		.me-editor-container {
+			height: 500px !important;
+			width: 100%;
+			z-index: 100;
+			position: relative;
+		}
+	}
+}

--- a/frontend/src/container/NewWidget/LeftContainer/QuerySection/QueryBuilder/ClickHouse/ClickHouse.styles.scss
+++ b/frontend/src/container/NewWidget/LeftContainer/QuerySection/QueryBuilder/ClickHouse/ClickHouse.styles.scss
@@ -1,7 +1,0 @@
-.info-banner-wrapper {
-	margin: 8px 8px 16px 16px;
-
-	a {
-		text-decoration: underline;
-	}
-}

--- a/frontend/src/container/NewWidget/LeftContainer/QuerySection/QueryBuilder/ClickHouse/index.tsx
+++ b/frontend/src/container/NewWidget/LeftContainer/QuerySection/QueryBuilder/ClickHouse/index.tsx
@@ -7,7 +7,7 @@ import DOCLINKS from 'utils/docLinks';
 import { QueryButton } from '../../styles';
 import ClickHouseQueryBuilder from './query';
 
-import './ClickHouse.styles.scss';
+import './ClickHouse.module.scss';
 
 function ClickHouseQueryContainer(): JSX.Element | null {
 	const { currentQuery, addNewQueryItem } = useQueryBuilder();

--- a/frontend/src/container/NewWidget/LeftContainer/QuerySection/QueryBuilder/ClickHouse/query.tsx
+++ b/frontend/src/container/NewWidget/LeftContainer/QuerySection/QueryBuilder/ClickHouse/query.tsx
@@ -1,7 +1,9 @@
-import { ChangeEvent, useCallback } from 'react';
-import MEditor, { Monaco } from '@monaco-editor/react';
+import { ChangeEvent, useCallback, useRef, useState } from 'react';
+import MEditor, { Monaco, OnMount } from '@monaco-editor/react';
 import { Color } from '@signozhq/design-tokens';
 import { Input } from 'antd';
+import { Button } from '@signozhq/ui/button';
+import { Fullscreen } from '@signozhq/icons';
 import { LEGEND } from 'constants/global';
 import { useQueryBuilder } from 'hooks/queryBuilder/useQueryBuilder';
 import { useIsDarkMode } from 'hooks/useDarkMode';
@@ -11,11 +13,15 @@ import { getFormatedLegend } from 'utils/getFormatedLegend';
 
 import QueryHeader from '../QueryHeader';
 
+import styles from './ClickHouse.module.scss';
+
 interface IClickHouseQueryBuilderProps {
 	queryData: IClickHouseQuery;
 	queryIndex: number;
 	deletable: boolean;
 }
+
+type MonacoEditor = Parameters<OnMount>[0];
 
 function ClickHouseQueryBuilder({
 	queryData,
@@ -24,6 +30,9 @@ function ClickHouseQueryBuilder({
 }: IClickHouseQueryBuilderProps): JSX.Element | null {
 	const { handleSetQueryItemData, removeQueryTypeItemByIndex } =
 		useQueryBuilder();
+
+	const editorRef = useRef<MonacoEditor | null>(null);
+	const [isExpanded, setIsExpanded] = useState(false);
 
 	const handleRemoveQuery = useCallback(() => {
 		removeQueryTypeItemByIndex(EQueryType.CLICKHOUSE, queryIndex);
@@ -71,6 +80,16 @@ function ClickHouseQueryBuilder({
 		[handleUpdateQuery],
 	);
 
+	const toggleExpand = useCallback(() => {
+		setIsExpanded((prev) => {
+			const next = !prev;
+			setTimeout(() => {
+				editorRef.current?.layout();
+			}, 0);
+			return next;
+		});
+	}, []);
+
 	const isDarkMode = useIsDarkMode();
 
 	function setEditorTheme(monaco: Monaco): void {
@@ -87,46 +106,71 @@ function ClickHouseQueryBuilder({
 		});
 	}
 
+	const editorHeight = isExpanded ? '500px' : '200px';
+	const containerClass = `clickhouse-query-builder ${isExpanded ? styles.expanded : ''}`;
+
 	return (
-		<QueryHeader
-			name={queryData?.name}
-			disabled={queryData?.disabled}
-			onDisable={handleDisable}
-			onDelete={handleRemoveQuery}
-			deletable={deletable}
-		>
-			<MEditor
-				language="sql"
-				height="200px"
-				onChange={handleUpdateEditor}
-				value={queryData?.query}
-				onMount={(_, monaco): void => {
-					document.fonts.ready.then(() => {
-						monaco.editor.remeasureFonts();
-					});
-				}}
-				options={{
-					scrollbar: {
-						alwaysConsumeMouseWheel: false,
-					},
-					minimap: {
-						enabled: false,
-					},
-					fontSize: 14,
-					fontFamily: 'Space Mono',
-				}}
-				theme={isDarkMode ? 'my-theme' : 'light'}
-				beforeMount={setEditorTheme}
-			/>
-			<Input
-				onChange={handleUpdateInput}
-				name="legend"
-				size="middle"
-				defaultValue={queryData?.legend}
-				value={queryData?.legend}
-				addonBefore="Legend Format"
-			/>
-		</QueryHeader>
+		<div className={containerClass}>
+			<QueryHeader
+				name={queryData?.name}
+				disabled={queryData?.disabled}
+				onDisable={handleDisable}
+				onDelete={handleRemoveQuery}
+				deletable={deletable}
+			>
+				<div
+					style={{
+						display: 'flex',
+						justifyContent: 'space-between',
+						alignItems: 'center',
+						marginBottom: '0.4rem',
+					}}
+				>
+					<Button
+						size="sm"
+						variant="outlined"
+						color="secondary"
+						prefix={<Fullscreen size={14} />}
+						onClick={toggleExpand}
+						data-testid="clickhouse-editor-expand-toggle"
+					>
+						{isExpanded ? 'Collapse' : 'Expand'}
+					</Button>
+				</div>
+				<MEditor
+					language="sql"
+					height={editorHeight}
+					onChange={handleUpdateEditor}
+					value={queryData?.query}
+					onMount={(editor, monaco): void => {
+						editorRef.current = editor;
+						document.fonts.ready.then(() => {
+							monaco.editor.remeasureFonts();
+						});
+					}}
+					options={{
+						scrollbar: {
+							alwaysConsumeMouseWheel: false,
+						},
+						minimap: {
+							enabled: false,
+						},
+						fontSize: 14,
+						fontFamily: 'Space Mono',
+					}}
+					theme={isDarkMode ? 'my-theme' : 'light'}
+					beforeMount={setEditorTheme}
+				/>
+				<Input
+					onChange={handleUpdateInput}
+					name="legend"
+					size="middle"
+					defaultValue={queryData?.legend}
+					value={queryData?.legend}
+					addonBefore="Legend Format"
+				/>
+			</QueryHeader>
+		</div>
 	);
 }
 


### PR DESCRIPTION
## Summary

Implements expand/collapse toggle for ClickHouse Monaco SQL editor as requested in issue #7169.

## Changes

- Added expand/collapse button to ClickHouse query editor toolbar
- When expanded, editor height increases from 200px to 500px
- Monaco editor layout is automatically remeasured on expand/collapse
- Uses Fullscreen icon from @signozhq/icons
- Updated styles to use CSS modules
- Works in both:
  - NewWidget query builder (frontend/src/container/NewWidget/LeftContainer/QuerySection/QueryBuilder/ClickHouse)
  - FormAlertRules ChQuerySection (frontend/src/container/FormAlertRules/ChQuerySection)

## Testing

- Build passes
- Lint passes
- Typecheck passes
- Stylelint passes (existing warnings only)

## Related Issue

Fixes #7169