### PR TITLE
fix(frontend): increase trace waterfall scrollbar size (#12518)

### DIFF
--- a/frontend/src/pages/TraceDetailsV3/TraceWaterfall/TraceWaterfallStates/Success/Success.module.scss
+++ b/frontend/src/pages/TraceDetailsV3/TraceWaterfall/TraceWaterfallStates/Success/Success.module.scss
@@ -57,7 +57,7 @@
 	padding: 0px 20px 0px 20px;
 
 	&::-webkit-scrollbar {
-		width: 0.1rem;
+		width: 0.4rem;
 	}
 }
 
@@ -148,7 +148,7 @@
 	}
 
 	&::-webkit-scrollbar {
-		height: 0.3rem;
+		height: 0.4rem;
 	}
 
 	&::-webkit-scrollbar-thumb {


### PR DESCRIPTION
#### Description

* Increased the scrollbar width/height in the Trace Waterfall view from `0.1rem` (~1.6px) to `0.4rem` (~6.4px).
* Previously, the `0.1rem` width made the scrollbar thumb almost invisible and extremely difficult to click and drag when navigating long waterfall traces.

#### Issues closed by this PR

Closes #12518

#### Screenshots / Screen Recordings

| Before (0.1rem / ~1.6px scrollbar) | After (0.4rem / ~6.4px scrollbar) |
| :---: | :---: |
| <img width="1463" height="418" alt="After - Fixed scrollbar" src="https://github.com/user-attachments/assets/8aba58b6-0938-43e2-9cdb-6f62f3e41ebd" /> | <img width="1405" height="426" alt="Before - Thin scrollbar" src="https://github.com/user-attachments/assets/13f13a4d-9e26-4cb2-9ae6-bac96c3f7547" /> |

#### Additional Information

* Pure frontend SCSS styling change in `Success.module.scss`. No logic or backend modifications were made.