### PR TITLE
fix(devenv): remove the unusable otel-collector healthcheck

### DIFF
--- a/.devenv/docker/signoz-otel-collector/compose.yaml
+++ b/.devenv/docker/signoz-otel-collector/compose.yaml
@@ -22,16 +22,6 @@ services:
       - "4317:4317" # OTLP gRPC receiver
       - "4318:4318" # OTLP HTTP receiver
       - "13133:13133" # health check extension
-    healthcheck:
-      test:
-        - CMD
-        - wget
-        - --spider
-        - -q
-        - localhost:13133
-      interval: 30s
-      timeout: 5s
-      retries: 3
     restart: unless-stopped
     extra_hosts:
       - "host.docker.internal:host-gateway"


### PR DESCRIPTION
#### Description

- The devenv `signoz-otel-collector` healthcheck probes with `wget`, which is not in the collector image — nor `curl` or `nc`, on either published architecture. The container therefore reports `unhealthy` forever even though the health extension serves 200 on `:13133` and the collector is working normally.
- Removing the healthcheck rather than replacing the probe, per @Nageshbansal on the issue thread. Nothing currently gates on this service's health status.

Verified after the change: the container reports `Up` with no health status instead of a permanent `unhealthy`, and `curl localhost:13133` still returns `{"status":"Server available"}`.

#### Issues closed by this PR

Closes #12657
