### PR TITLE
fix(dashboard): resolve missing legend format variables to empty string

### DIFF
--- a/frontend/src/lib/getLabelName.test.ts
+++ b/frontend/src/lib/getLabelName.test.ts
@@ -1,0 +1,47 @@
+import getLabelName from './getLabelName';
+
+describe('getLabelName', () => {
+	it('should substitute a legend variable present in the metric', () => {
+		const metric = { 'service.name': 'checkoutservice' };
+
+		const result = getLabelName(metric, '', '{{service.name}}');
+
+		expect(result).toBe('checkoutservice');
+	});
+
+	it('should resolve a missing legend variable to an empty string instead of "undefined"', () => {
+		const metric = { 'http.method': 'GET' };
+
+		const result = getLabelName(metric, '', '{{service.name}}');
+
+		expect(result).toBe('');
+	});
+
+	it('should resolve dotted attribute keys', () => {
+		const metric = { 'deployment.environment': 'production' };
+
+		const result = getLabelName(metric, '', 'env: {{deployment.environment}}');
+
+		expect(result).toBe('env: production');
+	});
+
+	it('should substitute every occurrence of a repeated legend variable', () => {
+		const metric = { 'service.name': 'checkoutservice' };
+
+		const result = getLabelName(
+			metric,
+			'',
+			'{{service.name}} - {{service.name}}',
+		);
+
+		expect(result).toBe('checkoutservice - checkoutservice');
+	});
+
+	it('should return an empty string when metric is undefined', () => {
+		const metric = undefined as unknown as Record<string, string>;
+
+		const result = getLabelName(metric, '', '{{service.name}}');
+
+		expect(result).toBe('');
+	});
+});

--- a/frontend/src/lib/getLabelName.ts
+++ b/frontend/src/lib/getLabelName.ts
@@ -16,12 +16,12 @@ const getLabelName = (
 			.filter((e) => e)
 			.map((e) => e.split('}}')[0]);
 
-		const results = variables.map((variable) => metric[variable]);
+		const results = variables.map((variable) => metric[variable] ?? '');
 
 		let endResult = legends;
 
 		variables.forEach((e, index) => {
-			endResult = endResult.replace(`{{${e}}}`, results[index]);
+			endResult = endResult.split(`{{${e}}}`).join(results[index]);
 		});
 
 		return endResult;


### PR DESCRIPTION
#### Description

- Legend format tokens referencing a key not present in a series' labels (e.g. `{{service.name}}` when the query isn't grouped by that attribute) rendered the literal text `"undefined"` in the legend, because the missing lookup was passed straight into `String.replace()`, which coerces `undefined` to a string.
- Fixed by defaulting a missing lookup to an empty string.
- While in the same function, switched from single-shot `.replace()` to `.split().join()` so repeated `{{var}}` tokens in a legend format all resolve, not just the first occurrence.
- Added unit tests for `getLabelName` (previously untested directly): present key, missing key, dotted key, repeated token, undefined metric.

#### Issues closed by this PR

Closes #12661
