### PR TITLE
fix(onboarding): handle zero-valued scale answers

### DIFF
--- a/frontend/src/container/OnboardingQuestionaire/OptimiseSignozNeeds/OptimiseSignozNeeds.tsx
+++ b/frontend/src/container/OnboardingQuestionaire/OptimiseSignozNeeds/OptimiseSignozNeeds.tsx
@@ -32,7 +32,7 @@ const servicesMax = 5000;
 interface OptimiseSignozNeedsProps {
 	optimiseSignozDetails: OptimiseSignozDetails;
 	setOptimiseSignozDetails: (details: OptimiseSignozDetails) => void;
-	onNext: () => void;
+	onNext: (details: OptimiseSignozDetails) => void;
 	onScaleInteraction: () => void;
 	onWillDoLater: () => void;
 	isUpdatingProfile: boolean;
@@ -110,13 +110,15 @@ function OptimiseSignozNeeds({
 	}, [services, hostsPerDay, logsPerDay]);
 
 	const handleOnNext = (): void => {
-		void logEvent('Org Onboarding: Answered', {
+		const scaleDetails = {
 			logsPerDay,
 			hostsPerDay,
 			services,
-		});
+		};
 
-		onNext();
+		void logEvent('Org Onboarding: Answered', scaleDetails);
+
+		onNext(scaleDetails);
 	};
 
 	const handleWillDoLater = (): void => {
@@ -135,10 +137,10 @@ function OptimiseSignozNeeds({
 
 	const handleSliderChange = (key: string, value: number): void => {
 		onScaleInteraction();
-		setSliderValues({
-			...sliderValues,
+		setSliderValues((currentSliderValues) => ({
+			...currentSliderValues,
 			[key]: value,
-		});
+		}));
 
 		switch (key) {
 			case 'logsPerDay':

--- a/frontend/src/container/OnboardingQuestionaire/OptimiseSignozNeeds/OptimiseSignozNeeds.tsx
+++ b/frontend/src/container/OnboardingQuestionaire/OptimiseSignozNeeds/OptimiseSignozNeeds.tsx
@@ -289,7 +289,7 @@ function OptimiseSignozNeeds({
 							id={SCALE_ANSWER_HINT_ID}
 							size="sm"
 						>
-							Adjust at least one slider to continue.
+							Interact with at least one slider to continue.
 						</Typography.Text>
 					)}
 					<Button

--- a/frontend/src/container/OnboardingQuestionaire/OptimiseSignozNeeds/OptimiseSignozNeeds.tsx
+++ b/frontend/src/container/OnboardingQuestionaire/OptimiseSignozNeeds/OptimiseSignozNeeds.tsx
@@ -6,6 +6,12 @@ import logEvent from 'api/common/logEvent';
 import { ArrowRight, LoaderCircle, Minus } from '@signozhq/icons';
 
 import { OnboardingQuestionHeader } from '../OnboardingQuestionHeader';
+import {
+	exponentialToLinear,
+	linearToExponential,
+	SLIDER_MAX_POSITION,
+	SLIDER_MIN_POSITION,
+} from './OptimiseSignozNeeds.utils';
 
 export interface OptimiseSignozDetails {
 	logsPerDay: number;
@@ -23,38 +29,17 @@ const hostsMax = 10000;
 const servicesMin = 1;
 const servicesMax = 5000;
 
-// Function to convert linear slider value to exponential scale
-const linearToExponential = (
-	value: number,
-	min: number,
-	max: number,
-): number => {
-	const expMin = Math.log10(min);
-	const expMax = Math.log10(max);
-	const expValue = 10 ** (expMin + ((expMax - expMin) * value) / 100);
-	return Math.round(expValue);
-};
-
-const exponentialToLinear = (
-	expValue: number,
-	min: number,
-	max: number,
-): number => {
-	const expMin = Math.log10(min);
-	const expMax = Math.log10(max);
-	const linearValue =
-		((Math.log10(expValue) - expMin) / (expMax - expMin)) * 100;
-	return Math.round(linearValue); // Round to get a whole number within the 0-100 range
-};
-
 interface OptimiseSignozNeedsProps {
 	optimiseSignozDetails: OptimiseSignozDetails;
 	setOptimiseSignozDetails: (details: OptimiseSignozDetails) => void;
 	onNext: () => void;
+	onScaleInteraction: () => void;
 	onWillDoLater: () => void;
 	isUpdatingProfile: boolean;
 	isNextDisabled: boolean;
 }
+
+const SCALE_ANSWER_HINT_ID = 'onboarding-scale-answer-hint';
 
 const marks = {
 	0: `${linearToExponential(0, logsMin, logsMax).toLocaleString()} GB`,
@@ -85,6 +70,7 @@ function OptimiseSignozNeeds({
 	optimiseSignozDetails,
 	setOptimiseSignozDetails,
 	onNext,
+	onScaleInteraction,
 	onWillDoLater,
 	isNextDisabled,
 }: OptimiseSignozNeedsProps): JSX.Element {
@@ -124,7 +110,7 @@ function OptimiseSignozNeeds({
 	}, [services, hostsPerDay, logsPerDay]);
 
 	const handleOnNext = (): void => {
-		logEvent('Org Onboarding: Answered', {
+		void logEvent('Org Onboarding: Answered', {
 			logsPerDay,
 			hostsPerDay,
 			services,
@@ -142,12 +128,13 @@ function OptimiseSignozNeeds({
 
 		onWillDoLater();
 
-		logEvent('Org Onboarding: Clicked Do Later', {
+		void logEvent('Org Onboarding: Clicked Do Later', {
 			currentPageID: 3,
 		});
 	};
 
 	const handleSliderChange = (key: string, value: number): void => {
+		onScaleInteraction();
 		setSliderValues({
 			...sliderValues,
 			[key]: value,
@@ -207,13 +194,15 @@ function OptimiseSignozNeeds({
 						<div className="slider-container">
 							<div>
 								<Slider
-									min={0}
-									max={100}
+									min={SLIDER_MIN_POSITION}
+									max={SLIDER_MAX_POSITION}
 									value={sliderValues.logsPerDay}
 									marks={marks}
 									onChange={(value): void =>
 										handleSliderChange('logsPerDay', value as number)
 									}
+									onKeyDown={onScaleInteraction}
+									onPointerDown={onScaleInteraction}
 									styles={{
 										range: {
 											backgroundColor: '#4E74F8',
@@ -222,6 +211,7 @@ function OptimiseSignozNeeds({
 									tooltip={{
 										formatter: (): string => `${logsPerDayValue.toLocaleString()} GB`,
 									}}
+									testId="onboarding-logs-slider"
 								/>
 							</div>
 						</div>
@@ -234,13 +224,15 @@ function OptimiseSignozNeeds({
 						<div className="slider-container">
 							<div>
 								<Slider
-									min={0}
-									max={100}
+									min={SLIDER_MIN_POSITION}
+									max={SLIDER_MAX_POSITION}
 									value={sliderValues.hostsPerDay}
 									marks={hostMarks}
 									onChange={(value): void =>
 										handleSliderChange('hostsPerDay', value as number)
 									}
+									onKeyDown={onScaleInteraction}
+									onPointerDown={onScaleInteraction}
 									styles={{
 										range: {
 											backgroundColor: '#4E74F8',
@@ -249,6 +241,7 @@ function OptimiseSignozNeeds({
 									tooltip={{
 										formatter: (): string => `${hostsPerDayValue.toLocaleString()}`,
 									}}
+									testId="onboarding-hosts-slider"
 								/>
 							</div>
 						</div>
@@ -261,13 +254,15 @@ function OptimiseSignozNeeds({
 						<div className="slider-container">
 							<div>
 								<Slider
-									min={0}
-									max={100}
+									min={SLIDER_MIN_POSITION}
+									max={SLIDER_MAX_POSITION}
 									value={sliderValues.services}
 									marks={serviceMarks}
 									onChange={(value): void =>
 										handleSliderChange('services', value as number)
 									}
+									onKeyDown={onScaleInteraction}
+									onPointerDown={onScaleInteraction}
 									styles={{
 										range: {
 											backgroundColor: '#4E74F8',
@@ -276,6 +271,7 @@ function OptimiseSignozNeeds({
 									tooltip={{
 										formatter: (): string => `${servicesValue.toLocaleString()}`,
 									}}
+									testId="onboarding-services-slider"
 								/>
 							</div>
 						</div>
@@ -283,14 +279,27 @@ function OptimiseSignozNeeds({
 				</div>
 
 				<div className="onboarding-buttons-container">
+					{isNextDisabled && (
+						<Typography.Text
+							align="center"
+							color="muted"
+							display="block"
+							id={SCALE_ANSWER_HINT_ID}
+							size="sm"
+						>
+							Adjust at least one slider to continue.
+						</Typography.Text>
+					)}
 					<Button
 						variant="solid"
 						color="primary"
+						aria-describedby={isNextDisabled ? SCALE_ANSWER_HINT_ID : undefined}
 						className={`onboarding-next-button ${
 							isUpdatingProfile || isNextDisabled ? 'disabled' : ''
 						}`}
 						onClick={handleOnNext}
 						disabled={isUpdatingProfile || isNextDisabled}
+						testId="onboarding-scale-next-button"
 						suffix={
 							isUpdatingProfile ? (
 								<LoaderCircle className="animate-spin" size={12} />
@@ -307,6 +316,7 @@ function OptimiseSignozNeeds({
 						className="onboarding-do-later-button"
 						onClick={handleWillDoLater}
 						disabled={isUpdatingProfile}
+						testId="onboarding-scale-do-later-button"
 					>
 						I&apos;ll do this later
 					</Button>

--- a/frontend/src/container/OnboardingQuestionaire/OptimiseSignozNeeds/OptimiseSignozNeeds.utils.ts
+++ b/frontend/src/container/OnboardingQuestionaire/OptimiseSignozNeeds/OptimiseSignozNeeds.utils.ts
@@ -1,0 +1,49 @@
+export const SLIDER_MIN_POSITION = 0;
+export const SLIDER_MAX_POSITION = 100;
+
+const FIRST_EXPONENTIAL_POSITION = 1;
+const EXPONENTIAL_POSITION_RANGE =
+	SLIDER_MAX_POSITION - FIRST_EXPONENTIAL_POSITION;
+
+export function linearToExponential(
+	value: number,
+	min: number,
+	max: number,
+): number {
+	if (!Number.isFinite(value) || value <= SLIDER_MIN_POSITION) {
+		return 0;
+	}
+
+	const sliderPosition = Math.min(
+		SLIDER_MAX_POSITION,
+		Math.max(FIRST_EXPONENTIAL_POSITION, value),
+	);
+	const expMin = Math.log10(min);
+	const expMax = Math.log10(max);
+	const exponent =
+		expMin +
+		((expMax - expMin) * (sliderPosition - FIRST_EXPONENTIAL_POSITION)) /
+			EXPONENTIAL_POSITION_RANGE;
+
+	return Math.round(10 ** exponent);
+}
+
+export function exponentialToLinear(
+	expValue: number,
+	min: number,
+	max: number,
+): number {
+	if (!Number.isFinite(expValue) || expValue <= 0) {
+		return SLIDER_MIN_POSITION;
+	}
+
+	const boundedValue = Math.min(max, Math.max(min, expValue));
+	const expMin = Math.log10(min);
+	const expMax = Math.log10(max);
+	const sliderPosition =
+		FIRST_EXPONENTIAL_POSITION +
+		((Math.log10(boundedValue) - expMin) / (expMax - expMin)) *
+			EXPONENTIAL_POSITION_RANGE;
+
+	return Math.round(sliderPosition);
+}

--- a/frontend/src/container/OnboardingQuestionaire/OptimiseSignozNeeds/__tests__/OptimiseSignozNeeds.test.tsx
+++ b/frontend/src/container/OnboardingQuestionaire/OptimiseSignozNeeds/__tests__/OptimiseSignozNeeds.test.tsx
@@ -95,4 +95,20 @@ describe('OptimiseSignozNeeds', () => {
 
 		expect(mockOnNext).toHaveBeenCalledTimes(1);
 	});
+
+	it('submits the current slider values directly when continuing', () => {
+		render(<OptimiseSignozNeedsHarness />);
+
+		const logsSlider = screen.getByTestId('onboarding-logs-slider');
+		const [, nonZeroLogMark] = within(logsSlider).getAllByRole('button');
+
+		fireEvent.click(nonZeroLogMark);
+		fireEvent.click(screen.getByTestId('onboarding-scale-next-button'));
+
+		expect(mockOnNext).toHaveBeenCalledWith({
+			logsPerDay: linearToExponential(25, 1, 10000),
+			hostsPerDay: 0,
+			services: 0,
+		});
+	});
 });

--- a/frontend/src/container/OnboardingQuestionaire/OptimiseSignozNeeds/__tests__/OptimiseSignozNeeds.test.tsx
+++ b/frontend/src/container/OnboardingQuestionaire/OptimiseSignozNeeds/__tests__/OptimiseSignozNeeds.test.tsx
@@ -81,14 +81,14 @@ describe('OptimiseSignozNeeds', () => {
 		expect(hostsSliderThumb).toHaveAttribute('aria-valuenow', '0');
 		expect(nextButton).toBeDisabled();
 		expect(
-			screen.getByText('Adjust at least one slider to continue.'),
+			screen.getByText('Interact with at least one slider to continue.'),
 		).toBeInTheDocument();
 
 		fireEvent.pointerDown(hostsSliderThumb, { pointerId: 1, clientX: 0 });
 
 		expect(nextButton).toBeEnabled();
 		expect(
-			screen.queryByText('Adjust at least one slider to continue.'),
+			screen.queryByText('Interact with at least one slider to continue.'),
 		).not.toBeInTheDocument();
 
 		fireEvent.click(nextButton);

--- a/frontend/src/container/OnboardingQuestionaire/OptimiseSignozNeeds/__tests__/OptimiseSignozNeeds.test.tsx
+++ b/frontend/src/container/OnboardingQuestionaire/OptimiseSignozNeeds/__tests__/OptimiseSignozNeeds.test.tsx
@@ -1,0 +1,98 @@
+import { useState } from 'react';
+import { fireEvent, render, screen, within } from 'tests/test-utils';
+
+import OptimiseSignozNeeds, {
+	OptimiseSignozDetails,
+} from '../OptimiseSignozNeeds';
+import {
+	exponentialToLinear,
+	linearToExponential,
+} from '../OptimiseSignozNeeds.utils';
+
+const INITIAL_DETAILS: OptimiseSignozDetails = {
+	logsPerDay: 0,
+	hostsPerDay: 0,
+	services: 0,
+};
+
+const mockOnNext = jest.fn();
+const mockOnWillDoLater = jest.fn();
+const setPointerCaptureDescriptor = Object.getOwnPropertyDescriptor(
+	HTMLElement.prototype,
+	'setPointerCapture',
+);
+
+function OptimiseSignozNeedsHarness(): JSX.Element {
+	const [optimiseSignozDetails, setOptimiseSignozDetails] =
+		useState<OptimiseSignozDetails>(INITIAL_DETAILS);
+	const [hasScaleAnswer, setHasScaleAnswer] = useState(false);
+
+	return (
+		<OptimiseSignozNeeds
+			isNextDisabled={!hasScaleAnswer}
+			isUpdatingProfile={false}
+			optimiseSignozDetails={optimiseSignozDetails}
+			setOptimiseSignozDetails={setOptimiseSignozDetails}
+			onNext={mockOnNext}
+			onScaleInteraction={(): void => setHasScaleAnswer(true)}
+			onWillDoLater={mockOnWillDoLater}
+		/>
+	);
+}
+
+describe('OptimiseSignozNeeds', () => {
+	beforeAll(() => {
+		Object.defineProperty(HTMLElement.prototype, 'setPointerCapture', {
+			configurable: true,
+			value: (): void => {},
+		});
+	});
+
+	afterAll(() => {
+		if (setPointerCaptureDescriptor) {
+			Object.defineProperty(
+				HTMLElement.prototype,
+				'setPointerCapture',
+				setPointerCaptureDescriptor,
+			);
+			return;
+		}
+
+		Reflect.deleteProperty(HTMLElement.prototype, 'setPointerCapture');
+	});
+
+	beforeEach(() => {
+		jest.clearAllMocks();
+	});
+
+	it('keeps zero values on a finite slider coordinate', () => {
+		expect(linearToExponential(0, 1, 10000)).toBe(0);
+		expect(exponentialToLinear(0, 1, 10000)).toBe(0);
+		expect(Number.isFinite(exponentialToLinear(0, 1, 10000))).toBe(true);
+	});
+
+	it('accepts an explicit zero answer from the minimum slider position', () => {
+		render(<OptimiseSignozNeedsHarness />);
+
+		const hostsSlider = screen.getByTestId('onboarding-hosts-slider');
+		const hostsSliderThumb = within(hostsSlider).getByRole('slider');
+		const nextButton = screen.getByTestId('onboarding-scale-next-button');
+
+		expect(hostsSliderThumb).toHaveAttribute('aria-valuenow', '0');
+		expect(nextButton).toBeDisabled();
+		expect(
+			screen.getByText('Adjust at least one slider to continue.'),
+		).toBeInTheDocument();
+
+		fireEvent.pointerDown(hostsSliderThumb, { pointerId: 1, clientX: 0 });
+
+		expect(nextButton).toBeEnabled();
+		expect(
+			screen.queryByText('Adjust at least one slider to continue.'),
+		).not.toBeInTheDocument();
+
+		fireEvent.click(nextButton);
+
+		expect(mockOnNext).toHaveBeenCalledTimes(1);
+	});
+});

--- a/frontend/src/container/OnboardingQuestionaire/__tests__/OnboardingQuestionaire.test.tsx
+++ b/frontend/src/container/OnboardingQuestionaire/__tests__/OnboardingQuestionaire.test.tsx
@@ -1,5 +1,5 @@
 import { rest, server } from 'mocks-server/server';
-import { render, screen, userEvent, waitFor } from 'tests/test-utils';
+import { render, screen, userEvent, waitFor, within } from 'tests/test-utils';
 
 import OnboardingQuestionaire from '../index';
 
@@ -279,11 +279,11 @@ describe('OnboardingQuestionaire Component', () => {
 
 		it('fires PUT to /zeus/profiles and advances to step 4 on success', async () => {
 			const user = userEvent.setup({ pointerEventsCheck: 0 });
-			let profilePutCalled = false;
+			let profileRequestBody: Record<string, unknown> | undefined;
 
 			server.use(
-				rest.put(UPDATE_PROFILE_ENDPOINT, (_, res, ctx) => {
-					profilePutCalled = true;
+				rest.put(UPDATE_PROFILE_ENDPOINT, async (req, res, ctx) => {
+					profileRequestBody = await req.json();
 					return res(ctx.status(200), ctx.json({ status: 'success', data: {} }));
 				}),
 			);
@@ -303,13 +303,20 @@ describe('OnboardingQuestionaire Component', () => {
 			await user.click(screen.getByLabelText(/lowering observability costs/i));
 			await user.click(screen.getByRole('button', { name: /next/i }));
 
-			// Click "I'll do this later" on step 3 — triggers PUT /zeus/profiles
-			await user.click(
-				await screen.findByRole('button', { name: /i'll do this later/i }),
-			);
+			const logsSlider = await screen.findByTestId('onboarding-logs-slider');
+			const [, nonZeroLogMark] = within(logsSlider).getAllByRole('button');
+			await user.click(nonZeroLogMark);
+
+			await user.click(screen.getByTestId('onboarding-scale-do-later-button'));
 
 			await waitFor(() => {
-				expect(profilePutCalled).toBe(true);
+				expect(profileRequestBody).toStrictEqual(
+					expect.objectContaining({
+						logs_scale_per_day_in_gb: 0,
+						number_of_hosts: 0,
+						number_of_services: 0,
+					}),
+				);
 				// Step 3 content is gone — successfully advanced to step 4
 				expect(
 					screen.queryByText(/what does your scale approximately look like/i),

--- a/frontend/src/container/OnboardingQuestionaire/index.tsx
+++ b/frontend/src/container/OnboardingQuestionaire/index.tsx
@@ -119,9 +119,7 @@ function OnboardingQuestionaire(): JSX.Element {
 		},
 	});
 
-	const handleUpdateProfile = (
-		scaleDetails: OptimiseSignozDetails = optimiseSignozDetails,
-	): void => {
+	const handleUpdateProfile = (scaleDetails: OptimiseSignozDetails): void => {
 		void logEvent(NEXT_BUTTON_EVENT_NAME, {
 			currentPageID: 3,
 			nextPageID: 4,

--- a/frontend/src/container/OnboardingQuestionaire/index.tsx
+++ b/frontend/src/container/OnboardingQuestionaire/index.tsx
@@ -70,12 +70,13 @@ function OnboardingQuestionaire(): JSX.Element {
 
 	const [optimiseSignozDetails, setOptimiseSignozDetails] =
 		useState<OptimiseSignozDetails>(INITIAL_OPTIMISE_SIGNOZ_DETAILS);
+	const [hasScaleAnswer, setHasScaleAnswer] = useState(false);
 
 	const [updatingOrgOnboardingStatus, setUpdatingOrgOnboardingStatus] =
 		useState<boolean>(false);
 
 	useEffect(() => {
-		logEvent('Org Onboarding: Started', {
+		void logEvent('Org Onboarding: Started', {
 			org_id: org?.[0]?.id,
 		});
 		// eslint-disable-next-line react-hooks/exhaustive-deps
@@ -93,7 +94,7 @@ function OnboardingQuestionaire(): JSX.Element {
 
 			setUpdatingOrgOnboardingStatus(false);
 
-			logEvent('Org Onboarding: Redirecting to Get Started', {});
+			void logEvent('Org Onboarding: Redirecting to Get Started', {});
 
 			history.push(ROUTES.GET_STARTED_WITH_CLOUD);
 		},
@@ -102,17 +103,14 @@ function OnboardingQuestionaire(): JSX.Element {
 		},
 	});
 
-	const isNextDisabled =
-		optimiseSignozDetails.logsPerDay === 0 &&
-		optimiseSignozDetails.hostsPerDay === 0 &&
-		optimiseSignozDetails.services === 0;
+	const isNextDisabled = !hasScaleAnswer;
 
 	const { mutate: updateProfile, isLoading: isUpdatingProfile } =
 		usePutProfile<AxiosError<RenderErrorResponseDTO>>();
 
 	const { mutate: updateOrgPreference } = useMutation(updateOrgPreferenceAPI, {
 		onSuccess: () => {
-			refetchOrgPreferences();
+			void refetchOrgPreferences();
 		},
 		onError: (error) => {
 			showErrorNotification(notifications, error as AxiosError);
@@ -121,8 +119,10 @@ function OnboardingQuestionaire(): JSX.Element {
 		},
 	});
 
-	const handleUpdateProfile = (): void => {
-		logEvent(NEXT_BUTTON_EVENT_NAME, {
+	const handleUpdateProfile = (
+		scaleDetails: OptimiseSignozDetails = optimiseSignozDetails,
+	): void => {
+		void logEvent(NEXT_BUTTON_EVENT_NAME, {
 			currentPageID: 3,
 			nextPageID: 4,
 		});
@@ -148,16 +148,16 @@ function OnboardingQuestionaire(): JSX.Element {
 								signozDetails?.otherInterestInSignoz,
 							] as string[])
 						: (signozDetails?.interestInSignoz as string[]),
-					logs_scale_per_day_in_gb: optimiseSignozDetails?.logsPerDay as number,
-					number_of_hosts: optimiseSignozDetails?.hostsPerDay as number,
-					number_of_services: optimiseSignozDetails?.services as number,
+					logs_scale_per_day_in_gb: scaleDetails.logsPerDay,
+					number_of_hosts: scaleDetails.hostsPerDay,
+					number_of_services: scaleDetails.services,
 				},
 			},
 			{
 				onSuccess: () => {
 					setCurrentStep(4);
 				},
-				onError: (error: any) => {
+				onError: (error) => {
 					toast.error(error?.message || SOMETHING_WENT_WRONG);
 
 					// Allow user to proceed even if API fails
@@ -168,7 +168,7 @@ function OnboardingQuestionaire(): JSX.Element {
 	};
 
 	const handleOnboardingComplete = (): void => {
-		logEvent(ONBOARDING_COMPLETE_EVENT_NAME, {
+		void logEvent(ONBOARDING_COMPLETE_EVENT_NAME, {
 			currentPageID: 4,
 		});
 
@@ -189,7 +189,7 @@ function OnboardingQuestionaire(): JSX.Element {
 							usesOtel: orgDetails.usesOtel ?? null,
 						}}
 						onNext={(orgDetails: OrgDetails): void => {
-							logEvent(NEXT_BUTTON_EVENT_NAME, {
+							void logEvent(NEXT_BUTTON_EVENT_NAME, {
 								currentPageID: 1,
 								nextPageID: 2,
 							});
@@ -205,7 +205,7 @@ function OnboardingQuestionaire(): JSX.Element {
 						signozDetails={signozDetails}
 						setSignozDetails={setSignozDetails}
 						onNext={(): void => {
-							logEvent(NEXT_BUTTON_EVENT_NAME, {
+							void logEvent(NEXT_BUTTON_EVENT_NAME, {
 								currentPageID: 2,
 								nextPageID: 3,
 							});
@@ -221,7 +221,10 @@ function OnboardingQuestionaire(): JSX.Element {
 						optimiseSignozDetails={optimiseSignozDetails}
 						setOptimiseSignozDetails={setOptimiseSignozDetails}
 						onNext={handleUpdateProfile}
-						onWillDoLater={handleUpdateProfile}
+						onScaleInteraction={(): void => setHasScaleAnswer(true)}
+						onWillDoLater={(): void =>
+							handleUpdateProfile(INITIAL_OPTIMISE_SIGNOZ_DETAILS)
+						}
 					/>
 				)}
 


### PR DESCRIPTION
#### Description

- Separate the scale question's unanswered state from its numeric values, allowing zero to be a valid answer.
- Reserve the leftmost slider position for zero and guard scale conversion against non-finite coordinates.
- Register pointer and keyboard interaction at the minimum position and explain why Next is initially disabled.
- Submit explicit zero scale values when the user selects "I'll do this later", avoiding stale slider state.
- Add focused component and questionnaire regression coverage for zero-value and skip behavior.

#### Issues closed by this PR

Closes #12659

#### Additional Information

Verification completed:

- `pnpm jest src/container/OnboardingQuestionaire/OptimiseSignozNeeds/__tests__/OptimiseSignozNeeds.test.tsx src/container/OnboardingQuestionaire/__tests__/OnboardingQuestionaire.test.tsx --runInBand --no-cache`
- `pnpm tsgo --noEmit`
- `pnpm lint:js --quiet`
- `pnpm oxlint` for all changed files
- `pnpm fmt`
- `pnpm build`
