### PR TITLE
feat(llm-observability): AI explorer QB and builder_ai_query wiring

### DIFF
--- a/frontend/src/api/v5/queryRange/convertV5Response.ts
+++ b/frontend/src/api/v5/queryRange/convertV5Response.ts
@@ -13,7 +13,6 @@ import {
 } from 'types/api/v5/queryRange';
 import { QueryDataV3 } from 'types/api/widgets/getQuery';
 
-/** builder_query and builder_ai_query both carry a BuilderQuery spec, hence aggregation metadata. */
 const isBuilderQueryEnvelope = (
 	envelope: QueryEnvelope,
 ): envelope is QueryEnvelope & { spec: BuilderQuery } =>

--- a/frontend/src/api/v5/queryRange/convertV5Response.ts
+++ b/frontend/src/api/v5/queryRange/convertV5Response.ts
@@ -418,7 +418,11 @@ export function convertV5ResponseToLegacy(
 	const aggregationPerQuery =
 		params?.compositeQuery?.queries?.filter(isBuilderQueryEnvelope).reduce(
 			(acc, query) => {
-				if ('aggregations' in query.spec && query.spec.name) {
+				if (
+					isBuilderQueryEnvelope(query) &&
+					'aggregations' in query.spec &&
+					query.spec.name
+				) {
 					acc[query.spec.name] = query.spec.aggregations;
 				}
 				return acc;

--- a/frontend/src/api/v5/queryRange/convertV5Response.ts
+++ b/frontend/src/api/v5/queryRange/convertV5Response.ts
@@ -2,14 +2,22 @@ import { cloneDeep, isEmpty } from 'lodash-es';
 import { SuccessResponse, Warning } from 'types/api';
 import { MetricRangePayloadV3 } from 'types/api/metrics/getQueryRange';
 import {
+	BuilderQuery,
 	DistributionData,
 	MetricRangePayloadV5,
+	QueryEnvelope,
 	QueryRangeRequestV5,
 	RawData,
 	ScalarData,
 	TimeSeriesData,
 } from 'types/api/v5/queryRange';
 import { QueryDataV3 } from 'types/api/widgets/getQuery';
+
+/** builder_query and builder_ai_query both carry a BuilderQuery spec, hence aggregation metadata. */
+const isBuilderQueryEnvelope = (
+	envelope: QueryEnvelope,
+): envelope is QueryEnvelope & { spec: BuilderQuery } =>
+	envelope.type === 'builder_query' || envelope.type === 'builder_ai_query';
 
 function getColName(
 	col: ScalarData['columns'][number],
@@ -409,21 +417,15 @@ export function convertV5ResponseToLegacy(
 	const v5Data = payload?.data;
 
 	const aggregationPerQuery =
-		params?.compositeQuery?.queries
-			?.filter((query) => query.type === 'builder_query')
-			.reduce(
-				(acc, query) => {
-					if (
-						query.type === 'builder_query' &&
-						'aggregations' in query.spec &&
-						query.spec.name
-					) {
-						acc[query.spec.name] = query.spec.aggregations;
-					}
-					return acc;
-				},
-				{} as Record<string, any>,
-			) || {};
+		params?.compositeQuery?.queries?.filter(isBuilderQueryEnvelope).reduce(
+			(acc, query) => {
+				if ('aggregations' in query.spec && query.spec.name) {
+					acc[query.spec.name] = query.spec.aggregations;
+				}
+				return acc;
+			},
+			{} as Record<string, any>,
+		) || {};
 
 	// clickhouse_sql queries have no aggregation metadata; their value columns
 	// are named/keyed by the real SQL alias the response carries (see getColId).

--- a/frontend/src/api/v5/queryRange/prepareQueryRangePayloadV5.test.ts
+++ b/frontend/src/api/v5/queryRange/prepareQueryRangePayloadV5.test.ts
@@ -14,6 +14,7 @@ import {
 	QueryBuilderFormula as V5QueryBuilderFormula,
 	QueryEnvelope,
 	QueryRangePayloadV5,
+	RequestType,
 } from 'types/api/v5/queryRange';
 import { EQueryType } from 'types/common/dashboard';
 import { DataSource, ReduceOperators } from 'types/common/queryBuilder';
@@ -933,5 +934,43 @@ describe('convertBuilderQueriesToV5 having normalization', () => {
 		expect(buildSpec({ expression: 'count() > 5' }).having).toStrictEqual({
 			expression: 'count() > 5',
 		});
+	});
+});
+
+describe('convertBuilderQueriesToV5 builder query type', () => {
+	const buildEnvelope = (
+		builderQueryType: IBuilderQuery['builderQueryType'],
+		requestType: RequestType,
+	): QueryEnvelope => {
+		const [envelope] = convertBuilderQueriesToV5(
+			{
+				A: {
+					dataSource: DataSource.TRACES,
+					queryName: 'A',
+					builderQueryType,
+				} as unknown as IBuilderQuery,
+			},
+			requestType,
+		);
+		return envelope;
+	};
+
+	it.each<[RequestType]>([
+		['trace'],
+		['raw'],
+		['time_series'],
+		['scalar'],
+		['distribution'],
+	])('sends builder_ai_query for the %s request type', (requestType) => {
+		expect(buildEnvelope('builder_ai_query', requestType).type).toBe(
+			'builder_ai_query',
+		);
+	});
+
+	it.each<[string, IBuilderQuery['builderQueryType']]>([
+		['an unmarked query', undefined],
+		['an explicitly generic query', 'builder_query'],
+	])('sends builder_query for %s', (_label, builderQueryType) => {
+		expect(buildEnvelope(builderQueryType, 'trace').type).toBe('builder_query');
 	});
 });

--- a/frontend/src/api/v5/queryRange/prepareQueryRangePayloadV5.ts
+++ b/frontend/src/api/v5/queryRange/prepareQueryRangePayloadV5.ts
@@ -364,7 +364,7 @@ export function convertBuilderQueriesToV5(
 			}
 
 			return {
-				type: 'builder_query' as QueryType,
+				type: queryData.builderQueryType ?? 'builder_query',
 				spec,
 			};
 		},

--- a/frontend/src/components/QueryBuilderV2/QueryV2/QuerySearch/QuerySearch.tsx
+++ b/frontend/src/components/QueryBuilderV2/QueryV2/QuerySearch/QuerySearch.tsx
@@ -248,12 +248,6 @@ function QuerySearch({
 		[keySuggestions],
 	);
 
-	// read inside fetchValueSuggestions so resolving a key's context does not churn its deps
-	const keySuggestionsRef = useRef<QueryKeyDataSuggestionsProps[]>([]);
-	useEffect(() => {
-		keySuggestionsRef.current = keySuggestions || [];
-	}, [keySuggestions]);
-
 	const [showExamples] = useState(false);
 
 	const [cursorPos, setCursorPos] = useState({ line: 0, ch: 0 });
@@ -511,9 +505,6 @@ function QuerySearch({
 							dataSource,
 							key,
 							searchText: sanitizedSearchText,
-							fieldContext: keySuggestionsRef.current.find(
-								(option) => option.label === key,
-							)?.fieldContext,
 							signalSource: signalSource as 'meter' | '',
 							metricName: debouncedMetricName ?? undefined,
 						}).then((response) => {

--- a/frontend/src/components/QueryBuilderV2/QueryV2/QuerySearch/QuerySearch.tsx
+++ b/frontend/src/components/QueryBuilderV2/QueryV2/QuerySearch/QuerySearch.tsx
@@ -516,6 +516,15 @@ function QuerySearch({
 							)?.fieldContext,
 							signalSource: signalSource as 'meter' | '',
 							metricName: debouncedMetricName ?? undefined,
+						}).then((response) => {
+							const responseData = response.data as any;
+							const data = responseData.data || {};
+							const values = data.values || {};
+							return {
+								stringValues: values.stringValues || [],
+								numberValues: values.numberValues || [],
+								complete: data.complete ?? false,
+							};
 						});
 
 				// Skip updates if component unmounted or key changed

--- a/frontend/src/components/QueryBuilderV2/QueryV2/QuerySearch/QuerySearch.tsx
+++ b/frontend/src/components/QueryBuilderV2/QueryV2/QuerySearch/QuerySearch.tsx
@@ -328,7 +328,7 @@ function QuerySearch({
 
 			lastFetchedKeyRef.current = searchText || '';
 
-			const keys = await fetchFieldKeysForQuery({
+			const response = await fetchFieldKeysForQuery({
 				builderQueryType: queryData.builderQueryType,
 				dataSource,
 				searchText: searchText || '',
@@ -337,7 +337,8 @@ function QuerySearch({
 				metricNamespace,
 			});
 
-			if (keys) {
+			if (response.data.data) {
+				const { keys } = response.data.data;
 				const options = generateOptions(keys);
 				// Deduplicate by full variant identity (name + context + data type), NOT by
 				// label. deduping by label removes varient which is not expected. If we need

--- a/frontend/src/components/QueryBuilderV2/QueryV2/QuerySearch/QuerySearch.tsx
+++ b/frontend/src/components/QueryBuilderV2/QueryV2/QuerySearch/QuerySearch.tsx
@@ -16,8 +16,6 @@ import { githubLight } from '@uiw/codemirror-theme-github';
 import CodeMirror, { EditorView, keymap, Prec } from '@uiw/react-codemirror';
 import { Button, Card, Collapse, Popover, Tooltip } from 'antd';
 import { Badge } from '@signozhq/ui/badge';
-import { getKeySuggestions } from 'api/querySuggestions/getKeySuggestions';
-import { getValueSuggestions } from 'api/querySuggestions/getValueSuggestion';
 import cx from 'classnames';
 import {
 	negationQueryOperatorSuggestions,
@@ -54,6 +52,12 @@ import {
 	SUGGESTION_FETCH_DEBOUNCE_MS,
 	SUGGESTIONS_SECTION,
 } from './constants';
+import {
+	fetchFieldKeysForQuery,
+	fetchFieldValuesForQuery,
+	SuggestedFieldKey,
+	SuggestedFieldKeysByName,
+} from './fieldSuggestions';
 import {
 	combineInitialAndUserExpression,
 	dedupeOptionsByLabel,
@@ -244,6 +248,12 @@ function QuerySearch({
 		[keySuggestions],
 	);
 
+	// read inside fetchValueSuggestions so resolving a key's context does not churn its deps
+	const keySuggestionsRef = useRef<QueryKeyDataSuggestionsProps[]>([]);
+	useEffect(() => {
+		keySuggestionsRef.current = keySuggestions || [];
+	}, [keySuggestions]);
+
 	const [showExamples] = useState(false);
 
 	const [cursorPos, setCursorPos] = useState({ line: 0, ch: 0 });
@@ -264,10 +274,8 @@ function QuerySearch({
 	);
 
 	// Add back the generateOptions function and useEffect
-	const generateOptions = (keys: {
-		[key: string]: QueryKeyDataSuggestionsProps[];
-	}): any[] =>
-		Object.values(keys).flatMap((items: QueryKeyDataSuggestionsProps[]) =>
+	const generateOptions = (keys: SuggestedFieldKeysByName): any[] =>
+		Object.values(keys).flatMap((items: SuggestedFieldKey[]) =>
 			items.map(({ name, fieldDataType, fieldContext }) => ({
 				label: name,
 				type: fieldDataType === 'string' ? 'keyword' : fieldDataType,
@@ -320,16 +328,16 @@ function QuerySearch({
 
 			lastFetchedKeyRef.current = searchText || '';
 
-			const response = await getKeySuggestions({
-				signal: dataSource,
+			const keys = await fetchFieldKeysForQuery({
+				builderQueryType: queryData.builderQueryType,
+				dataSource,
 				searchText: searchText || '',
 				metricName: debouncedMetricName ?? undefined,
 				signalSource: signalSource as 'meter' | '',
 				metricNamespace,
 			});
 
-			if (response.data.data) {
-				const { keys } = response.data.data;
+			if (keys) {
 				const options = generateOptions(keys);
 				// Deduplicate by full variant identity (name + context + data type), NOT by
 				// label. deduping by label removes varient which is not expected. If we need
@@ -363,6 +371,7 @@ function QuerySearch({
 			hardcodedAttributeKeys,
 			showFilterSuggestionsWithoutMetric,
 			metricNamespace,
+			queryData.builderQueryType,
 		],
 	);
 
@@ -496,21 +505,16 @@ function QuerySearch({
 			try {
 				const values = valueSuggestionsOverride
 					? await valueSuggestionsOverride(key, sanitizedSearchText)
-					: await getValueSuggestions({
+					: await fetchFieldValuesForQuery({
+							builderQueryType: queryData.builderQueryType,
+							dataSource,
 							key,
 							searchText: sanitizedSearchText,
-							signal: dataSource,
+							fieldContext: keySuggestionsRef.current.find(
+								(option) => option.label === key,
+							)?.fieldContext,
 							signalSource: signalSource as 'meter' | '',
 							metricName: debouncedMetricName ?? undefined,
-						}).then((response) => {
-							const responseData = response.data as any;
-							const data = responseData.data || {};
-							const values = data.values || {};
-							return {
-								stringValues: values.stringValues || [],
-								numberValues: values.numberValues || [],
-								complete: data.complete ?? false,
-							};
 						});
 
 				// Skip updates if component unmounted or key changed
@@ -604,6 +608,7 @@ function QuerySearch({
 			signalSource,
 			toggleSuggestions,
 			valueSuggestionsOverride,
+			queryData.builderQueryType,
 		],
 	);
 

--- a/frontend/src/components/QueryBuilderV2/QueryV2/QuerySearch/__tests__/fieldSuggestions.test.ts
+++ b/frontend/src/components/QueryBuilderV2/QueryV2/QuerySearch/__tests__/fieldSuggestions.test.ts
@@ -1,0 +1,230 @@
+import {
+	getAIObservabilityFieldsKeys,
+	getAIObservabilityFieldsValues,
+} from 'api/generated/services/ai-observability';
+import { TelemetrytypesFieldContextDTO } from 'api/generated/services/sigNoz.schemas';
+import { getKeySuggestions } from 'api/querySuggestions/getKeySuggestions';
+import { getValueSuggestions } from 'api/querySuggestions/getValueSuggestion';
+import { DataSource } from 'types/common/queryBuilder';
+
+import {
+	fetchFieldKeysForQuery,
+	fetchFieldValuesForQuery,
+} from '../fieldSuggestions';
+
+jest.mock('api/generated/services/ai-observability', () => ({
+	getAIObservabilityFieldsKeys: jest.fn(),
+	getAIObservabilityFieldsValues: jest.fn(),
+}));
+
+jest.mock('api/querySuggestions/getKeySuggestions', () => ({
+	getKeySuggestions: jest.fn(),
+}));
+
+jest.mock('api/querySuggestions/getValueSuggestion', () => ({
+	getValueSuggestions: jest.fn(),
+}));
+
+const mockedAIKeys = getAIObservabilityFieldsKeys as jest.MockedFunction<
+	typeof getAIObservabilityFieldsKeys
+>;
+const mockedGenericKeys = getKeySuggestions as jest.MockedFunction<
+	typeof getKeySuggestions
+>;
+const mockedAIValues = getAIObservabilityFieldsValues as jest.MockedFunction<
+	typeof getAIObservabilityFieldsValues
+>;
+const mockedGenericValues = getValueSuggestions as jest.MockedFunction<
+	typeof getValueSuggestions
+>;
+
+const aiValuesResponse = (
+	values: { stringValues?: string[]; numberValues?: number[] } | null,
+	complete = true,
+): Awaited<ReturnType<typeof getAIObservabilityFieldsValues>> =>
+	({
+		status: 'success',
+		data: { complete, values },
+	}) as Awaited<ReturnType<typeof getAIObservabilityFieldsValues>>;
+
+describe('fetchFieldKeysForQuery', () => {
+	beforeEach(() => {
+		jest.clearAllMocks();
+	});
+
+	it('reads the ai_observability endpoint for a builder_ai_query', async () => {
+		mockedAIKeys.mockResolvedValue({
+			status: 'success',
+			data: {
+				complete: true,
+				keys: { llm_call_count: [{ name: 'llm_call_count' }] },
+			},
+		} as Awaited<ReturnType<typeof getAIObservabilityFieldsKeys>>);
+
+		const keys = await fetchFieldKeysForQuery({
+			builderQueryType: 'builder_ai_query',
+			dataSource: DataSource.TRACES,
+			searchText: 'llm',
+		});
+
+		expect(mockedAIKeys).toHaveBeenCalledWith({ searchText: 'llm' });
+		expect(mockedGenericKeys).not.toHaveBeenCalled();
+		expect(keys).toStrictEqual({
+			llm_call_count: [{ name: 'llm_call_count' }],
+		});
+	});
+
+	it.each<[string, 'builder_query' | undefined]>([
+		['an unmarked query', undefined],
+		['an explicitly generic query', 'builder_query'],
+	])('reads the generic endpoint for %s', async (_label, builderQueryType) => {
+		mockedGenericKeys.mockResolvedValue({
+			data: { status: 'success', data: { complete: true, keys: {} } },
+		} as Awaited<ReturnType<typeof getKeySuggestions>>);
+
+		await fetchFieldKeysForQuery({
+			builderQueryType,
+			dataSource: DataSource.TRACES,
+			searchText: 'svc',
+		});
+
+		expect(mockedAIKeys).not.toHaveBeenCalled();
+		expect(mockedGenericKeys).toHaveBeenCalledWith(
+			expect.objectContaining({ signal: DataSource.TRACES, searchText: 'svc' }),
+		);
+	});
+
+	it('normalizes a null ai_observability keys payload to undefined', async () => {
+		mockedAIKeys.mockResolvedValue({
+			status: 'success',
+			data: { complete: false, keys: null },
+		} as Awaited<ReturnType<typeof getAIObservabilityFieldsKeys>>);
+
+		await expect(
+			fetchFieldKeysForQuery({
+				builderQueryType: 'builder_ai_query',
+				dataSource: DataSource.TRACES,
+				searchText: '',
+			}),
+		).resolves.toBeUndefined();
+	});
+});
+
+describe('fetchFieldValuesForQuery', () => {
+	beforeEach(() => {
+		jest.clearAllMocks();
+	});
+
+	it('reads the ai_observability endpoint for a builder_ai_query', async () => {
+		mockedAIValues.mockResolvedValue(
+			aiValuesResponse({ stringValues: ['gpt-4o'], numberValues: [] }),
+		);
+
+		const values = await fetchFieldValuesForQuery({
+			builderQueryType: 'builder_ai_query',
+			dataSource: DataSource.TRACES,
+			key: 'gen_ai.request.model',
+			searchText: 'gpt',
+			fieldContext: 'attribute',
+		});
+
+		expect(mockedGenericValues).not.toHaveBeenCalled();
+		expect(values).toStrictEqual({
+			stringValues: ['gpt-4o'],
+			numberValues: [],
+			complete: true,
+		});
+	});
+
+	it('forwards fieldContext so the endpoint can short-circuit trace aggregates', async () => {
+		mockedAIValues.mockResolvedValue(aiValuesResponse({}));
+
+		const values = await fetchFieldValuesForQuery({
+			builderQueryType: 'builder_ai_query',
+			dataSource: DataSource.TRACES,
+			key: 'total_tokens',
+			searchText: '',
+			fieldContext: 'trace',
+		});
+
+		expect(mockedAIValues).toHaveBeenCalledWith({
+			name: 'total_tokens',
+			searchText: '',
+			fieldContext: TelemetrytypesFieldContextDTO.trace,
+		});
+		expect(values).toStrictEqual({
+			stringValues: [],
+			numberValues: [],
+			complete: true,
+		});
+	});
+
+	it('normalizes a null ai_observability values payload to empty lists', async () => {
+		mockedAIValues.mockResolvedValue(aiValuesResponse(null, false));
+
+		await expect(
+			fetchFieldValuesForQuery({
+				builderQueryType: 'builder_ai_query',
+				dataSource: DataSource.TRACES,
+				key: 'llm_call_count',
+				searchText: '',
+				fieldContext: 'trace',
+			}),
+		).resolves.toStrictEqual({
+			stringValues: [],
+			numberValues: [],
+			complete: false,
+		});
+	});
+
+	it.each<[string, 'builder_query' | undefined]>([
+		['an unmarked query', undefined],
+		['an explicitly generic query', 'builder_query'],
+	])('reads the generic endpoint for %s', async (_label, builderQueryType) => {
+		mockedGenericValues.mockResolvedValue({
+			data: {
+				data: { complete: false, values: { stringValues: ['frontend'] } },
+			},
+		} as unknown as Awaited<ReturnType<typeof getValueSuggestions>>);
+
+		const values = await fetchFieldValuesForQuery({
+			builderQueryType,
+			dataSource: DataSource.TRACES,
+			key: 'service.name',
+			searchText: 'front',
+		});
+
+		expect(mockedAIValues).not.toHaveBeenCalled();
+		expect(mockedGenericValues).toHaveBeenCalledWith(
+			expect.objectContaining({
+				signal: DataSource.TRACES,
+				key: 'service.name',
+				searchText: 'front',
+			}),
+		);
+		expect(values).toStrictEqual({
+			stringValues: ['frontend'],
+			numberValues: [],
+			complete: false,
+		});
+	});
+
+	it('falls back to empty lists when the generic endpoint returns no data', async () => {
+		mockedGenericValues.mockResolvedValue({ data: {} } as unknown as Awaited<
+			ReturnType<typeof getValueSuggestions>
+		>);
+
+		await expect(
+			fetchFieldValuesForQuery({
+				builderQueryType: 'builder_query',
+				dataSource: DataSource.TRACES,
+				key: 'service.name',
+				searchText: '',
+			}),
+		).resolves.toStrictEqual({
+			stringValues: [],
+			numberValues: [],
+			complete: false,
+		});
+	});
+});

--- a/frontend/src/components/QueryBuilderV2/QueryV2/QuerySearch/__tests__/fieldSuggestions.test.ts
+++ b/frontend/src/components/QueryBuilderV2/QueryV2/QuerySearch/__tests__/fieldSuggestions.test.ts
@@ -136,7 +136,7 @@ describe('fetchFieldValuesForQuery', () => {
 			aiValuesResponse({ stringValues: ['gpt-4o'], numberValues: [] }),
 		);
 
-		const values = await fetchFieldValuesForQuery({
+		const response = await fetchFieldValuesForQuery({
 			builderQueryType: 'builder_ai_query',
 			dataSource: DataSource.TRACES,
 			key: 'gen_ai.request.model',
@@ -145,17 +145,20 @@ describe('fetchFieldValuesForQuery', () => {
 		});
 
 		expect(mockedGenericValues).not.toHaveBeenCalled();
-		expect(values).toStrictEqual({
-			stringValues: ['gpt-4o'],
-			numberValues: [],
-			complete: true,
+		expect(response).toStrictEqual({
+			data: {
+				data: {
+					complete: true,
+					values: { stringValues: ['gpt-4o'], numberValues: [] },
+				},
+			},
 		});
 	});
 
 	it('forwards fieldContext so the endpoint can short-circuit trace aggregates', async () => {
 		mockedAIValues.mockResolvedValue(aiValuesResponse({}));
 
-		const values = await fetchFieldValuesForQuery({
+		await fetchFieldValuesForQuery({
 			builderQueryType: 'builder_ai_query',
 			dataSource: DataSource.TRACES,
 			key: 'total_tokens',
@@ -168,14 +171,9 @@ describe('fetchFieldValuesForQuery', () => {
 			searchText: '',
 			fieldContext: TelemetrytypesFieldContextDTO.trace,
 		});
-		expect(values).toStrictEqual({
-			stringValues: [],
-			numberValues: [],
-			complete: true,
-		});
 	});
 
-	it('normalizes a null ai_observability values payload to empty lists', async () => {
+	it('wraps the ai_observability payload in the envelope the call site unwraps', async () => {
 		mockedAIValues.mockResolvedValue(aiValuesResponse(null, false));
 
 		await expect(
@@ -187,9 +185,7 @@ describe('fetchFieldValuesForQuery', () => {
 				fieldContext: 'trace',
 			}),
 		).resolves.toStrictEqual({
-			stringValues: [],
-			numberValues: [],
-			complete: false,
+			data: { data: { complete: false, values: null } },
 		});
 	});
 
@@ -197,13 +193,14 @@ describe('fetchFieldValuesForQuery', () => {
 		['an unmarked query', undefined],
 		['an explicitly generic query', 'builder_query'],
 	])('reads the generic endpoint for %s', async (_label, builderQueryType) => {
-		mockedGenericValues.mockResolvedValue({
+		const genericResponse = {
 			data: {
 				data: { complete: false, values: { stringValues: ['frontend'] } },
 			},
-		} as unknown as Awaited<ReturnType<typeof getValueSuggestions>>);
+		} as unknown as Awaited<ReturnType<typeof getValueSuggestions>>;
+		mockedGenericValues.mockResolvedValue(genericResponse);
 
-		const values = await fetchFieldValuesForQuery({
+		const response = await fetchFieldValuesForQuery({
 			builderQueryType,
 			dataSource: DataSource.TRACES,
 			key: 'service.name',
@@ -218,29 +215,6 @@ describe('fetchFieldValuesForQuery', () => {
 				searchText: 'front',
 			}),
 		);
-		expect(values).toStrictEqual({
-			stringValues: ['frontend'],
-			numberValues: [],
-			complete: false,
-		});
-	});
-
-	it('falls back to empty lists when the generic endpoint returns no data', async () => {
-		mockedGenericValues.mockResolvedValue({ data: {} } as unknown as Awaited<
-			ReturnType<typeof getValueSuggestions>
-		>);
-
-		await expect(
-			fetchFieldValuesForQuery({
-				builderQueryType: 'builder_query',
-				dataSource: DataSource.TRACES,
-				key: 'service.name',
-				searchText: '',
-			}),
-		).resolves.toStrictEqual({
-			stringValues: [],
-			numberValues: [],
-			complete: false,
-		});
+		expect(response).toBe(genericResponse);
 	});
 });

--- a/frontend/src/components/QueryBuilderV2/QueryV2/QuerySearch/__tests__/fieldSuggestions.test.ts
+++ b/frontend/src/components/QueryBuilderV2/QueryV2/QuerySearch/__tests__/fieldSuggestions.test.ts
@@ -69,8 +69,9 @@ describe('fetchFieldKeysForQuery', () => {
 
 		expect(mockedAIKeys).toHaveBeenCalledWith({ searchText: 'llm' });
 		expect(mockedGenericKeys).not.toHaveBeenCalled();
-		expect(keys).toStrictEqual({
-			llm_call_count: [{ name: 'llm_call_count' }],
+		expect(keys.data.data).toStrictEqual({
+			complete: true,
+			keys: { llm_call_count: [{ name: 'llm_call_count' }] },
 		});
 	});
 
@@ -94,19 +95,34 @@ describe('fetchFieldKeysForQuery', () => {
 		);
 	});
 
-	it('normalizes a null ai_observability keys payload to undefined', async () => {
+	it('normalizes a null ai_observability keys payload to an empty map', async () => {
 		mockedAIKeys.mockResolvedValue({
 			status: 'success',
 			data: { complete: false, keys: null },
 		} as Awaited<ReturnType<typeof getAIObservabilityFieldsKeys>>);
 
+		const response = await fetchFieldKeysForQuery({
+			builderQueryType: 'builder_ai_query',
+			dataSource: DataSource.TRACES,
+			searchText: '',
+		});
+
+		expect(response.data.data).toStrictEqual({ complete: false, keys: {} });
+	});
+
+	it('passes the generic response through untouched', async () => {
+		const genericResponse = {
+			data: { status: 'success', data: { complete: true, keys: {} } },
+		} as unknown as Awaited<ReturnType<typeof getKeySuggestions>>;
+		mockedGenericKeys.mockResolvedValue(genericResponse);
+
 		await expect(
 			fetchFieldKeysForQuery({
-				builderQueryType: 'builder_ai_query',
+				builderQueryType: 'builder_query',
 				dataSource: DataSource.TRACES,
 				searchText: '',
 			}),
-		).resolves.toBeUndefined();
+		).resolves.toBe(genericResponse);
 	});
 });
 

--- a/frontend/src/components/QueryBuilderV2/QueryV2/QuerySearch/__tests__/fieldSuggestions.test.ts
+++ b/frontend/src/components/QueryBuilderV2/QueryV2/QuerySearch/__tests__/fieldSuggestions.test.ts
@@ -2,7 +2,6 @@ import {
 	getAIObservabilityFieldsKeys,
 	getAIObservabilityFieldsValues,
 } from 'api/generated/services/ai-observability';
-import { TelemetrytypesFieldContextDTO } from 'api/generated/services/sigNoz.schemas';
 import { getKeySuggestions } from 'api/querySuggestions/getKeySuggestions';
 import { getValueSuggestions } from 'api/querySuggestions/getValueSuggestion';
 import { DataSource } from 'types/common/queryBuilder';
@@ -141,7 +140,6 @@ describe('fetchFieldValuesForQuery', () => {
 			dataSource: DataSource.TRACES,
 			key: 'gen_ai.request.model',
 			searchText: 'gpt',
-			fieldContext: 'attribute',
 		});
 
 		expect(mockedGenericValues).not.toHaveBeenCalled();
@@ -155,7 +153,7 @@ describe('fetchFieldValuesForQuery', () => {
 		});
 	});
 
-	it('forwards fieldContext so the endpoint can short-circuit trace aggregates', async () => {
+	it('forwards the key as the name the endpoint expects', async () => {
 		mockedAIValues.mockResolvedValue(aiValuesResponse({}));
 
 		await fetchFieldValuesForQuery({
@@ -163,13 +161,11 @@ describe('fetchFieldValuesForQuery', () => {
 			dataSource: DataSource.TRACES,
 			key: 'total_tokens',
 			searchText: '',
-			fieldContext: 'trace',
 		});
 
 		expect(mockedAIValues).toHaveBeenCalledWith({
 			name: 'total_tokens',
 			searchText: '',
-			fieldContext: TelemetrytypesFieldContextDTO.trace,
 		});
 	});
 
@@ -182,7 +178,6 @@ describe('fetchFieldValuesForQuery', () => {
 				dataSource: DataSource.TRACES,
 				key: 'llm_call_count',
 				searchText: '',
-				fieldContext: 'trace',
 			}),
 		).resolves.toStrictEqual({
 			data: { data: { complete: false, values: null } },

--- a/frontend/src/components/QueryBuilderV2/QueryV2/QuerySearch/fieldSuggestions.ts
+++ b/frontend/src/components/QueryBuilderV2/QueryV2/QuerySearch/fieldSuggestions.ts
@@ -1,0 +1,137 @@
+import {
+	getAIObservabilityFieldsKeys,
+	getAIObservabilityFieldsValues,
+} from 'api/generated/services/ai-observability';
+import { TelemetrytypesFieldContextDTO } from 'api/generated/services/sigNoz.schemas';
+import { getKeySuggestions } from 'api/querySuggestions/getKeySuggestions';
+import { getValueSuggestions } from 'api/querySuggestions/getValueSuggestion';
+import { IBuilderQuery } from 'types/api/queryBuilder/queryBuilderData';
+import { DataSource } from 'types/common/queryBuilder';
+
+/** The only fields both key endpoints agree on; ai_observability reports a wider fieldContext (adds trace). */
+export interface SuggestedFieldKey {
+	name: string;
+	fieldContext?: string;
+	fieldDataType?: string;
+}
+
+export type SuggestedFieldKeysByName = Record<string, SuggestedFieldKey[]>;
+
+export interface SuggestedFieldValues {
+	stringValues: string[];
+	numberValues: number[];
+	complete: boolean;
+}
+
+interface FetchFieldKeysParams {
+	builderQueryType: IBuilderQuery['builderQueryType'];
+	dataSource: DataSource;
+	searchText: string;
+	metricName?: string;
+	signalSource?: 'meter' | '';
+	metricNamespace?: string;
+}
+
+interface FetchFieldValuesParams {
+	builderQueryType: IBuilderQuery['builderQueryType'];
+	dataSource: DataSource;
+	key: string;
+	searchText: string;
+	fieldContext?: SuggestedFieldKey['fieldContext'];
+	metricName?: string;
+	signalSource?: 'meter' | '';
+}
+
+/** getValueSuggestions declares data as an array, but the endpoint returns the object read here. */
+interface LegacyFieldValuesResponseData {
+	complete?: boolean;
+	values?: {
+		stringValues?: string[] | null;
+		numberValues?: number[] | null;
+	} | null;
+}
+
+const EMPTY_FIELD_VALUES: SuggestedFieldValues = {
+	stringValues: [],
+	numberValues: [],
+	complete: false,
+};
+
+/** builder_ai_query needs the ai_observability endpoint: its per-trace aggregates are computed, never ingested. */
+export const fetchFieldKeysForQuery = async ({
+	builderQueryType,
+	dataSource,
+	searchText,
+	metricName,
+	signalSource,
+	metricNamespace,
+}: FetchFieldKeysParams): Promise<SuggestedFieldKeysByName | undefined> => {
+	if (builderQueryType === 'builder_ai_query') {
+		const response = await getAIObservabilityFieldsKeys({ searchText });
+
+		return response.data?.keys ?? undefined;
+	}
+
+	const response = await getKeySuggestions({
+		signal: dataSource,
+		searchText,
+		metricName,
+		signalSource,
+		metricNamespace,
+	});
+
+	return response.data.data?.keys;
+};
+
+/**
+ * Mirrors fetchFieldKeysForQuery for values, so a key suggested under the gen_ai gate is
+ * valued under it too. fieldContext must be forwarded: the endpoint short-circuits the
+ * computed trace aggregates on it rather than scanning for attributes that were never ingested.
+ */
+export const fetchFieldValuesForQuery = async ({
+	builderQueryType,
+	dataSource,
+	key,
+	searchText,
+	fieldContext,
+	metricName,
+	signalSource,
+}: FetchFieldValuesParams): Promise<SuggestedFieldValues> => {
+	if (builderQueryType === 'builder_ai_query') {
+		const response = await getAIObservabilityFieldsValues({
+			name: key,
+			searchText,
+			fieldContext: fieldContext as TelemetrytypesFieldContextDTO | undefined,
+		});
+
+		return {
+			stringValues: response.data?.values?.stringValues ?? [],
+			numberValues: response.data?.values?.numberValues ?? [],
+			complete: response.data?.complete ?? false,
+		};
+	}
+
+	const response = await getValueSuggestions({
+		signal: dataSource,
+		key,
+		searchText,
+		signalSource,
+		metricName,
+	});
+
+	const data = (
+		response.data as unknown as {
+			data?: LegacyFieldValuesResponseData;
+		}
+	)?.data;
+
+	if (!data) {
+		return EMPTY_FIELD_VALUES;
+	}
+
+	return {
+		stringValues: data.values?.stringValues ?? [],
+		numberValues: data.values?.numberValues ?? [],
+		complete: data.complete ?? false,
+	};
+};

--- a/frontend/src/components/QueryBuilderV2/QueryV2/QuerySearch/fieldSuggestions.ts
+++ b/frontend/src/components/QueryBuilderV2/QueryV2/QuerySearch/fieldSuggestions.ts
@@ -2,7 +2,6 @@ import {
 	getAIObservabilityFieldsKeys,
 	getAIObservabilityFieldsValues,
 } from 'api/generated/services/ai-observability';
-import { TelemetrytypesFieldContextDTO } from 'api/generated/services/sigNoz.schemas';
 import { getKeySuggestions } from 'api/querySuggestions/getKeySuggestions';
 import { getValueSuggestions } from 'api/querySuggestions/getValueSuggestion';
 import { IBuilderQuery } from 'types/api/queryBuilder/queryBuilderData';
@@ -51,7 +50,6 @@ interface FetchFieldValuesParams {
 	dataSource: DataSource;
 	key: string;
 	searchText: string;
-	fieldContext?: SuggestedFieldKey['fieldContext'];
 	metricName?: string;
 	signalSource?: 'meter' | '';
 }
@@ -90,7 +88,6 @@ export const fetchFieldValuesForQuery = async ({
 	dataSource,
 	key,
 	searchText,
-	fieldContext,
 	metricName,
 	signalSource,
 }: FetchFieldValuesParams): Promise<SuggestedFieldValuesResponse> => {
@@ -98,7 +95,6 @@ export const fetchFieldValuesForQuery = async ({
 		const response = await getAIObservabilityFieldsValues({
 			name: key,
 			searchText,
-			fieldContext: fieldContext as TelemetrytypesFieldContextDTO | undefined,
 		});
 
 		return { data: { data: response.data } };

--- a/frontend/src/components/QueryBuilderV2/QueryV2/QuerySearch/fieldSuggestions.ts
+++ b/frontend/src/components/QueryBuilderV2/QueryV2/QuerySearch/fieldSuggestions.ts
@@ -25,10 +25,16 @@ export interface SuggestedFieldKeysResponse {
 	data: { data?: SuggestedFieldKeysPayload };
 }
 
-export interface SuggestedFieldValues {
-	stringValues: string[];
-	numberValues: number[];
-	complete: boolean;
+export interface SuggestedFieldValuesPayload {
+	complete?: boolean;
+	values?: {
+		stringValues?: string[] | null;
+		numberValues?: number[] | null;
+	} | null;
+}
+
+export interface SuggestedFieldValuesResponse {
+	data: { data?: SuggestedFieldValuesPayload };
 }
 
 interface FetchFieldKeysParams {
@@ -49,20 +55,6 @@ interface FetchFieldValuesParams {
 	metricName?: string;
 	signalSource?: 'meter' | '';
 }
-
-interface LegacyFieldValuesResponseData {
-	complete?: boolean;
-	values?: {
-		stringValues?: string[] | null;
-		numberValues?: number[] | null;
-	} | null;
-}
-
-const EMPTY_FIELD_VALUES: SuggestedFieldValues = {
-	stringValues: [],
-	numberValues: [],
-	complete: false,
-};
 
 export const fetchFieldKeysForQuery = async ({
 	builderQueryType,
@@ -101,7 +93,7 @@ export const fetchFieldValuesForQuery = async ({
 	fieldContext,
 	metricName,
 	signalSource,
-}: FetchFieldValuesParams): Promise<SuggestedFieldValues> => {
+}: FetchFieldValuesParams): Promise<SuggestedFieldValuesResponse> => {
 	if (builderQueryType === 'builder_ai_query') {
 		const response = await getAIObservabilityFieldsValues({
 			name: key,
@@ -109,34 +101,15 @@ export const fetchFieldValuesForQuery = async ({
 			fieldContext: fieldContext as TelemetrytypesFieldContextDTO | undefined,
 		});
 
-		return {
-			stringValues: response.data?.values?.stringValues ?? [],
-			numberValues: response.data?.values?.numberValues ?? [],
-			complete: response.data?.complete ?? false,
-		};
+		return { data: { data: response.data } };
 	}
 
-	const response = await getValueSuggestions({
+	// getValueSuggestions' declared response type does not match what the endpoint returns.
+	return getValueSuggestions({
 		signal: dataSource,
 		key,
 		searchText,
 		signalSource,
 		metricName,
-	});
-
-	const data = (
-		response.data as unknown as {
-			data?: LegacyFieldValuesResponseData;
-		}
-	)?.data;
-
-	if (!data) {
-		return EMPTY_FIELD_VALUES;
-	}
-
-	return {
-		stringValues: data.values?.stringValues ?? [],
-		numberValues: data.values?.numberValues ?? [],
-		complete: data.complete ?? false,
-	};
+	}) as unknown as Promise<SuggestedFieldValuesResponse>;
 };

--- a/frontend/src/components/QueryBuilderV2/QueryV2/QuerySearch/fieldSuggestions.ts
+++ b/frontend/src/components/QueryBuilderV2/QueryV2/QuerySearch/fieldSuggestions.ts
@@ -8,7 +8,6 @@ import { getValueSuggestions } from 'api/querySuggestions/getValueSuggestion';
 import { IBuilderQuery } from 'types/api/queryBuilder/queryBuilderData';
 import { DataSource } from 'types/common/queryBuilder';
 
-/** The only fields both key endpoints agree on; ai_observability reports a wider fieldContext (adds trace). */
 export interface SuggestedFieldKey {
 	name: string;
 	fieldContext?: string;
@@ -16,6 +15,15 @@ export interface SuggestedFieldKey {
 }
 
 export type SuggestedFieldKeysByName = Record<string, SuggestedFieldKey[]>;
+
+export interface SuggestedFieldKeysPayload {
+	complete: boolean;
+	keys: SuggestedFieldKeysByName;
+}
+
+export interface SuggestedFieldKeysResponse {
+	data: { data?: SuggestedFieldKeysPayload };
+}
 
 export interface SuggestedFieldValues {
 	stringValues: string[];
@@ -42,7 +50,6 @@ interface FetchFieldValuesParams {
 	signalSource?: 'meter' | '';
 }
 
-/** getValueSuggestions declares data as an array, but the endpoint returns the object read here. */
 interface LegacyFieldValuesResponseData {
 	complete?: boolean;
 	values?: {
@@ -57,7 +64,6 @@ const EMPTY_FIELD_VALUES: SuggestedFieldValues = {
 	complete: false,
 };
 
-/** builder_ai_query needs the ai_observability endpoint: its per-trace aggregates are computed, never ingested. */
 export const fetchFieldKeysForQuery = async ({
 	builderQueryType,
 	dataSource,
@@ -65,29 +71,28 @@ export const fetchFieldKeysForQuery = async ({
 	metricName,
 	signalSource,
 	metricNamespace,
-}: FetchFieldKeysParams): Promise<SuggestedFieldKeysByName | undefined> => {
+}: FetchFieldKeysParams): Promise<SuggestedFieldKeysResponse> => {
 	if (builderQueryType === 'builder_ai_query') {
 		const response = await getAIObservabilityFieldsKeys({ searchText });
 
-		return response.data?.keys ?? undefined;
+		return {
+			data: {
+				data: response.data
+					? { complete: response.data.complete, keys: response.data.keys ?? {} }
+					: undefined,
+			},
+		};
 	}
 
-	const response = await getKeySuggestions({
+	return getKeySuggestions({
 		signal: dataSource,
 		searchText,
 		metricName,
 		signalSource,
 		metricNamespace,
 	});
-
-	return response.data.data?.keys;
 };
 
-/**
- * Mirrors fetchFieldKeysForQuery for values, so a key suggested under the gen_ai gate is
- * valued under it too. fieldContext must be forwarded: the endpoint short-circuits the
- * computed trace aggregates on it rather than scanning for attributes that were never ingested.
- */
 export const fetchFieldValuesForQuery = async ({
 	builderQueryType,
 	dataSource,

--- a/frontend/src/components/QueryBuilderV2/QueryV2/QueryV2.tsx
+++ b/frontend/src/components/QueryBuilderV2/QueryV2/QueryV2.tsx
@@ -54,7 +54,7 @@ export const QueryV2 = forwardRef(function QueryV2(
 	const { cloneQuery, panelType } = useQueryBuilder();
 
 	const showFunctions = query?.functions?.length > 0;
-	const { dataSource } = query;
+	const { dataSource, builderQueryType } = query;
 
 	const [isCollapsed, setIsCollapsed] = useState(false);
 
@@ -94,8 +94,9 @@ export const QueryV2 = forwardRef(function QueryV2(
 	);
 
 	const showSpanScopeSelector = useMemo(
-		() => dataSource === DataSource.TRACES,
-		[dataSource],
+		() =>
+			dataSource === DataSource.TRACES && builderQueryType !== 'builder_ai_query',
+		[dataSource, builderQueryType],
 	);
 
 	const showInlineQuerySearch = useMemo(() => {

--- a/frontend/src/constants/queryBuilder.ts
+++ b/frontend/src/constants/queryBuilder.ts
@@ -348,6 +348,19 @@ export const initialQueryMeterWithType: Query = {
 	},
 };
 
+export const initialQueryAIWithType: Query = {
+	...initialQueryWithType,
+	builder: {
+		...initialQueryWithType.builder,
+		queryData: [
+			{
+				...initialQueryBuilderFormValuesMap.traces,
+				builderQueryType: 'builder_ai_query',
+			},
+		],
+	},
+};
+
 export const operatorsByTypes: Record<LocalDataType, string[]> = {
 	string: Object.values(StringOperators),
 	number: Object.values(NumberOperators),

--- a/frontend/src/container/LLMObservability/Explorer/Explorer.tsx
+++ b/frontend/src/container/LLMObservability/Explorer/Explorer.tsx
@@ -18,10 +18,6 @@ import { useOptionsMenu } from 'container/OptionsMenu';
 import LeftToolbarActions from 'container/QueryBuilder/components/ToolbarActions/LeftToolbarActions';
 import RightToolbarActions from 'container/QueryBuilder/components/ToolbarActions/RightToolbarActions';
 import Toolbar from 'container/Toolbar/Toolbar';
-import {
-	getExportQueryData,
-	getQueryByPanelType,
-} from 'container/TracesExplorer/explorerUtils';
 import { ExportDashboard } from 'hooks/dashboard/useExportDashboards';
 import { useGetExportToDashboardLink } from 'hooks/dashboard/useGetExportToDashboardLink';
 import { useGetPanelTypesQueryParam } from 'hooks/queryBuilder/useGetPanelTypesQueryParam';
@@ -52,6 +48,7 @@ import {
 import { v4 } from 'uuid';
 
 import { DEFAULT_PANEL_TYPE, TOOLBAR_VIEWS } from './constants';
+import { getExportQueryData, getQueryByPanelType } from './explorerUtils';
 import ListView from './ListView/ListView';
 import { defaultSelectedColumns } from './ListView/configs';
 import QuerySection from './QuerySection/QuerySection';

--- a/frontend/src/container/LLMObservability/Explorer/Explorer.tsx
+++ b/frontend/src/container/LLMObservability/Explorer/Explorer.tsx
@@ -11,7 +11,7 @@ import QuickFilters from 'components/QuickFilters/QuickFilters';
 import { QuickFiltersSource, SignalType } from 'components/QuickFilters/types';
 import WarningPopover from 'components/WarningPopover/WarningPopover';
 import { AVAILABLE_EXPORT_PANEL_TYPES } from 'constants/panelTypes';
-import { initialQueriesMap, PANEL_TYPES } from 'constants/queryBuilder';
+import { initialQueryAIWithType, PANEL_TYPES } from 'constants/queryBuilder';
 import { usePageActions } from 'container/AIAssistant/pageActions/usePageActions';
 import ExplorerOptionWrapper from 'container/ExplorerOptions/ExplorerOptionWrapper';
 import { useOptionsMenu } from 'container/OptionsMenu';
@@ -51,7 +51,7 @@ import {
 } from 'utils/explorerUtils';
 import { v4 } from 'uuid';
 
-import { TOOLBAR_VIEWS } from './constants';
+import { DEFAULT_PANEL_TYPE, TOOLBAR_VIEWS } from './constants';
 import ListView from './ListView/ListView';
 import { defaultSelectedColumns } from './ListView/configs';
 import QuerySection from './QuerySection/QuerySection';
@@ -88,7 +88,7 @@ function Explorer(): JSX.Element {
 	const listQueryKeyRef = useRef<any>();
 
 	// Get panel type from URL
-	const panelTypesFromUrl = useGetPanelTypesQueryParam(PANEL_TYPES.LIST);
+	const panelTypesFromUrl = useGetPanelTypesQueryParam(DEFAULT_PANEL_TYPE);
 	const [isLoadingQueries, setIsLoadingQueries] = useState<boolean>(false);
 	const [isCancelled, setIsCancelled] = useState(false);
 
@@ -118,8 +118,8 @@ function Explorer(): JSX.Element {
 	const defaultQuery = useMemo(
 		(): Query =>
 			updateAllQueriesOperators(
-				initialQueriesMap.traces,
-				PANEL_TYPES.LIST,
+				initialQueryAIWithType,
+				DEFAULT_PANEL_TYPE,
 				DataSource.TRACES,
 			),
 		[updateAllQueriesOperators],
@@ -185,8 +185,8 @@ function Explorer(): JSX.Element {
 	const exportDefaultQuery = useMemo(
 		() =>
 			getQueryByPanelType(
-				stagedQuery || initialQueriesMap.traces,
-				panelType || PANEL_TYPES.LIST,
+				stagedQuery || initialQueryAIWithType,
+				panelType || DEFAULT_PANEL_TYPE,
 			),
 		[stagedQuery, panelType],
 	);

--- a/frontend/src/container/LLMObservability/Explorer/Explorer.tsx
+++ b/frontend/src/container/LLMObservability/Explorer/Explorer.tsx
@@ -47,7 +47,7 @@ import {
 } from 'utils/explorerUtils';
 import { v4 } from 'uuid';
 
-import { DEFAULT_PANEL_TYPE, TOOLBAR_VIEWS } from './constants';
+import { TOOLBAR_VIEWS } from './constants';
 import { getExportQueryData, getQueryByPanelType } from './explorerUtils';
 import ListView from './ListView/ListView';
 import { defaultSelectedColumns } from './ListView/configs';
@@ -85,7 +85,7 @@ function Explorer(): JSX.Element {
 	const listQueryKeyRef = useRef<any>();
 
 	// Get panel type from URL
-	const panelTypesFromUrl = useGetPanelTypesQueryParam(DEFAULT_PANEL_TYPE);
+	const panelTypesFromUrl = useGetPanelTypesQueryParam(PANEL_TYPES.LIST);
 	const [isLoadingQueries, setIsLoadingQueries] = useState<boolean>(false);
 	const [isCancelled, setIsCancelled] = useState(false);
 
@@ -116,7 +116,7 @@ function Explorer(): JSX.Element {
 		(): Query =>
 			updateAllQueriesOperators(
 				initialQueryAIWithType,
-				DEFAULT_PANEL_TYPE,
+				PANEL_TYPES.LIST,
 				DataSource.TRACES,
 			),
 		[updateAllQueriesOperators],
@@ -183,7 +183,7 @@ function Explorer(): JSX.Element {
 		() =>
 			getQueryByPanelType(
 				stagedQuery || initialQueryAIWithType,
-				panelType || DEFAULT_PANEL_TYPE,
+				panelType || PANEL_TYPES.LIST,
 			),
 		[stagedQuery, panelType],
 	);

--- a/frontend/src/container/LLMObservability/Explorer/ListView/ListView.tsx
+++ b/frontend/src/container/LLMObservability/Explorer/ListView/ListView.tsx
@@ -22,7 +22,6 @@ import { REACT_QUERY_KEY } from 'constants/reactQueryKeys';
 import { useOptionsMenu } from 'container/OptionsMenu';
 import { CustomTimeType } from 'container/TopNav/DateTimeSelectionV2/types';
 import TraceExplorerControls from 'container/TracesExplorer/Controls';
-import { getListViewQuery } from 'container/TracesExplorer/explorerUtils';
 import {
 	getTraceLink,
 	transformSpanRows,
@@ -43,6 +42,7 @@ import { Warning } from 'types/api';
 import { DataSource } from 'types/common/queryBuilder';
 import { GlobalReducer } from 'types/reducer/globalTime';
 
+import { getListViewQuery } from '../explorerUtils';
 import {
 	defaultSelectedColumns,
 	PER_PAGE_OPTIONS,

--- a/frontend/src/container/LLMObservability/Explorer/ListView/ListView.tsx
+++ b/frontend/src/container/LLMObservability/Explorer/ListView/ListView.tsx
@@ -17,7 +17,7 @@ import ListViewOrderBy from 'components/OrderBy/ListViewOrderBy';
 import type { TableColumnDef } from 'components/TanStackTableView/types';
 import { ENTITY_VERSION_V5 } from 'constants/app';
 import { QueryParams } from 'constants/query';
-import { initialQueriesMap, PANEL_TYPES } from 'constants/queryBuilder';
+import { initialQueryAIWithType, PANEL_TYPES } from 'constants/queryBuilder';
 import { REACT_QUERY_KEY } from 'constants/reactQueryKeys';
 import { useOptionsMenu } from 'container/OptionsMenu';
 import { CustomTimeType } from 'container/TopNav/DateTimeSelectionV2/types';
@@ -94,7 +94,7 @@ function ListView({
 		paginationQueryData ?? getDefaultPaginationConfig(PER_PAGE_OPTIONS);
 
 	const requestQuery = useMemo(
-		() => getListViewQuery(stagedQuery || initialQueriesMap.traces, orderBy),
+		() => getListViewQuery(stagedQuery || initialQueryAIWithType, orderBy),
 		[stagedQuery, orderBy],
 	);
 

--- a/frontend/src/container/LLMObservability/Explorer/QuerySection/QuerySection.tsx
+++ b/frontend/src/container/LLMObservability/Explorer/QuerySection/QuerySection.tsx
@@ -1,41 +1,24 @@
-import { memo, useCallback, useMemo } from 'react';
+import { memo, useMemo } from 'react';
 import { QueryBuilderV2 } from 'components/QueryBuilderV2/QueryBuilderV2';
 import { PANEL_TYPES } from 'constants/queryBuilder';
-import ExplorerOrderBy from 'container/ExplorerOrderBy';
-import { OrderByFilterProps } from 'container/QueryBuilder/filters/OrderByFilter/OrderByFilter.interfaces';
 import { QueryBuilderProps } from 'container/QueryBuilder/QueryBuilder.interfaces';
 import { useGetPanelTypesQueryParam } from 'hooks/queryBuilder/useGetPanelTypesQueryParam';
 import { DataSource } from 'types/common/queryBuilder';
 
+import { DEFAULT_PANEL_TYPE } from '../constants';
+
 function QuerySection(): JSX.Element {
-	const panelTypes = useGetPanelTypesQueryParam(PANEL_TYPES.LIST);
+	const panelTypes = useGetPanelTypesQueryParam(DEFAULT_PANEL_TYPE);
 
-	const filterConfigs: QueryBuilderProps['filterConfigs'] = useMemo(() => {
-		const isList = panelTypes === PANEL_TYPES.LIST;
-		const config: QueryBuilderProps['filterConfigs'] = {
+	// Only reaches the builder for timeseries/table; list/trace panels use QueryBuilderV2's listViewTracesFilterConfigs.
+	const filterConfigs: QueryBuilderProps['filterConfigs'] = useMemo(
+		() => ({
 			stepInterval: { isHidden: false, isDisabled: false },
-			limit: { isHidden: isList, isDisabled: true },
-			having: { isHidden: isList, isDisabled: true },
-		};
-
-		return config;
-	}, [panelTypes]);
-
-	const renderOrderBy = useCallback(
-		({ query, onChange }: OrderByFilterProps) => (
-			<ExplorerOrderBy query={query} onChange={onChange} />
-		),
+			limit: { isHidden: false, isDisabled: true },
+			having: { isHidden: false, isDisabled: true },
+		}),
 		[],
 	);
-
-	const queryComponents = useMemo((): QueryBuilderProps['queryComponents'] => {
-		const shouldRenderCustomOrderBy =
-			panelTypes === PANEL_TYPES.LIST || panelTypes === PANEL_TYPES.TRACE;
-
-		return {
-			...(shouldRenderCustomOrderBy ? { renderOrderBy } : {}),
-		};
-	}, [panelTypes, renderOrderBy]);
 
 	const isListViewPanel = useMemo(
 		() => panelTypes === PANEL_TYPES.LIST || panelTypes === PANEL_TYPES.TRACE,
@@ -45,14 +28,10 @@ function QuerySection(): JSX.Element {
 	return (
 		<QueryBuilderV2
 			isListViewPanel={isListViewPanel}
-			showTraceOperator
 			config={{ initialDataSource: DataSource.TRACES, queryVariant: 'static' }}
-			queryComponents={queryComponents}
 			panelType={panelTypes}
 			filterConfigs={filterConfigs}
-			showOnlyWhereClause={
-				panelTypes === PANEL_TYPES.LIST || panelTypes === PANEL_TYPES.TRACE
-			}
+			showOnlyWhereClause={isListViewPanel}
 			version="v3" // setting this to v3 as we this is rendered in logs explorer
 		/>
 	);

--- a/frontend/src/container/LLMObservability/Explorer/QuerySection/QuerySection.tsx
+++ b/frontend/src/container/LLMObservability/Explorer/QuerySection/QuerySection.tsx
@@ -5,10 +5,8 @@ import { QueryBuilderProps } from 'container/QueryBuilder/QueryBuilder.interface
 import { useGetPanelTypesQueryParam } from 'hooks/queryBuilder/useGetPanelTypesQueryParam';
 import { DataSource } from 'types/common/queryBuilder';
 
-import { DEFAULT_PANEL_TYPE } from '../constants';
-
 function QuerySection(): JSX.Element {
-	const panelTypes = useGetPanelTypesQueryParam(DEFAULT_PANEL_TYPE);
+	const panelTypes = useGetPanelTypesQueryParam(PANEL_TYPES.LIST);
 
 	// Only reaches the builder for timeseries/table; list/trace panels use QueryBuilderV2's listViewTracesFilterConfigs.
 	const filterConfigs: QueryBuilderProps['filterConfigs'] = useMemo(

--- a/frontend/src/container/LLMObservability/Explorer/TracesView/TracesView.tsx
+++ b/frontend/src/container/LLMObservability/Explorer/TracesView/TracesView.tsx
@@ -14,7 +14,7 @@ import logEvent from 'api/common/logEvent';
 import DownloadOptionsMenu from 'components/DownloadOptionsMenu/DownloadOptionsMenu';
 import { ENTITY_VERSION_V5 } from 'constants/app';
 import { QueryParams } from 'constants/query';
-import { initialQueriesMap, PANEL_TYPES } from 'constants/queryBuilder';
+import { initialQueryAIWithType, PANEL_TYPES } from 'constants/queryBuilder';
 import { REACT_QUERY_KEY } from 'constants/reactQueryKeys';
 import TraceExplorerControls from 'container/TracesExplorer/Controls';
 import { getListViewQuery } from 'container/TracesExplorer/explorerUtils';
@@ -60,7 +60,7 @@ function TracesView({
 	);
 
 	const transformedQuery = useMemo(
-		() => getListViewQuery(stagedQuery || initialQueriesMap.traces),
+		() => getListViewQuery(stagedQuery || initialQueryAIWithType),
 		[stagedQuery],
 	);
 

--- a/frontend/src/container/LLMObservability/Explorer/TracesView/TracesView.tsx
+++ b/frontend/src/container/LLMObservability/Explorer/TracesView/TracesView.tsx
@@ -17,7 +17,6 @@ import { QueryParams } from 'constants/query';
 import { initialQueryAIWithType, PANEL_TYPES } from 'constants/queryBuilder';
 import { REACT_QUERY_KEY } from 'constants/reactQueryKeys';
 import TraceExplorerControls from 'container/TracesExplorer/Controls';
-import { getListViewQuery } from 'container/TracesExplorer/explorerUtils';
 import { getTraceLink } from 'container/TracesExplorer/ListView/utils';
 import { TracesTableRow } from 'container/TracesExplorer/TracesTable/getFieldColumn';
 import TracesTable from 'container/TracesExplorer/TracesTable/TracesTable';
@@ -31,6 +30,7 @@ import { DataSource } from 'types/common/queryBuilder';
 import { GlobalReducer } from 'types/reducer/globalTime';
 import DOCLINKS from 'utils/docLinks';
 
+import { getListViewQuery } from '../explorerUtils';
 import { columns, PER_PAGE_OPTIONS } from './configs';
 import styles from './TracesView.module.scss';
 

--- a/frontend/src/container/LLMObservability/Explorer/constants.ts
+++ b/frontend/src/container/LLMObservability/Explorer/constants.ts
@@ -1,3 +1,7 @@
+import { PANEL_TYPES } from 'constants/queryBuilder';
+
+export const DEFAULT_PANEL_TYPE = PANEL_TYPES.TRACE;
+
 export const TOOLBAR_VIEWS = {
 	list: {
 		name: 'list',

--- a/frontend/src/container/LLMObservability/Explorer/constants.ts
+++ b/frontend/src/container/LLMObservability/Explorer/constants.ts
@@ -1,7 +1,3 @@
-import { PANEL_TYPES } from 'constants/queryBuilder';
-
-export const DEFAULT_PANEL_TYPE = PANEL_TYPES.TRACE;
-
 export const TOOLBAR_VIEWS = {
 	list: {
 		name: 'list',

--- a/frontend/src/container/LLMObservability/Explorer/explorerUtils.ts
+++ b/frontend/src/container/LLMObservability/Explorer/explorerUtils.ts
@@ -1,0 +1,75 @@
+import { initialQueriesMap, PANEL_TYPES } from 'constants/queryBuilder';
+import { OptionsQuery } from 'container/OptionsMenu/types';
+import { cloneDeep, set } from 'lodash-es';
+import { OrderByPayload, Query } from 'types/api/queryBuilder/queryBuilderData';
+
+export const getListViewQuery = (
+	stagedQuery: Query,
+	orderBy?: string,
+): Query => {
+	const query = stagedQuery
+		? cloneDeep(stagedQuery)
+		: cloneDeep(initialQueriesMap.traces);
+
+	const orderByPayload: OrderByPayload[] = orderBy
+		? [
+				{
+					columnName: orderBy.split(':')[0],
+					order: orderBy.split(':')[1] as 'asc' | 'desc',
+				},
+			]
+		: [];
+
+	for (let i = 0; i < query.builder.queryData.length; i++) {
+		const queryData = query.builder.queryData[i];
+		queryData.groupBy = [];
+		queryData.having = {
+			expression: '',
+		};
+		queryData.orderBy = orderByPayload;
+	}
+
+	if (
+		query.builder.queryTraceOperator &&
+		query.builder.queryTraceOperator.length > 0
+	) {
+		for (let i = 0; i < query.builder.queryTraceOperator.length; i++) {
+			const queryTraceOperator = query.builder.queryTraceOperator[i];
+			queryTraceOperator.groupBy = [];
+			queryTraceOperator.having = {
+				expression: '',
+			};
+			queryTraceOperator.orderBy = orderByPayload;
+		}
+	}
+
+	return query;
+};
+
+export const getQueryByPanelType = (
+	stagedQuery: Query,
+	panelType: PANEL_TYPES,
+): Query => {
+	if (panelType === PANEL_TYPES.LIST || panelType === PANEL_TYPES.TRACE) {
+		return getListViewQuery(stagedQuery);
+	}
+	return stagedQuery;
+};
+
+export const getExportQueryData = (
+	query: Query,
+	panelType: PANEL_TYPES,
+	options: OptionsQuery,
+): Query => {
+	if (panelType === PANEL_TYPES.LIST) {
+		const updatedQuery = cloneDeep(query);
+		set(
+			updatedQuery,
+			'builder.queryData[0].selectColumns',
+			options.selectColumns,
+		);
+
+		return updatedQuery;
+	}
+	return query;
+};

--- a/frontend/src/container/LLMObservability/Explorer/explorerUtils.ts
+++ b/frontend/src/container/LLMObservability/Explorer/explorerUtils.ts
@@ -29,20 +29,6 @@ export const getListViewQuery = (
 		queryData.orderBy = orderByPayload;
 	}
 
-	if (
-		query.builder.queryTraceOperator &&
-		query.builder.queryTraceOperator.length > 0
-	) {
-		for (let i = 0; i < query.builder.queryTraceOperator.length; i++) {
-			const queryTraceOperator = query.builder.queryTraceOperator[i];
-			queryTraceOperator.groupBy = [];
-			queryTraceOperator.having = {
-				expression: '',
-			};
-			queryTraceOperator.orderBy = orderByPayload;
-		}
-	}
-
 	return query;
 };
 

--- a/frontend/src/providers/QueryBuilder.tsx
+++ b/frontend/src/providers/QueryBuilder.tsx
@@ -470,6 +470,7 @@ export function QueryBuilderProvider({
 			const newQuery: IBuilderQuery = {
 				...initialBuilderQuery,
 				source: queries?.[0]?.source || '',
+				builderQueryType: queries?.[0]?.builderQueryType,
 				queryName: createNewBuilderItemName({ existNames, sourceNames: alphabet }),
 				expression: createNewBuilderItemName({
 					existNames,

--- a/frontend/src/providers/__tests__/QueryBuilder.createNewBuilderQuery.test.tsx
+++ b/frontend/src/providers/__tests__/QueryBuilder.createNewBuilderQuery.test.tsx
@@ -1,0 +1,55 @@
+import {
+	initialQueriesMap,
+	initialQueryAIWithType,
+} from 'constants/queryBuilder';
+import { useQueryBuilder } from 'hooks/queryBuilder/useQueryBuilder';
+import { act, AllTheProviders, renderHook } from 'tests/test-utils';
+import { Query } from 'types/api/queryBuilder/queryBuilderData';
+
+const renderQueryBuilder = (
+	initialQuery: Query,
+): ReturnType<
+	typeof renderHook<ReturnType<typeof useQueryBuilder>, unknown>
+> => {
+	const hook = renderHook(() => useQueryBuilder(), {
+		wrapper: AllTheProviders,
+	});
+
+	act(() => {
+		hook.result.current.initQueryBuilderData(initialQuery);
+	});
+
+	return hook;
+};
+
+describe('createNewBuilderQuery builderQueryType propagation', () => {
+	it('carries builderQueryType from the first query onto an added query', () => {
+		const { result } = renderQueryBuilder(initialQueryAIWithType);
+
+		expect(
+			result.current.currentQuery.builder.queryData[0].builderQueryType,
+		).toBe('builder_ai_query');
+
+		act(() => {
+			result.current.addNewBuilderQuery();
+		});
+
+		expect(result.current.currentQuery.builder.queryData).toHaveLength(2);
+		expect(
+			result.current.currentQuery.builder.queryData[1].builderQueryType,
+		).toBe('builder_ai_query');
+	});
+
+	it('leaves builderQueryType unset when the first query has none', () => {
+		const { result } = renderQueryBuilder(initialQueriesMap.traces);
+
+		act(() => {
+			result.current.addNewBuilderQuery();
+		});
+
+		expect(result.current.currentQuery.builder.queryData).toHaveLength(2);
+		expect(
+			result.current.currentQuery.builder.queryData[1].builderQueryType,
+		).toBeUndefined();
+	});
+});

--- a/frontend/src/types/api/queryBuilder/queryBuilderData.ts
+++ b/frontend/src/types/api/queryBuilder/queryBuilderData.ts
@@ -91,7 +91,6 @@ export type IBuilderQuery = {
 	offset?: number;
 	selectColumns?: BaseAutocompleteData[] | TelemetryFieldKey[];
 	source?: 'meter' | '';
-	/** Envelope type this query serializes to in the v5 payload; absent means builder_query. */
 	builderQueryType?: BuilderQueryType;
 };
 

--- a/frontend/src/types/api/queryBuilder/queryBuilderData.ts
+++ b/frontend/src/types/api/queryBuilder/queryBuilderData.ts
@@ -8,6 +8,7 @@ import {
 } from 'types/common/queryBuilder';
 
 import {
+	BuilderQueryType,
 	Filter,
 	Having as HavingV5,
 	LogAggregation,
@@ -90,6 +91,8 @@ export type IBuilderQuery = {
 	offset?: number;
 	selectColumns?: BaseAutocompleteData[] | TelemetryFieldKey[];
 	source?: 'meter' | '';
+	/** Envelope type this query serializes to in the v5 payload; absent means builder_query. */
+	builderQueryType?: BuilderQueryType;
 };
 
 export interface IClickHouseQuery {

--- a/frontend/src/types/api/v5/queryRange.ts
+++ b/frontend/src/types/api/v5/queryRange.ts
@@ -16,12 +16,19 @@ export type RequestType =
 
 export type QueryType =
 	| 'builder_query'
+	| 'builder_ai_query'
 	| 'builder_trace_operator'
 	| 'builder_formula'
 	| 'builder_sub_query'
 	| 'builder_join'
 	| 'clickhouse_sql'
 	| 'promql';
+
+/** Envelope types carrying a BuilderQuery spec; builder_ai_query routes to the gen_ai-scoped trace builder. */
+export type BuilderQueryType = Extract<
+	QueryType,
+	'builder_query' | 'builder_ai_query'
+>;
 
 export type OrderDirection = 'asc' | 'desc';
 

--- a/frontend/src/types/api/v5/queryRange.ts
+++ b/frontend/src/types/api/v5/queryRange.ts
@@ -24,7 +24,6 @@ export type QueryType =
 	| 'clickhouse_sql'
 	| 'promql';
 
-/** Envelope types carrying a BuilderQuery spec; builder_ai_query routes to the gen_ai-scoped trace builder. */
 export type BuilderQueryType = Extract<
 	QueryType,
 	'builder_query' | 'builder_ai_query'


### PR DESCRIPTION
#### Description

- Adds the `builder_ai_query` envelope type, seeded by the AI explorer via `initialQueryAIWithType`.
- AI queries pull filter-bar keys from `/api/v1/ai_observability/fields/keys` and values from `/api/v1/ai_observability/fields/values`. 
- `QuerySection` drops the builder's custom order-by (`ExplorerOrderBy` via `renderOrderBy`) for the list and trace panels, along with `showTraceOperator`. Ordering for those views is the list's own concern, not the builder's — the trace view supplies its own control in #12688. `limit` and `having` are now rendered disabled on every panel instead of hidden on list.
- Hides the span-scope selector for AI queries — "Root / Entrypoint Spans" ANDs badly with the gate, since GenAI attributes sit on nested spans. Derived from the query itself, so no new prop on the shared builder.
- `createNewBuilderQuery` inherits `builderQueryType` from the first query, the way it already inherits `source`.
- Response conversion reads aggregation metadata from both builder envelope types, not just `builder_query`.

TDD - https://app.notion.com/p/signoz/Query-Builder-Changes-3b4fcc6bcd1980889c7aed782665e78d 

#### Issues closed by this PR

Closes - https://github.com/orgs/SigNoz/projects/39/views/20?pane=issue&itemId=226748421&issue=SigNoz%7Cengineering-pod%7C5889

#### Screenshots / Screen Recordings

https://github.com/user-attachments/assets/985cb178-ffb0-405c-b0a6-82ec242c3d68
