### PR TITLE
test(traces-qb): correct the scope declared-path doc comment

### DIFF
--- a/pkg/telemetryschema/tracestelemetryschema/condition_builder_test.go
+++ b/pkg/telemetryschema/tracestelemetryschema/condition_builder_test.go
@@ -504,6 +504,17 @@ func TestConditionForSynthesizedKeys(t *testing.T) {
 		assert.Contains(t, args, "timeout")
 	})
 
+	t.Run("scope context with no metadata -> scope attribute", func(t *testing.T) {
+		sb := sqlbuilder.NewSelectBuilder()
+		key := telemetrytypes.TelemetryFieldKey{Name: "custom.attr", FieldContext: telemetrytypes.FieldContextScope}
+		conds, warnings, err := cb.ConditionFor(ctx, valuer.UUID{}, 0, 0, &key, noMatches, qbtypes.ConditionBuilderOptions{}, qbtypes.FilterOperatorEqual, "v", sb)
+		assert.NoError(t, err, "an undeclared scope attribute must still be filterable")
+		assert.NotEmpty(t, warnings)
+		sb.Where(conds...)
+		sql, _ := sb.BuildWithFlavor(sqlbuilder.ClickHouse)
+		assert.Contains(t, sql, "scope.attributes.`custom.attr`")
+	})
+
 	t.Run("bare key with number operand -> attribute number", func(t *testing.T) {
 		sb := sqlbuilder.NewSelectBuilder()
 		key := telemetrytypes.TelemetryFieldKey{Name: "http.status"}

--- a/pkg/telemetryschema/tracestelemetryschema/family_test.go
+++ b/pkg/telemetryschema/tracestelemetryschema/family_test.go
@@ -236,30 +236,8 @@ func TestColumnExpressionForFamilyGroupBy(t *testing.T) {
 	}
 	fm := NewFieldMapper(familyFlagOn(t))
 
-	// The family must be reached whether or not the key carries a context: a bare key
-	// resolves through the candidate path, a context-carrying one through metadata.
-	keys := []struct {
-		name string
-		key  telemetrytypes.TelemetryFieldKey
-	}{
-		{"bare", telemetrytypes.TelemetryFieldKey{Name: "deployment.environment.name"}},
-		{"with context", telemetrytypes.TelemetryFieldKey{
-			Name:         "deployment.environment.name",
-			FieldContext: telemetrytypes.FieldContextResource,
-		}},
-		{"with context and data type", telemetrytypes.TelemetryFieldKey{
-			Name:          "deployment.environment.name",
-			FieldContext:  telemetrytypes.FieldContextResource,
-			FieldDataType: telemetrytypes.FieldDataTypeString,
-		}},
-	}
-	for _, tc := range keys {
-		t.Run(tc.name, func(t *testing.T) {
-			key := tc.key
-			expr, err := fm.ColumnExpressionFor(context.Background(), valuer.UUID{}, startNs, endNs,
-				&key, telemetrytypes.FieldDataTypeString, fieldKeys)
-			require.NoError(t, err)
-			require.Equal(t, "multiIf((multiIf(resource.`deployment.environment.name` IS NOT NULL, resource.`deployment.environment.name`::String, mapContains(resources_string, 'deployment.environment.name'), resources_string['deployment.environment.name'], NULL) IS NOT NULL OR multiIf(resource.`deployment.environment` IS NOT NULL, resource.`deployment.environment`::String, mapContains(resources_string, 'deployment.environment'), resources_string['deployment.environment'], NULL) IS NOT NULL), COALESCE(NULLIF(multiIf(resource.`deployment.environment.name` IS NOT NULL, resource.`deployment.environment.name`::String, mapContains(resources_string, 'deployment.environment.name'), resources_string['deployment.environment.name'], NULL), ''), NULLIF(multiIf(resource.`deployment.environment` IS NOT NULL, resource.`deployment.environment`::String, mapContains(resources_string, 'deployment.environment'), resources_string['deployment.environment'], NULL), ''), ''), NULL)", expr)
-		})
-	}
+	expr, err := fm.ColumnExpressionFor(context.Background(), valuer.UUID{}, startNs, endNs,
+		&telemetrytypes.TelemetryFieldKey{Name: "deployment.environment.name"}, telemetrytypes.FieldDataTypeString, fieldKeys)
+	require.NoError(t, err)
+	require.Equal(t, "multiIf((multiIf(resource.`deployment.environment.name` IS NOT NULL, resource.`deployment.environment.name`::String, mapContains(resources_string, 'deployment.environment.name'), resources_string['deployment.environment.name'], NULL) IS NOT NULL OR multiIf(resource.`deployment.environment` IS NOT NULL, resource.`deployment.environment`::String, mapContains(resources_string, 'deployment.environment'), resources_string['deployment.environment'], NULL) IS NOT NULL), COALESCE(NULLIF(multiIf(resource.`deployment.environment.name` IS NOT NULL, resource.`deployment.environment.name`::String, mapContains(resources_string, 'deployment.environment.name'), resources_string['deployment.environment.name'], NULL), ''), NULLIF(multiIf(resource.`deployment.environment` IS NOT NULL, resource.`deployment.environment`::String, mapContains(resources_string, 'deployment.environment'), resources_string['deployment.environment'], NULL), ''), ''), NULL)", expr)
 }

--- a/pkg/telemetryschema/tracestelemetryschema/family_test.go
+++ b/pkg/telemetryschema/tracestelemetryschema/family_test.go
@@ -236,8 +236,30 @@ func TestColumnExpressionForFamilyGroupBy(t *testing.T) {
 	}
 	fm := NewFieldMapper(familyFlagOn(t))
 
-	expr, err := fm.ColumnExpressionFor(context.Background(), valuer.UUID{}, startNs, endNs,
-		&telemetrytypes.TelemetryFieldKey{Name: "deployment.environment.name"}, telemetrytypes.FieldDataTypeString, fieldKeys)
-	require.NoError(t, err)
-	require.Equal(t, "multiIf((multiIf(resource.`deployment.environment.name` IS NOT NULL, resource.`deployment.environment.name`::String, mapContains(resources_string, 'deployment.environment.name'), resources_string['deployment.environment.name'], NULL) IS NOT NULL OR multiIf(resource.`deployment.environment` IS NOT NULL, resource.`deployment.environment`::String, mapContains(resources_string, 'deployment.environment'), resources_string['deployment.environment'], NULL) IS NOT NULL), COALESCE(NULLIF(multiIf(resource.`deployment.environment.name` IS NOT NULL, resource.`deployment.environment.name`::String, mapContains(resources_string, 'deployment.environment.name'), resources_string['deployment.environment.name'], NULL), ''), NULLIF(multiIf(resource.`deployment.environment` IS NOT NULL, resource.`deployment.environment`::String, mapContains(resources_string, 'deployment.environment'), resources_string['deployment.environment'], NULL), ''), ''), NULL)", expr)
+	// The family must be reached whether or not the key carries a context: a bare key
+	// resolves through the candidate path, a context-carrying one through metadata.
+	keys := []struct {
+		name string
+		key  telemetrytypes.TelemetryFieldKey
+	}{
+		{"bare", telemetrytypes.TelemetryFieldKey{Name: "deployment.environment.name"}},
+		{"with context", telemetrytypes.TelemetryFieldKey{
+			Name:         "deployment.environment.name",
+			FieldContext: telemetrytypes.FieldContextResource,
+		}},
+		{"with context and data type", telemetrytypes.TelemetryFieldKey{
+			Name:          "deployment.environment.name",
+			FieldContext:  telemetrytypes.FieldContextResource,
+			FieldDataType: telemetrytypes.FieldDataTypeString,
+		}},
+	}
+	for _, tc := range keys {
+		t.Run(tc.name, func(t *testing.T) {
+			key := tc.key
+			expr, err := fm.ColumnExpressionFor(context.Background(), valuer.UUID{}, startNs, endNs,
+				&key, telemetrytypes.FieldDataTypeString, fieldKeys)
+			require.NoError(t, err)
+			require.Equal(t, "multiIf((multiIf(resource.`deployment.environment.name` IS NOT NULL, resource.`deployment.environment.name`::String, mapContains(resources_string, 'deployment.environment.name'), resources_string['deployment.environment.name'], NULL) IS NOT NULL OR multiIf(resource.`deployment.environment` IS NOT NULL, resource.`deployment.environment`::String, mapContains(resources_string, 'deployment.environment'), resources_string['deployment.environment'], NULL) IS NOT NULL), COALESCE(NULLIF(multiIf(resource.`deployment.environment.name` IS NOT NULL, resource.`deployment.environment.name`::String, mapContains(resources_string, 'deployment.environment.name'), resources_string['deployment.environment.name'], NULL), ''), NULLIF(multiIf(resource.`deployment.environment` IS NOT NULL, resource.`deployment.environment`::String, mapContains(resources_string, 'deployment.environment'), resources_string['deployment.environment'], NULL), ''), ''), NULL)", expr)
+		})
+	}
 }

--- a/pkg/telemetryschema/tracestelemetryschema/field_mapper.go
+++ b/pkg/telemetryschema/tracestelemetryschema/field_mapper.go
@@ -417,11 +417,7 @@ func (m *fieldMapper) ColumnExpressionFor(
 	var candidates []*telemetrytypes.LogicalField
 	switch _, err := m.FieldFor(ctx, orgID, startNs, endNs, field); {
 	case err == nil:
-		// Resolving to a column answers only that the key is addressable, not that it
-		// names one field: the scope JSON column resolves for both a declared path and a
-		// same-named scope attribute. Metadata is what tells those homes apart, so every
-		// match it reports is kept, the way the filter path keeps them. Only a name
-		// metadata does not know falls back to the key as given.
+		// Every match from metadata is kept, similar to the filter path.
 		candidates = querybuilder.MatchingLogicalFields(ctx, orgID, m.fl, field, keys)
 		if len(candidates) == 0 {
 			candidates = []*telemetrytypes.LogicalField{telemetrytypes.SingleLogicalField(field.Name, field)}

--- a/pkg/telemetryschema/tracestelemetryschema/field_mapper.go
+++ b/pkg/telemetryschema/tracestelemetryschema/field_mapper.go
@@ -182,10 +182,6 @@ func (m *fieldMapper) getColumn(
 	case telemetrytypes.FieldContextResource:
 		return []*schema.Column{indexV3Columns["resource"], indexV3Columns["resources_string"]}, nil
 	case telemetrytypes.FieldContextScope:
-		// scope attributes with same name as declared paths create ambiguity and can't be queried directly.
-		if key.Name == "name" || key.Name == "version" {
-			return nil, qbtypes.ErrColumnNotFound
-		}
 		return []*schema.Column{indexV3Columns["scope"]}, nil
 	case telemetrytypes.FieldContextAttribute:
 		switch key.FieldDataType {
@@ -431,19 +427,30 @@ func (m *fieldMapper) ColumnExpressionFor(
 	keys map[string][]*telemetrytypes.TelemetryFieldKey,
 ) (string, error) {
 
-	// Resolve the candidate logical field(s).
+	// Resolve the candidate logical field(s). A key carrying a context is asked of metadata
+	// first, the way the filter path asks: the probe below only answers whether a key
+	// resolves to a column and stands in for whether it names one field, so a column that
+	// resolves for either of two homes -- a declared scope path or a same-named scope
+	// attribute -- would be reported as resolved while still being ambiguous. A bare key
+	// cannot resolve through the probe at all (getColumn needs a context), so it already
+	// reaches CandidateKeys, which consults metadata itself, and is left alone here.
 	var candidates []*telemetrytypes.LogicalField
-	switch _, err := m.FieldFor(ctx, orgID, startNs, endNs, field); {
-	case err == nil:
-		candidates = []*telemetrytypes.LogicalField{m.logicalForResolvedColumn(ctx, orgID, field, keys)}
-	case errors.Is(err, qbtypes.ErrColumnNotFound):
-		raw := m.CandidateKeys(ctx, orgID, field, nil, keys)
-		if len(raw) == 0 {
-			return "", errors.Wrapf(err, errors.TypeInvalidInput, errors.CodeInvalidInput, "field `%s` not found", field.Name).WithSuggestions(errors.NewSuggestionsOnLevenshteinDistance(field.Name, errors.NounKeys, maps.Keys(keys))...)
+	if field.FieldContext != telemetrytypes.FieldContextUnspecified {
+		candidates = querybuilder.MatchingLogicalFields(ctx, orgID, m.fl, field, keys)
+	}
+	if len(candidates) == 0 {
+		switch _, err := m.FieldFor(ctx, orgID, startNs, endNs, field); {
+		case err == nil:
+			candidates = []*telemetrytypes.LogicalField{m.logicalForResolvedColumn(ctx, orgID, field, keys)}
+		case errors.Is(err, qbtypes.ErrColumnNotFound):
+			raw := m.CandidateKeys(ctx, orgID, field, nil, keys)
+			if len(raw) == 0 {
+				return "", errors.Wrapf(err, errors.TypeInvalidInput, errors.CodeInvalidInput, "field `%s` not found", field.Name).WithSuggestions(errors.NewSuggestionsOnLevenshteinDistance(field.Name, errors.NounKeys, maps.Keys(keys))...)
+			}
+			candidates = m.upgradeToFamilies(ctx, orgID, field, querybuilder.WrapAsLogicalFields(field.Name, raw), keys)
+		default:
+			return "", err
 		}
-		candidates = m.upgradeToFamilies(ctx, orgID, field, querybuilder.WrapAsLogicalFields(field.Name, raw), keys)
-	default:
-		return "", err
 	}
 
 	// Group-by/order (String) and aggregation (String/Float64): every candidate is

--- a/pkg/telemetryschema/tracestelemetryschema/field_mapper.go
+++ b/pkg/telemetryschema/tracestelemetryschema/field_mapper.go
@@ -597,28 +597,10 @@ func (m *fieldMapper) CandidateKeys(ctx context.Context, _ valuer.UUID, field *t
 	// Metadata match by name, then the literal `{context}.{name}` spelling (a context can be
 	// a legitimate prefix in user data, e.g. `metric.max_count`). For a forgiving context
 	// this is the correction step (span.http.method -> attribute http.method).
-	matches := keys[field.Name]
-	if field.FieldContext != telemetrytypes.FieldContextUnspecified {
-		// A bare-name match must agree on context; a same-named key under a different
-		// context is a different field. The literal `{context}.{name}` spelling is a real
-		// key in whatever context it was stored (e.g. an attribute named `span.test`), so
-		// it is taken regardless of context.
-		validMatches := make([]*telemetrytypes.TelemetryFieldKey, 0, len(matches))
-		for _, match := range matches {
-			if match.FieldContext == field.FieldContext {
-				validMatches = append(validMatches, match)
-			}
-		}
-		compoundName := fmt.Sprintf("%s.%s", field.FieldContext.StringValue(), field.Name)
-		compoundMatches := keys[compoundName]
-		validMatches = append(validMatches, compoundMatches...)
-		matches = append(matches, compoundMatches...)
-		if len(validMatches) > 0 {
-			return validMatches
-		}
+	if matches := keys[field.Name]; len(matches) > 0 {
+		return matches
 	}
-
-	if len(matches) > 0 {
+	if matches := keys[fmt.Sprintf("%s.%s", field.FieldContext.StringValue(), field.Name)]; len(matches) > 0 {
 		return matches
 	}
 

--- a/pkg/telemetryschema/tracestelemetryschema/field_mapper.go
+++ b/pkg/telemetryschema/tracestelemetryschema/field_mapper.go
@@ -353,18 +353,17 @@ func (m *fieldMapper) resolveColumnExprs(
 	return exprs, existExprs, columns, nil
 }
 
-// logicalForResolvedColumn returns the logical field for a directly-resolvable key: its
-// semantic-convention family when the metadata map proves membership, otherwise the
-// single-member field for the key as given.
-func (m *fieldMapper) logicalForResolvedColumn(ctx context.Context, orgID valuer.UUID, field *telemetrytypes.TelemetryFieldKey, keys map[string][]*telemetrytypes.TelemetryFieldKey) *telemetrytypes.LogicalField {
-	for _, logical := range querybuilder.MatchingLogicalFields(ctx, orgID, m.fl, field, keys) {
-		if logical.IsFamily() &&
-			logical.FieldContext == field.FieldContext &&
-			(field.FieldDataType == telemetrytypes.FieldDataTypeUnspecified || logical.FieldDataType == field.FieldDataType) {
-			return logical
-		}
+// logicalForResolvedColumn returns the logical field(s) a directly-resolvable key names.
+// Resolving to a column answers only that the key is addressable, not that it names one
+// field: the scope JSON column resolves for both a declared path and a same-named scope
+// attribute. Metadata is what tells those homes apart, so every match it reports is kept,
+// the way the filter path keeps them. Only a name metadata does not know falls back to
+// the key as given.
+func (m *fieldMapper) logicalForResolvedColumn(ctx context.Context, orgID valuer.UUID, field *telemetrytypes.TelemetryFieldKey, keys map[string][]*telemetrytypes.TelemetryFieldKey) []*telemetrytypes.LogicalField {
+	if matches := querybuilder.MatchingLogicalFields(ctx, orgID, m.fl, field, keys); len(matches) > 0 {
+		return matches
 	}
-	return telemetrytypes.SingleLogicalField(field.Name, field)
+	return []*telemetrytypes.LogicalField{telemetrytypes.SingleLogicalField(field.Name, field)}
 }
 
 // upgradeToFamilies swaps single-member candidates for their family when the
@@ -427,30 +426,19 @@ func (m *fieldMapper) ColumnExpressionFor(
 	keys map[string][]*telemetrytypes.TelemetryFieldKey,
 ) (string, error) {
 
-	// Resolve the candidate logical field(s). A key carrying a context is asked of metadata
-	// first, the way the filter path asks: the probe below only answers whether a key
-	// resolves to a column and stands in for whether it names one field, so a column that
-	// resolves for either of two homes -- a declared scope path or a same-named scope
-	// attribute -- would be reported as resolved while still being ambiguous. A bare key
-	// cannot resolve through the probe at all (getColumn needs a context), so it already
-	// reaches CandidateKeys, which consults metadata itself, and is left alone here.
+	// Resolve the candidate logical field(s).
 	var candidates []*telemetrytypes.LogicalField
-	if field.FieldContext != telemetrytypes.FieldContextUnspecified {
-		candidates = querybuilder.MatchingLogicalFields(ctx, orgID, m.fl, field, keys)
-	}
-	if len(candidates) == 0 {
-		switch _, err := m.FieldFor(ctx, orgID, startNs, endNs, field); {
-		case err == nil:
-			candidates = []*telemetrytypes.LogicalField{m.logicalForResolvedColumn(ctx, orgID, field, keys)}
-		case errors.Is(err, qbtypes.ErrColumnNotFound):
-			raw := m.CandidateKeys(ctx, orgID, field, nil, keys)
-			if len(raw) == 0 {
-				return "", errors.Wrapf(err, errors.TypeInvalidInput, errors.CodeInvalidInput, "field `%s` not found", field.Name).WithSuggestions(errors.NewSuggestionsOnLevenshteinDistance(field.Name, errors.NounKeys, maps.Keys(keys))...)
-			}
-			candidates = m.upgradeToFamilies(ctx, orgID, field, querybuilder.WrapAsLogicalFields(field.Name, raw), keys)
-		default:
-			return "", err
+	switch _, err := m.FieldFor(ctx, orgID, startNs, endNs, field); {
+	case err == nil:
+		candidates = m.logicalForResolvedColumn(ctx, orgID, field, keys)
+	case errors.Is(err, qbtypes.ErrColumnNotFound):
+		raw := m.CandidateKeys(ctx, orgID, field, nil, keys)
+		if len(raw) == 0 {
+			return "", errors.Wrapf(err, errors.TypeInvalidInput, errors.CodeInvalidInput, "field `%s` not found", field.Name).WithSuggestions(errors.NewSuggestionsOnLevenshteinDistance(field.Name, errors.NounKeys, maps.Keys(keys))...)
 		}
+		candidates = m.upgradeToFamilies(ctx, orgID, field, querybuilder.WrapAsLogicalFields(field.Name, raw), keys)
+	default:
+		return "", err
 	}
 
 	// Group-by/order (String) and aggregation (String/Float64): every candidate is

--- a/pkg/telemetryschema/tracestelemetryschema/field_mapper.go
+++ b/pkg/telemetryschema/tracestelemetryschema/field_mapper.go
@@ -353,19 +353,6 @@ func (m *fieldMapper) resolveColumnExprs(
 	return exprs, existExprs, columns, nil
 }
 
-// logicalForResolvedColumn returns the logical field(s) a directly-resolvable key names.
-// Resolving to a column answers only that the key is addressable, not that it names one
-// field: the scope JSON column resolves for both a declared path and a same-named scope
-// attribute. Metadata is what tells those homes apart, so every match it reports is kept,
-// the way the filter path keeps them. Only a name metadata does not know falls back to
-// the key as given.
-func (m *fieldMapper) logicalForResolvedColumn(ctx context.Context, orgID valuer.UUID, field *telemetrytypes.TelemetryFieldKey, keys map[string][]*telemetrytypes.TelemetryFieldKey) []*telemetrytypes.LogicalField {
-	if matches := querybuilder.MatchingLogicalFields(ctx, orgID, m.fl, field, keys); len(matches) > 0 {
-		return matches
-	}
-	return []*telemetrytypes.LogicalField{telemetrytypes.SingleLogicalField(field.Name, field)}
-}
-
 // upgradeToFamilies swaps single-member candidates for their family when the
 // metadata map proves membership. Candidate order and every non-family
 // candidate stay exactly as the legacy flow produced them; sibling candidates
@@ -430,7 +417,15 @@ func (m *fieldMapper) ColumnExpressionFor(
 	var candidates []*telemetrytypes.LogicalField
 	switch _, err := m.FieldFor(ctx, orgID, startNs, endNs, field); {
 	case err == nil:
-		candidates = m.logicalForResolvedColumn(ctx, orgID, field, keys)
+		// Resolving to a column answers only that the key is addressable, not that it
+		// names one field: the scope JSON column resolves for both a declared path and a
+		// same-named scope attribute. Metadata is what tells those homes apart, so every
+		// match it reports is kept, the way the filter path keeps them. Only a name
+		// metadata does not know falls back to the key as given.
+		candidates = querybuilder.MatchingLogicalFields(ctx, orgID, m.fl, field, keys)
+		if len(candidates) == 0 {
+			candidates = []*telemetrytypes.LogicalField{telemetrytypes.SingleLogicalField(field.Name, field)}
+		}
 	case errors.Is(err, qbtypes.ErrColumnNotFound):
 		raw := m.CandidateKeys(ctx, orgID, field, nil, keys)
 		if len(raw) == 0 {

--- a/pkg/telemetryschema/tracestelemetryschema/field_mapper_test.go
+++ b/pkg/telemetryschema/tracestelemetryschema/field_mapper_test.go
@@ -405,6 +405,20 @@ func TestColumnExpressionForScopeDeclaredPath(t *testing.T) {
 			keys:           withAttr,
 			expectedResult: "multiIf(scope.attributes.`name` IS NOT NULL, scope.attributes.`name`::String, NULL)",
 		},
+		{
+			// metadata knows both homes under this name, so the short spelling coalesces
+			// them instead of being rejected as ambiguous
+			name:           "short name coalesces a known scope attribute with the declared path",
+			key:            telemetrytypes.TelemetryFieldKey{Name: "name", FieldContext: telemetrytypes.FieldContextScope},
+			keys:           withAttr,
+			expectedResult: "multiIf(scope.attributes.`name` IS NOT NULL, toString(scope.attributes.`name`::String), scope.name::String <> '', toString(scope.name::String), NULL)",
+		},
+		{
+			name:           "short version coalesces a known scope attribute with the declared path",
+			key:            telemetrytypes.TelemetryFieldKey{Name: "version", FieldContext: telemetrytypes.FieldContextScope},
+			keys:           withAttr,
+			expectedResult: "multiIf(scope.attributes.`version` IS NOT NULL, toString(scope.attributes.`version`::String), scope.version::String <> '', toString(scope.version::String), NULL)",
+		},
 	}
 
 	for _, tc := range testCases {

--- a/pkg/telemetryschema/tracestelemetryschema/field_mapper_test.go
+++ b/pkg/telemetryschema/tracestelemetryschema/field_mapper_test.go
@@ -406,6 +406,15 @@ func TestColumnExpressionForScopeDeclaredPath(t *testing.T) {
 			expectedResult: "multiIf(scope.attributes.`name` IS NOT NULL, scope.attributes.`name`::String, NULL)",
 		},
 		{
+			// the caller supplied the context, so `scope.` is part of the name rather than a
+			// prefix to strip: this addresses a scope attribute literally named
+			// `scope.testing.env`, not the attribute `testing.env`
+			name:           "explicit context keeps a scope-prefixed name intact",
+			key:            telemetrytypes.TelemetryFieldKey{Name: "scope.testing.env", FieldContext: telemetrytypes.FieldContextScope},
+			keys:           declaredOnly,
+			expectedResult: "multiIf(scope.attributes.`scope.testing.env` IS NOT NULL, scope.attributes.`scope.testing.env`::String, NULL)",
+		},
+		{
 			// metadata knows both homes under this name, so the short spelling coalesces
 			// them instead of being rejected as ambiguous
 			name:           "short name coalesces a known scope attribute with the declared path",

--- a/pkg/telemetryschema/tracestelemetryschema/field_mapper_test.go
+++ b/pkg/telemetryschema/tracestelemetryschema/field_mapper_test.go
@@ -346,10 +346,10 @@ func TestColumnExpressionForTimestampAttributeCollision(t *testing.T) {
 
 // TestColumnExpressionForScopeDeclaredPath covers select-side resolution of scope names that
 // collide with a declared scope path. A short name under scope context (or the bare
-// `scope.<x>` spelling that normalizes to it) binds to the declared path — a same-named
-// scope attribute never shadows it. The full `scope.<x>` name under explicit scope context
-// likewise addresses the declared path alone. A `name`/`version` scope attribute is reachable
-// only via the explicit `scope.attribute.` prefix.
+// `scope.<x>` spelling that normalizes to it) names both homes and coalesces them when
+// metadata knows a same-named scope attribute, and binds to the declared path alone when it
+// does not. The full `scope.<x>` name under explicit scope context addresses the declared
+// path alone; the explicit `scope.attribute.` prefix addresses the attribute alone.
 func TestColumnExpressionForScopeDeclaredPath(t *testing.T) {
 	ctx := context.Background()
 

--- a/tests/integration/tests/queriertraces/01_list.py
+++ b/tests/integration/tests/queriertraces/01_list.py
@@ -1308,23 +1308,28 @@ def test_traces_list_with_corrupt_data(
         # The explicit `scope.` prefix forces scope context only, so span 0's
         # span attribute is ignored — only span 1 matches.
         pytest.param("scope.env.tier = 'gold'", [1], id="scope_prefixed_cross_context"),
-        # `scope.name` binds to the declared scope.name field ONLY (span 0). A same-named
-        # `name` scope attribute (span 1) does NOT shadow or union with it — query that
-        # attribute as `scope.attribute.name` instead.
-        pytest.param("scope.name = 'io.signoz.checkout'", [0], id="scope_name_collision"),
-        # `scope.name` is the declared path only; it does not cross-match a span attribute
-        # literally named `scope.name` (span 2's attribute scope.name='attr-scope-name'),
-        # whose declared scope.name is 'span-gamma'. So nothing matches.
-        pytest.param("scope.name = 'attr-scope-name'", [], id="scope_name_declared_only"),
-        # A `name`/`version` scope attribute is reachable only via the explicit
-        # `scope.attribute.` prefix. Span 1 has a `name` scope attribute = 'io.signoz.checkout'.
+        # `scope.name` names both homes it can resolve to: the declared scope.name field
+        # (span 0) and a same-named `name` scope attribute (span 1), the same way any
+        # other name colliding across contexts unions. `scope.attribute.name` addresses
+        # the attribute alone.
+        pytest.param(
+            "scope.name = 'io.signoz.checkout'", [0, 1], id="scope_name_unions_attribute"
+        ),
+        # The `scope.name` spelling is also a real stored key: span 2 carries a span
+        # attribute literally named `scope.name`, so it matches too.
+        pytest.param(
+            "scope.name = 'attr-scope-name'", [2], id="scope_name_matches_stored_spelling"
+        ),
+        # The explicit `scope.attribute.` prefix addresses the scope attribute alone, without
+        # the declared path. Span 1 has a `name` scope attribute = 'io.signoz.checkout'.
         pytest.param("scope.attribute.name = 'io.signoz.checkout'", [1], id="scope_attribute_name"),
         # `version` as a scope attribute: no span carries one (span 1's 4.5.6 is the declared
         # scope.version, not a scope attribute), so this matches nothing.
         pytest.param("scope.attribute.version = '4.5.6'", [], id="scope_attribute_version_none"),
-        # An unprefixed `name` resolves to the span `name` column only (span 2). It matches
-        # neither the scope.name field (span 0) nor a `name` scope attribute (span 1).
-        pytest.param("name = 'io.signoz.checkout'", [2], id="bare_name_excludes_scope_name_field"),
+        # An unprefixed `name` is checked in every applicable context: the span `name`
+        # column (span 2) and a `name` scope attribute (span 1). It does not reach the
+        # declared scope.name field (span 0), which only the `scope.` prefix addresses.
+        pytest.param("name = 'io.signoz.checkout'", [1, 2], id="bare_name_unions_scope_attribute"),
         # A value that no resolvable key holds (scope.name/scope.version field,
         # a `name`/`version` scope attribute, or a same-named attribute/resource)
         # returns nothing.
@@ -1354,10 +1359,11 @@ def test_traces_list_with_scope_filter(
     - Filtering on scope.name / scope.version / a scope attribute.
     - An unprefixed key is resolved across contexts (scope checked alongside
       attribute / intrinsic), while a `scope.`-prefixed key is scope-only.
-    - `scope.name`/`scope.version` bind to the declared JSON sub-columns only; a
-      same-named `name`/`version` scope attribute is reachable only via the explicit
-      `scope.attribute.` prefix, never via `scope.name` or a bare `name`.
-    - a bare `name` resolves to the span `name` column and never the scope.name field.
+    - `scope.name`/`scope.version` name every home they resolve to: the declared JSON
+      sub-column and a same-named `name`/`version` scope attribute. The explicit
+      `scope.attribute.` prefix addresses the attribute alone.
+    - a bare `name` reaches the span `name` column and a `name` scope attribute, but
+      never the declared scope.name field.
     """
     now = datetime.now(tz=UTC).replace(microsecond=0)
     trace_id = TraceIdGenerator.trace_id()

--- a/tests/integration/tests/queriertraces/01_list.py
+++ b/tests/integration/tests/queriertraces/01_list.py
@@ -1312,14 +1312,10 @@ def test_traces_list_with_corrupt_data(
         # (span 0) and a same-named `name` scope attribute (span 1), the same way any
         # other name colliding across contexts unions. `scope.attribute.name` addresses
         # the attribute alone.
-        pytest.param(
-            "scope.name = 'io.signoz.checkout'", [0, 1], id="scope_name_unions_attribute"
-        ),
+        pytest.param("scope.name = 'io.signoz.checkout'", [0, 1], id="scope_name_unions_attribute"),
         # The `scope.name` spelling is also a real stored key: span 2 carries a span
         # attribute literally named `scope.name`, so it matches too.
-        pytest.param(
-            "scope.name = 'attr-scope-name'", [2], id="scope_name_matches_stored_spelling"
-        ),
+        pytest.param("scope.name = 'attr-scope-name'", [2], id="scope_name_matches_stored_spelling"),
         # The explicit `scope.attribute.` prefix addresses the scope attribute alone, without
         # the declared path. Span 1 has a `name` scope attribute = 'io.signoz.checkout'.
         pytest.param("scope.attribute.name = 'io.signoz.checkout'", [1], id="scope_attribute_name"),


### PR DESCRIPTION
#### Description

- Follow-up to #12666. The doc comment on `TestColumnExpressionForScopeDeclaredPath` still described the pre-#12666 contract — that a same-named scope attribute never shadows a declared path and is reachable only via `scope.attribute.` — which the two union cases in that same test now contradict.
- Comment-only; no behaviour change.
