### PR TITLE
refactor(querier): share the variable substitution between dialects

### DIFF
--- a/pkg/querier/clickhouse_query.go
+++ b/pkg/querier/clickhouse_query.go
@@ -1,19 +1,12 @@
 package querier
 
 import (
-	"bytes"
 	"context"
-	"fmt"
 	"log/slog"
-	"sort"
-	"strings"
-	"text/template"
 	"time"
 
 	"github.com/ClickHouse/clickhouse-go/v2"
 	"github.com/SigNoz/signoz/pkg/clickhousesql"
-	"github.com/SigNoz/signoz/pkg/errors"
-	"github.com/SigNoz/signoz/pkg/querybuilder"
 	"github.com/SigNoz/signoz/pkg/telemetrystore"
 	"github.com/SigNoz/signoz/pkg/types/ctxtypes"
 	"github.com/SigNoz/signoz/pkg/types/instrumentationtypes"
@@ -63,42 +56,8 @@ func (q *chSQLQuery) Fingerprint() string {
 
 func (q *chSQLQuery) Window() (uint64, uint64) { return q.fromMS, q.toMS }
 
-// TODO(srikanthccv): cleanup the templating logic.
 func (q *chSQLQuery) renderVars(query string, vars map[string]qbtypes.VariableItem, start, end uint64) (string, error) {
-	varsData := map[string]any{}
-	for k, v := range vars {
-		varsData[k] = clickhousesql.Literal(v.Value)
-	}
-
-	querybuilder.AssignReservedVars(varsData, start, end)
-
-	keys := make([]string, 0, len(varsData))
-	for k := range varsData {
-		keys = append(keys, k)
-	}
-	sort.Slice(keys, func(i, j int) bool {
-		return len(keys[i]) > len(keys[j])
-	})
-
-	for _, k := range keys {
-		query = strings.ReplaceAll(query, fmt.Sprintf("{{%s}}", k), fmt.Sprint(varsData[k]))
-		query = strings.ReplaceAll(query, fmt.Sprintf("[[%s]]", k), fmt.Sprint(varsData[k]))
-		query = strings.ReplaceAll(query, fmt.Sprintf("$%s", k), fmt.Sprint(varsData[k]))
-	}
-
-	tmpl := template.New("clickhouse-query")
-	tmpl, err := tmpl.Parse(query)
-	if err != nil {
-		return "", errors.WrapInternalf(err, errors.CodeInternal, "error while replacing template variables")
-	}
-	var newQuery bytes.Buffer
-
-	// replace go template variables
-	err = tmpl.Execute(&newQuery, varsData)
-	if err != nil {
-		return "", errors.WrapInternalf(err, errors.CodeInternal, "error while replacing template variables")
-	}
-	return newQuery.String(), nil
+	return substituteVariables(query, vars, start, end, clickhousesql.Literal, "clickhouse-query")
 }
 
 func (q *chSQLQuery) render(ctx context.Context) (string, error) {

--- a/pkg/querier/promql_query.go
+++ b/pkg/querier/promql_query.go
@@ -1,16 +1,13 @@
 package querier
 
 import (
-	"bytes"
 	"context"
 	"fmt"
 	"log/slog"
 	"math"
 	"regexp"
-	"sort"
 	"strings"
 	"sync"
-	"text/template"
 	"time"
 
 	"github.com/ClickHouse/clickhouse-go/v2"
@@ -217,7 +214,6 @@ func (q *promqlQuery) removeAllVarMatchers(query string, vars map[string]qbv5.Va
 	return expr.String(), nil
 }
 
-// TODO(srikanthccv): cleanup the templating logic.
 func (q *promqlQuery) renderVars(query string, vars map[string]qbv5.VariableItem, start, end uint64) (string, error) {
 	// First, remove label matchers that use variables with __all__ value.
 	// This must happen before variable substitution so we can detect variable references
@@ -226,40 +222,8 @@ func (q *promqlQuery) renderVars(query string, vars map[string]qbv5.VariableItem
 	if err != nil {
 		return "", err
 	}
-	varsData := map[string]any{}
-	for k, v := range vars {
-		varsData[k] = formatValueForProm(v.Value)
-	}
 
-	querybuilder.AssignReservedVars(varsData, start, end)
-
-	keys := make([]string, 0, len(varsData))
-	for k := range varsData {
-		keys = append(keys, k)
-	}
-	sort.Slice(keys, func(i, j int) bool {
-		return len(keys[i]) > len(keys[j])
-	})
-
-	for _, k := range keys {
-		query = strings.ReplaceAll(query, fmt.Sprintf("{{%s}}", k), fmt.Sprint(varsData[k]))
-		query = strings.ReplaceAll(query, fmt.Sprintf("[[%s]]", k), fmt.Sprint(varsData[k]))
-		query = strings.ReplaceAll(query, fmt.Sprintf("$%s", k), fmt.Sprint(varsData[k]))
-	}
-
-	tmpl := template.New("promql-query")
-	tmpl, err = tmpl.Parse(query)
-	if err != nil {
-		return "", errors.WrapInternalf(err, errors.CodeInternal, "error while replacing template variables")
-	}
-	var newQuery bytes.Buffer
-
-	// replace go template variables
-	err = tmpl.Execute(&newQuery, varsData)
-	if err != nil {
-		return "", errors.WrapInternalf(err, errors.CodeInternal, "error while replacing template variables")
-	}
-	return newQuery.String(), nil
+	return substituteVariables(query, vars, start, end, formatValueForProm, "promql-query")
 }
 
 // Statement renders the PromQL string (no SQL args) without executing it, for

--- a/pkg/querier/render.go
+++ b/pkg/querier/render.go
@@ -1,0 +1,66 @@
+package querier
+
+import (
+	"bytes"
+	"fmt"
+	"sort"
+	"strings"
+	"text/template"
+
+	"github.com/SigNoz/signoz/pkg/errors"
+	"github.com/SigNoz/signoz/pkg/querybuilder"
+	qbtypes "github.com/SigNoz/signoz/pkg/types/querybuildertypes/querybuildertypesv5"
+)
+
+// substituteVariables replaces the caller's variables and the reserved
+// time-range variables in query, accepting each as {{name}}, [[name]] or $name.
+// formatValue renders the values and is what makes the substitution
+// dialect-specific.
+//
+// Names are substituted longest-first so a name that prefixes another is not
+// replaced inside it: with both host and host.name defined, $host.name has to
+// resolve to the latter instead of leaving a dangling .name behind.
+//
+// The literal substitution runs first, then the result is evaluated as a go
+// template with the same variables as its data, so a query may also reference
+// them as {{.name}}. templateName appears only in parse and execute errors.
+func substituteVariables(
+	query string,
+	vars map[string]qbtypes.VariableItem,
+	start, end uint64,
+	formatValue func(any) string,
+	templateName string,
+) (string, error) {
+	varsData := map[string]any{}
+	for k, v := range vars {
+		varsData[k] = formatValue(v.Value)
+	}
+
+	querybuilder.AssignReservedVars(varsData, start, end)
+
+	keys := make([]string, 0, len(varsData))
+	for k := range varsData {
+		keys = append(keys, k)
+	}
+	sort.Slice(keys, func(i, j int) bool {
+		return len(keys[i]) > len(keys[j])
+	})
+
+	for _, k := range keys {
+		query = strings.ReplaceAll(query, fmt.Sprintf("{{%s}}", k), fmt.Sprint(varsData[k]))
+		query = strings.ReplaceAll(query, fmt.Sprintf("[[%s]]", k), fmt.Sprint(varsData[k]))
+		query = strings.ReplaceAll(query, fmt.Sprintf("$%s", k), fmt.Sprint(varsData[k]))
+	}
+
+	tmpl, err := template.New(templateName).Parse(query)
+	if err != nil {
+		return "", errors.WrapInternalf(err, errors.CodeInternal, "error while replacing template variables")
+	}
+	var newQuery bytes.Buffer
+
+	// replace go template variables
+	if err := tmpl.Execute(&newQuery, varsData); err != nil {
+		return "", errors.WrapInternalf(err, errors.CodeInternal, "error while replacing template variables")
+	}
+	return newQuery.String(), nil
+}

--- a/pkg/querier/render_test.go
+++ b/pkg/querier/render_test.go
@@ -1,0 +1,255 @@
+package querier
+
+import (
+	"log/slog"
+	"testing"
+
+	"github.com/SigNoz/signoz/pkg/clickhousesql"
+	"github.com/SigNoz/signoz/pkg/prometheus"
+	qbtypes "github.com/SigNoz/signoz/pkg/types/querybuildertypes/querybuildertypesv5"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// Milliseconds, which is what both callers pass; AssignReservedVars scales them.
+const (
+	testStartMS uint64 = 1700000000000
+	testEndMS   uint64 = 1700000600000
+)
+
+func TestSubstituteVariables(t *testing.T) {
+	tests := []struct {
+		name         string
+		query        string
+		vars         map[string]qbtypes.VariableItem
+		formatValue  func(any) string
+		templateName string
+		expected     string
+	}{
+		{
+			name:         "curly syntax with clickhouse formatter quotes strings",
+			query:        `SELECT * FROM t WHERE service = {{service}}`,
+			vars:         map[string]qbtypes.VariableItem{"service": {Value: "api"}},
+			formatValue:  clickhousesql.Literal,
+			templateName: "clickhouse-query",
+			expected:     `SELECT * FROM t WHERE service = 'api'`,
+		},
+		{
+			name:         "square syntax",
+			query:        `SELECT * FROM t WHERE service = [[service]]`,
+			vars:         map[string]qbtypes.VariableItem{"service": {Value: "api"}},
+			formatValue:  clickhousesql.Literal,
+			templateName: "clickhouse-query",
+			expected:     `SELECT * FROM t WHERE service = 'api'`,
+		},
+		{
+			name:         "dollar syntax",
+			query:        `SELECT * FROM t WHERE service = $service`,
+			vars:         map[string]qbtypes.VariableItem{"service": {Value: "api"}},
+			formatValue:  clickhousesql.Literal,
+			templateName: "clickhouse-query",
+			expected:     `SELECT * FROM t WHERE service = 'api'`,
+		},
+		{
+			name:  "all three syntaxes in one query",
+			query: `SELECT * FROM t WHERE a = {{service}} AND b = [[service]] AND c = $service`,
+			vars:  map[string]qbtypes.VariableItem{"service": {Value: "api"}},
+
+			formatValue:  clickhousesql.Literal,
+			templateName: "clickhouse-query",
+			expected:     `SELECT * FROM t WHERE a = 'api' AND b = 'api' AND c = 'api'`,
+		},
+		{
+			// The longest-first ordering is what keeps "host" from matching
+			// inside "$host.name" and leaving a dangling ".name" behind.
+			name:  "longest name wins when one name prefixes another",
+			query: `SELECT * FROM t WHERE h = $host.name AND s = $host`,
+			vars: map[string]qbtypes.VariableItem{
+				"host":      {Value: "srv"},
+				"host.name": {Value: "web-1"},
+			},
+			formatValue:  clickhousesql.Literal,
+			templateName: "clickhouse-query",
+			expected:     `SELECT * FROM t WHERE h = 'web-1' AND s = 'srv'`,
+		},
+		{
+			name:         "numeric and boolean values are not quoted",
+			query:        `SELECT * FROM t WHERE code = $code AND ok = $ok`,
+			vars:         map[string]qbtypes.VariableItem{"code": {Value: 500}, "ok": {Value: false}},
+			formatValue:  clickhousesql.Literal,
+			templateName: "clickhouse-query",
+			expected:     `SELECT * FROM t WHERE code = 500 AND ok = false`,
+		},
+		{
+			name:         "list value renders as a clickhouse array",
+			query:        `SELECT * FROM t WHERE service IN $services`,
+			vars:         map[string]qbtypes.VariableItem{"services": {Value: []any{"api", "web"}}},
+			formatValue:  clickhousesql.Literal,
+			templateName: "clickhouse-query",
+			expected:     `SELECT * FROM t WHERE service IN ['api','web']`,
+		},
+		{
+			name:         "list value renders as a promql alternation",
+			query:        `sum(rate(m{service=~"$services"}[5m]))`,
+			vars:         map[string]qbtypes.VariableItem{"services": {Value: []any{"api", "web"}}},
+			formatValue:  formatValueForProm,
+			templateName: "promql-query",
+			expected:     `sum(rate(m{service=~"api|web"}[5m]))`,
+		},
+		{
+			name:         "promql formatter leaves strings unquoted",
+			query:        `sum(rate(m{service="$service"}[5m]))`,
+			vars:         map[string]qbtypes.VariableItem{"service": {Value: "api"}},
+			formatValue:  formatValueForProm,
+			templateName: "promql-query",
+			expected:     `sum(rate(m{service="api"}[5m]))`,
+		},
+		{
+			name:         "reserved time range variables",
+			query:        `SELECT * FROM t WHERE ts BETWEEN $start_timestamp_ms AND $end_timestamp_ms`,
+			vars:         map[string]qbtypes.VariableItem{},
+			formatValue:  clickhousesql.Literal,
+			templateName: "clickhouse-query",
+			expected:     `SELECT * FROM t WHERE ts BETWEEN 1700000000000 AND 1700000600000`,
+		},
+		{
+			name:         "reserved second, nano and datetime variables",
+			query:        `$start_timestamp $end_timestamp $start_timestamp_nano $end_timestamp_nano {{start_datetime}} [[end_datetime]]`,
+			vars:         map[string]qbtypes.VariableItem{},
+			formatValue:  clickhousesql.Literal,
+			templateName: "clickhouse-query",
+			expected:     `1700000000 1700000600 1700000000000000000 1700000600000000000 toDateTime(1700000000) toDateTime(1700000600)`,
+		},
+		{
+			name:         "reserved SIGNOZ variables",
+			query:        `SELECT * FROM t WHERE ts BETWEEN $SIGNOZ_START_TIME AND $SIGNOZ_END_TIME`,
+			vars:         map[string]qbtypes.VariableItem{},
+			formatValue:  clickhousesql.Literal,
+			templateName: "clickhouse-query",
+			expected:     `SELECT * FROM t WHERE ts BETWEEN 1700000000000 AND 1700000600000`,
+		},
+		{
+			// A dotted reference survives the literal pass and is resolved by
+			// the go template pass instead.
+			name:         "go template reference is evaluated against the same variables",
+			query:        `SELECT * FROM t WHERE service = {{.service}}`,
+			vars:         map[string]qbtypes.VariableItem{"service": {Value: "api"}},
+			formatValue:  clickhousesql.Literal,
+			templateName: "clickhouse-query",
+			expected:     `SELECT * FROM t WHERE service = 'api'`,
+		},
+		{
+			name:         "go template control flow is evaluated",
+			query:        `SELECT * FROM t{{if .service}} WHERE service = {{.service}}{{end}}`,
+			vars:         map[string]qbtypes.VariableItem{"service": {Value: "api"}},
+			formatValue:  clickhousesql.Literal,
+			templateName: "clickhouse-query",
+			expected:     `SELECT * FROM t WHERE service = 'api'`,
+		},
+		{
+			name:         "query with no variables is unchanged",
+			query:        `SELECT count() FROM t`,
+			vars:         map[string]qbtypes.VariableItem{},
+			formatValue:  clickhousesql.Literal,
+			templateName: "clickhouse-query",
+			expected:     `SELECT count() FROM t`,
+		},
+		{
+			name:         "unknown variable reference is left alone",
+			query:        `SELECT * FROM t WHERE service = $nope`,
+			vars:         map[string]qbtypes.VariableItem{"service": {Value: "api"}},
+			formatValue:  clickhousesql.Literal,
+			templateName: "clickhouse-query",
+			expected:     `SELECT * FROM t WHERE service = $nope`,
+		},
+		{
+			name:         "single quote in a value is escaped for clickhouse",
+			query:        `SELECT * FROM t WHERE service = $service`,
+			vars:         map[string]qbtypes.VariableItem{"service": {Value: `o'brien`}},
+			formatValue:  clickhousesql.Literal,
+			templateName: "clickhouse-query",
+			expected:     `SELECT * FROM t WHERE service = 'o\'brien'`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := substituteVariables(tt.query, tt.vars, testStartMS, testEndMS, tt.formatValue, tt.templateName)
+			require.NoError(t, err)
+			assert.Equal(t, tt.expected, got)
+		})
+	}
+}
+
+func TestSubstituteVariablesErrors(t *testing.T) {
+	tests := []struct {
+		name         string
+		query        string
+		vars         map[string]qbtypes.VariableItem
+		templateName string
+	}{
+		{
+			name:         "unclosed action fails to parse",
+			query:        `SELECT * FROM t WHERE service = {{.service`,
+			vars:         map[string]qbtypes.VariableItem{"service": {Value: "api"}},
+			templateName: "clickhouse-query",
+		},
+		{
+			name:         "unterminated if fails to parse",
+			query:        `SELECT * FROM t{{if .service}} WHERE service = {{.service}}`,
+			vars:         map[string]qbtypes.VariableItem{"service": {Value: "api"}},
+			templateName: "clickhouse-query",
+		},
+		{
+			name:         "field lookup on a non struct fails to execute",
+			query:        `SELECT * FROM t WHERE service = {{.service.name}}`,
+			vars:         map[string]qbtypes.VariableItem{"service": {Value: "api"}},
+			templateName: "promql-query",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := substituteVariables(tt.query, tt.vars, testStartMS, testEndMS, clickhousesql.Literal, tt.templateName)
+			require.Error(t, err)
+			assert.Empty(t, got)
+			assert.Contains(t, err.Error(), tt.templateName)
+		})
+	}
+}
+
+// The two callers differ only in how a value is formatted, so the same query
+// and variables must render for each dialect's own conventions.
+func TestRenderVarsPerDialect(t *testing.T) {
+	vars := map[string]qbtypes.VariableItem{"service": {Value: "api"}}
+
+	t.Run("clickhouse", func(t *testing.T) {
+		q := &chSQLQuery{}
+		got, err := q.renderVars(`SELECT * FROM t WHERE service = $service AND ts >= $start_timestamp_ms`, vars, testStartMS, testEndMS)
+		require.NoError(t, err)
+		assert.Equal(t, `SELECT * FROM t WHERE service = 'api' AND ts >= 1700000000000`, got)
+	})
+
+	t.Run("promql", func(t *testing.T) {
+		q := &promqlQuery{logger: slog.Default(), parser: prometheus.NewParser()}
+		got, err := q.renderVars(`sum(rate(m{service="$service"}[5m]))`, vars, testStartMS, testEndMS)
+		require.NoError(t, err)
+		assert.Equal(t, `sum(rate(m{service="api"}[5m]))`, got)
+	})
+}
+
+// The __all__ pre-step is PromQL-only: it drops the matcher rather than
+// substituting the sentinel into the query.
+func TestRenderVarsPromqlDropsAllMatcher(t *testing.T) {
+	q := &promqlQuery{logger: slog.Default(), parser: prometheus.NewParser()}
+
+	got, err := q.renderVars(
+		`sum(rate({__name__="system.cpu.time", "host.name"=~"$host.name"}[5m]))`,
+		map[string]qbtypes.VariableItem{
+			"host.name": {Type: qbtypes.DynamicVariableType, Value: "__all__"},
+		},
+		testStartMS, testEndMS,
+	)
+	require.NoError(t, err)
+	assert.Equal(t, `sum(rate({__name__="system.cpu.time"}[5m]))`, got)
+}


### PR DESCRIPTION
#### Description

- `chSQLQuery.renderVars` and `promqlQuery.renderVars` each carried their own copy of the same variable-substitution algorithm — build the vars map, `AssignReservedVars`, sort names longest-first, three `ReplaceAll` passes for `{{var}}` / `[[var]]` / `$var`, then a `text/template` parse and execute. Both carried a `TODO(srikanthccv): cleanup the templating logic`.
- Extracted that algorithm into `substituteVariables` (new `pkg/querier/render.go`). The two methods now pass in the only things that actually differed: the per-value formatter (`formatValueForCH` / `formatValueForProm`) and the template name that shows up in errors.
- The PromQL-only `removeAllVarMatchers` pre-step stays at its call site, so the one real difference between the two paths is now visible instead of buried inside a near-identical copy. That step is also where the duplication had already drifted — the ClickHouse path never grew it.
- No behaviour change. `renderVars` had no test coverage at all before, so `render_test.go` pins each substitution syntax, the longest-first ordering, the reserved time-range variables, the go-template pass, and both the parse and execute error paths.
- Removes both TODO comments.

#### Issues closed by this PR

Closes #12372

#### Additional Information

Since this is a behaviour-preserving refactor, I checked that rather than assuming it. Alongside the committed tests I ran a temporary differential test (not part of this PR) that kept verbatim copies of the two pre-refactor `renderVars` bodies as oracles and compared them against the extracted helper over a corpus of queries, variable subsets and time ranges — every syntax, dotted and prefixing names, arrays, nil pointers, quote/backslash escaping, reserved vars, values that themselves look like template syntax, and malformed templates. **8,610 combinations per dialect matched byte-for-byte, including identical error strings.**

Verified on the committed tree (exported with `git archive` so the check ran on exactly what is in the commit):

- `go build ./...`
- `go vet ./pkg/querier/...`
- `go test -race -count=1 -short ./pkg/querier/...`
- `golangci-lint run ./pkg/querier/...` with the repo's `.golangci.yml` — 0 issues
- tests of the packages that depend on `pkg/querier` (`pkg/query-service/rules`, `pkg/signoz`, `pkg/modules/services`, `pkg/modules/rawdataexport`, `pkg/modules/spanpercentile`)

One unrelated thing I noticed while running the formatter: `pkg/querier/postprocess.go` is already `gofmt`-dirty on pristine `main` (an import-ordering slip). I left it alone to keep this diff to the issue's scope, but happy to send it separately.
