### PR TITLE
fix(opamp): drop redundant DISTINCT from agent pruning subquery

### DIFF
--- a/pkg/query-service/app/opamp/model/agent.go
+++ b/pkg/query-service/app/opamp/model/agent.go
@@ -79,7 +79,7 @@ func (agent *Agent) KeepOnlyLast50Agents(ctx context.Context) {
 		Where("agent_id NOT IN (?)",
 			agent.store.BunDB().
 				NewSelect().
-				ColumnExpr("distinct(agent_id)").
+				ColumnExpr("agent_id").
 				Model(new(opamptypes.StorableAgent)).
 				Where("org_id = ?", agent.OrgID).
 				OrderExpr("created_at DESC").

--- a/pkg/query-service/app/opamp/model/agent_test.go
+++ b/pkg/query-service/app/opamp/model/agent_test.go
@@ -8,12 +8,14 @@ import (
 	"testing"
 	"time"
 
+	"github.com/DATA-DOG/go-sqlmock"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	"github.com/SigNoz/signoz/pkg/factory/factorytest"
 	"github.com/SigNoz/signoz/pkg/sqlstore"
 	"github.com/SigNoz/signoz/pkg/sqlstore/sqlitesqlstore"
+	"github.com/SigNoz/signoz/pkg/sqlstore/sqlstoretest"
 	"github.com/SigNoz/signoz/pkg/types"
 	"github.com/SigNoz/signoz/pkg/types/opamptypes"
 	"github.com/SigNoz/signoz/pkg/valuer"
@@ -98,4 +100,21 @@ func TestKeepOnlyLast50Agents(t *testing.T) {
 		Count(context.Background())
 	require.NoError(t, err)
 	assert.Equal(t, 5, otherCount)
+}
+
+func TestKeepOnlyLast50Agents_PostgresDialect(t *testing.T) {
+	store := sqlstoretest.New(sqlstore.Config{Provider: "postgres"}, sqlmock.QueryMatcherRegexp)
+	orgID := valuer.GenerateUUID()
+
+	// SQLite tolerates SELECT DISTINCT ... ORDER BY in the pruning subquery, so
+	// TestKeepOnlyLast50Agents cannot catch the postgres dialect regression. Assert
+	// the exact bun-rendered DELETE shape instead: the subquery must select bare
+	// agent_id, not distinct(agent_id).
+	store.Mock().ExpectExec(`^DELETE FROM "agent" AS "storable_agent" WHERE \(org_id = '[^']+'\) AND \(agent_id NOT IN \(SELECT agent_id FROM "agent" AS "storable_agent" WHERE \(org_id = '[^']+'\) ORDER BY created_at DESC LIMIT 50\)\)$`).
+		WillReturnResult(sqlmock.NewResult(0, 0))
+
+	agent := New(store, slog.New(slog.DiscardHandler), orgID, "agent-00", nil)
+	agent.KeepOnlyLast50Agents(context.Background())
+
+	require.NoError(t, store.Mock().ExpectationsWereMet())
 }

--- a/pkg/query-service/app/opamp/model/agent_test.go
+++ b/pkg/query-service/app/opamp/model/agent_test.go
@@ -1,0 +1,101 @@
+package model
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/SigNoz/signoz/pkg/factory/factorytest"
+	"github.com/SigNoz/signoz/pkg/sqlstore"
+	"github.com/SigNoz/signoz/pkg/sqlstore/sqlitesqlstore"
+	"github.com/SigNoz/signoz/pkg/types"
+	"github.com/SigNoz/signoz/pkg/types/opamptypes"
+	"github.com/SigNoz/signoz/pkg/valuer"
+)
+
+func newAgentTestStore(t *testing.T) sqlstore.SQLStore {
+	t.Helper()
+	store, err := sqlitesqlstore.New(t.Context(), factorytest.NewSettings(), sqlstore.Config{
+		Provider: "sqlite",
+		Connection: sqlstore.ConnectionConfig{
+			MaxOpenConns:    1,
+			MaxConnLifetime: 0,
+		},
+		Sqlite: sqlstore.SqliteConfig{
+			Path:            filepath.Join(t.TempDir(), "test.db"),
+			Mode:            "wal",
+			BusyTimeout:     5 * time.Second,
+			TransactionMode: "deferred",
+		},
+	})
+	require.NoError(t, err)
+
+	t.Cleanup(func() {
+		_ = store.SQLDB().Close()
+	})
+
+	_, err = store.BunDB().NewCreateTable().
+		Model((*opamptypes.StorableAgent)(nil)).
+		IfNotExists().
+		Exec(t.Context())
+	require.NoError(t, err)
+
+	return store
+}
+
+func insertTestAgent(t *testing.T, store sqlstore.SQLStore, orgID valuer.UUID, agentID string, createdAt time.Time) {
+	t.Helper()
+	storable := opamptypes.StorableAgent{
+		Identifiable:  types.Identifiable{ID: valuer.GenerateUUID()},
+		TimeAuditable: types.TimeAuditable{CreatedAt: createdAt, UpdatedAt: createdAt},
+		AgentID:       agentID,
+		OrgID:         orgID,
+		Status:        opamptypes.AgentStatusConnected,
+		Config:        "{}",
+	}
+	_, err := store.BunDB().NewInsert().Model(&storable).Exec(t.Context())
+	require.NoError(t, err)
+}
+
+func TestKeepOnlyLast50Agents(t *testing.T) {
+	store := newAgentTestStore(t)
+	orgID := valuer.GenerateUUID()
+	otherOrgID := valuer.GenerateUUID()
+
+	base := time.Now().UTC().Truncate(time.Second)
+	for i := range 60 {
+		insertTestAgent(t, store, orgID, fmt.Sprintf("agent-%02d", i), base.Add(time.Duration(i)*time.Minute))
+	}
+	for i := range 5 {
+		insertTestAgent(t, store, otherOrgID, fmt.Sprintf("other-%02d", i), base.Add(time.Duration(i)*time.Minute))
+	}
+
+	agent := New(store, slog.New(slog.DiscardHandler), orgID, "agent-59", nil)
+	agent.KeepOnlyLast50Agents(context.Background())
+
+	var remaining []opamptypes.StorableAgent
+	err := store.BunDB().NewSelect().
+		Model(&remaining).
+		Where("org_id = ?", orgID).
+		Order("created_at ASC").
+		Scan(context.Background())
+	require.NoError(t, err)
+	require.Len(t, remaining, 50)
+
+	for i, storable := range remaining {
+		assert.Equal(t, fmt.Sprintf("agent-%02d", i+10), storable.AgentID)
+	}
+
+	otherCount, err := store.BunDB().NewSelect().
+		Model((*opamptypes.StorableAgent)(nil)).
+		Where("org_id = ?", otherOrgID).
+		Count(context.Background())
+	require.NoError(t, err)
+	assert.Equal(t, 5, otherCount)
+}


### PR DESCRIPTION
## Problem

`Agent.KeepOnlyLast50Agents` builds its pruning DELETE with a subquery of the form

```sql
SELECT distinct(agent_id) FROM agent WHERE org_id = ? ORDER BY created_at DESC LIMIT 50
```

`SELECT DISTINCT` combined with `ORDER BY created_at` (a column not in the select list) is invalid under standard SQL. Postgres rejects the statement with `SQLSTATE 42P10`, so on Postgres deployments (`SIGNOZ_SQLSTORE_PROVIDER=postgres`) agent pruning never runs and an error is logged on every agent check-in — the call site is the opamp update hot path (`agents.go:98`). The default SQLite store accepts the construct, which is why it goes unnoticed there.

Closes #12308

## Root cause

`agent_id` is declared `NOT NULL UNIQUE` on the model (`pkg/types/opamptypes/agent.go:36`) and in the production schema (migration 041), so under the per-org filter `distinct(agent_id)` can never remove a row — the DISTINCT is redundant. Its presence forces Postgres to reject the query because the `ORDER BY` expression does not appear in the select list.

## Fix

Drop the redundant `distinct(...)` wrapper and select the plain column (`ColumnExpr("agent_id")`). The statement becomes valid on all supported dialects with identical pruning semantics.

The same root-cause analysis was independently posted on the tracking issue by @BILLKISHORE; this PR implements it together with a regression test.

## Testing

- New unit test `TestKeepOnlyLast50Agents` (sqlite store): seeds 60 agents plus 5 agents in another org, runs the prune, asserts exactly the newest 50 remain and other-org rows are untouched.
  - `go test ./pkg/query-service/app/opamp/model/... -run TestKeepOnlyLast50Agents -v` → PASS
- Real Postgres 17 check (docker `postgres:17-alpine`, table shaped like migration 041, 60 rows seeded), running bun's rendered statements directly:
  - pre-fix statement → `ERROR:  for SELECT DISTINCT, ORDER BY expressions must appear in select list`
  - post-fix statement → `DELETE 10`; 50 rows remain, oldest remaining row is the expected one (newest-50 by `created_at`)
- `go build ./...` (with `GOTOOLCHAIN=go1.25.7` as pinned by go.mod) → OK
- `go vet ./pkg/query-service/app/opamp/...` → OK
- `go test -race ./pkg/query-service/app/opamp/model/...` → ok
