### PR TITLE
fix(alerts): don't stop rule-loading at the first org with no stored rules

### DIFF
--- a/pkg/query-service/rules/manager.go
+++ b/pkg/query-service/rules/manager.go
@@ -260,7 +260,7 @@ func (m *Manager) initiate(ctx context.Context) error {
 			return err
 		}
 		if len(storedRules) == 0 {
-			return nil
+			continue
 		}
 
 		for _, rec := range storedRules {

--- a/pkg/query-service/rules/manager_initiate_test.go
+++ b/pkg/query-service/rules/manager_initiate_test.go
@@ -1,0 +1,87 @@
+package rules
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/SigNoz/signoz/pkg/instrumentation/instrumentationtest"
+	"github.com/SigNoz/signoz/pkg/types"
+	"github.com/SigNoz/signoz/pkg/types/ruletypes"
+	"github.com/SigNoz/signoz/pkg/valuer"
+)
+
+type fakeOrgGetter struct {
+	orgs []*types.Organization
+}
+
+func (f *fakeOrgGetter) Get(context.Context, valuer.UUID) (*types.Organization, error) {
+	return nil, nil
+}
+
+func (f *fakeOrgGetter) GetByIDOrName(context.Context, valuer.UUID, string) (*types.Organization, bool, error) {
+	return nil, false, nil
+}
+
+func (f *fakeOrgGetter) ListByOwnedKeyRange(context.Context) ([]*types.Organization, error) {
+	return f.orgs, nil
+}
+
+func (f *fakeOrgGetter) GetByName(context.Context, string) (*types.Organization, error) {
+	return nil, nil
+}
+
+type fakeRuleStore struct {
+	rulesByOrg map[string][]*ruletypes.StorableRule
+}
+
+func (f *fakeRuleStore) CreateRule(context.Context, *ruletypes.StorableRule, func(context.Context, valuer.UUID) error) (valuer.UUID, error) {
+	return valuer.UUID{}, nil
+}
+
+func (f *fakeRuleStore) EditRule(context.Context, *ruletypes.StorableRule, func(context.Context) error) error {
+	return nil
+}
+
+func (f *fakeRuleStore) DeleteRule(context.Context, valuer.UUID, valuer.UUID, func(context.Context) error) error {
+	return nil
+}
+
+func (f *fakeRuleStore) GetStoredRules(_ context.Context, orgID string) ([]*ruletypes.StorableRule, error) {
+	return f.rulesByOrg[orgID], nil
+}
+
+func (f *fakeRuleStore) GetStoredRule(context.Context, valuer.UUID, valuer.UUID) (*ruletypes.StorableRule, error) {
+	return nil, nil
+}
+
+func (f *fakeRuleStore) GetStoredRulesByMetricName(context.Context, string, string) ([]ruletypes.RuleAlert, error) {
+	return nil, nil
+}
+
+// TestManager_Initiate_ContinuesPastOrgsWithNoRules guards against a regression where initiate()
+// returned on the first org with no stored rules instead of continuing to the next org, silently
+// skipping rule-loading for every org that came after it.
+func TestManager_Initiate_ContinuesPastOrgsWithNoRules(t *testing.T) {
+	orgWithNoRules := types.NewOrganization("empty-org", "empty-org")
+	orgWithRule := types.NewOrganization("org-with-rule", "org-with-rule")
+
+	ruleStore := &fakeRuleStore{
+		rulesByOrg: map[string][]*ruletypes.StorableRule{
+			orgWithRule.ID.StringValue(): {
+				{Data: "not-json"},
+			},
+		},
+	}
+
+	m := &Manager{
+		logger:    instrumentationtest.New().Logger(),
+		ruleStore: ruleStore,
+		orgGetter: &fakeOrgGetter{orgs: []*types.Organization{orgWithNoRules, orgWithRule}},
+	}
+
+	err := m.initiate(context.Background())
+
+	require.Error(t, err)
+}


### PR DESCRIPTION
#### Description

- `Manager.initiate()` (called on startup to load alert rules for every org) returned immediately as soon as it hit an org with zero stored rules, instead of continuing to the next org.
- A brand-new org with no alert rules yet is the normal case, so hitting one anywhere but last in the iteration order would silently prevent every org after it from ever having its alert rules loaded — and since it returns `nil`, nothing gets logged.
- Fix: `return nil` → `continue`, so the loop keeps visiting every org, matching the function's existing intent of collecting `loadErrors` across all orgs and joining them at the end.
- Added `TestManager_Initiate_ContinuesPastOrgsWithNoRules`, which puts an empty org first and an org with a rule second, and asserts the second org's rule is actually processed. Verified by reverting the fix locally: the test fails without it.
- Found while reviewing #12658.

#### Additional Information

Introduced a couple of small in-package fakes (`fakeOrgGetter`, `fakeRuleStore`) since no existing test double covers `organization.Getter`, and the existing `rulestoretest.MockSQLRuleStore` is regex/SQL-mock based, which is more machinery than this control-flow test needs.