### PR TITLE
feat(licensing): add resource authz to license endpoints

### DIFF
--- a/docs/api/openapi.yml
+++ b/docs/api/openapi.yml
@@ -24122,9 +24122,9 @@ paths:
           description: Internal Server Error
       security:
       - api_key:
-        - ADMIN
+        - license:create
       - tokenizer:
-        - ADMIN
+        - license:create
       summary: Activate a license.
       tags:
       - licenses
@@ -24168,9 +24168,9 @@ paths:
           description: Internal Server Error
       security:
       - api_key:
-        - ADMIN
+        - license:update
       - tokenizer:
-        - ADMIN
+        - license:update
       summary: Refresh the active license.
       tags:
       - licenses

--- a/pkg/apiserver/signozapiserver/licensing.go
+++ b/pkg/apiserver/signozapiserver/licensing.go
@@ -4,43 +4,62 @@ import (
 	"net/http"
 
 	"github.com/SigNoz/signoz/pkg/http/handler"
-	"github.com/SigNoz/signoz/pkg/types"
+	"github.com/SigNoz/signoz/pkg/types/authtypes"
+	"github.com/SigNoz/signoz/pkg/types/coretypes"
 	"github.com/SigNoz/signoz/pkg/types/licensetypes"
 	"github.com/gorilla/mux"
 )
 
 func (provider *provider) addLicensingRoutes(router *mux.Router) error {
-	if err := router.Handle("/api/v3/licenses", handler.New(provider.authzMiddleware.AdminAccess(provider.licensingHandler.Activate), handler.OpenAPIDef{
-		ID:                  "ActivateLicense",
-		Tags:                []string{"licenses"},
-		Summary:             "Activate a license.",
-		Description:         "This endpoint validates the license key with upstream and activates the license for the organization.",
-		Request:             new(licensetypes.PostableLicense),
-		RequestContentType:  "application/json",
-		Response:            nil,
-		ResponseContentType: "",
-		SuccessStatusCode:   http.StatusAccepted,
-		ErrorStatusCodes:    []int{http.StatusBadRequest, http.StatusUnauthorized, http.StatusForbidden, http.StatusNotFound, http.StatusConflict},
-		Deprecated:          false,
-		SecuritySchemes:     newSecuritySchemes(types.RoleAdmin),
-	})).Methods(http.MethodPost).GetError(); err != nil {
+	if err := router.Handle("/api/v3/licenses", handler.New(
+		provider.authzMiddleware.CheckResources(provider.licensingHandler.Activate, authtypes.SigNozAdminRoleName),
+		handler.OpenAPIDef{
+			ID:                  "ActivateLicense",
+			Tags:                []string{"licenses"},
+			Summary:             "Activate a license.",
+			Description:         "This endpoint validates the license key with upstream and activates the license for the organization.",
+			Request:             new(licensetypes.PostableLicense),
+			RequestContentType:  "application/json",
+			Response:            nil,
+			ResponseContentType: "",
+			SuccessStatusCode:   http.StatusAccepted,
+			ErrorStatusCodes:    []int{http.StatusBadRequest, http.StatusUnauthorized, http.StatusForbidden, http.StatusNotFound, http.StatusConflict},
+			Deprecated:          false,
+			SecuritySchemes:     newScopedSecuritySchemes([]string{coretypes.ResourceMetaResourceLicense.Scope(coretypes.VerbCreate)}),
+		},
+		handler.WithResourceDefs(handler.BasicResourceDef{
+			Resource: coretypes.ResourceMetaResourceLicense,
+			Verb:     coretypes.VerbCreate,
+			Category: coretypes.ActionCategoryConfigurationChange,
+			Selector: coretypes.WildcardSelector,
+		}),
+	)).Methods(http.MethodPost).GetError(); err != nil {
 		return err
 	}
 
-	if err := router.Handle("/api/v3/licenses", handler.New(provider.authzMiddleware.AdminAccess(provider.licensingHandler.Refresh), handler.OpenAPIDef{
-		ID:                  "RefreshLicense",
-		Tags:                []string{"licenses"},
-		Summary:             "Refresh the active license.",
-		Description:         "This endpoint refreshes the active license of the organization from upstream.",
-		Request:             nil,
-		RequestContentType:  "",
-		Response:            nil,
-		ResponseContentType: "",
-		SuccessStatusCode:   http.StatusNoContent,
-		ErrorStatusCodes:    []int{http.StatusBadRequest, http.StatusUnauthorized, http.StatusForbidden, http.StatusNotFound},
-		Deprecated:          false,
-		SecuritySchemes:     newSecuritySchemes(types.RoleAdmin),
-	})).Methods(http.MethodPut).GetError(); err != nil {
+	if err := router.Handle("/api/v3/licenses", handler.New(
+		provider.authzMiddleware.CheckResources(provider.licensingHandler.Refresh, authtypes.SigNozAdminRoleName),
+		handler.OpenAPIDef{
+			ID:                  "RefreshLicense",
+			Tags:                []string{"licenses"},
+			Summary:             "Refresh the active license.",
+			Description:         "This endpoint refreshes the active license of the organization from upstream.",
+			Request:             nil,
+			RequestContentType:  "",
+			Response:            nil,
+			ResponseContentType: "",
+			SuccessStatusCode:   http.StatusNoContent,
+			ErrorStatusCodes:    []int{http.StatusBadRequest, http.StatusUnauthorized, http.StatusForbidden, http.StatusNotFound},
+			Deprecated:          false,
+			SecuritySchemes:     newScopedSecuritySchemes([]string{coretypes.ResourceMetaResourceLicense.Scope(coretypes.VerbUpdate)}),
+		},
+		handler.WithResourceDefs(handler.BasicResourceDef{
+			Resource: coretypes.ResourceMetaResourceLicense,
+			Verb:     coretypes.VerbUpdate,
+			Category: coretypes.ActionCategoryConfigurationChange,
+			Selector: coretypes.WildcardSelector,
+		}),
+	)).Methods(http.MethodPut).GetError(); err != nil {
 		return err
 	}
 

--- a/pkg/signoz/provider.go
+++ b/pkg/signoz/provider.go
@@ -244,6 +244,7 @@ func NewSQLMigrationProviderFactories(
 		sqlmigration.NewDeleteOrphanUserRolesFactory(),
 		sqlmigration.NewMigrateLambdaDashboardsFactory(),
 		sqlmigration.NewAddAuthDomainTuplesFactory(sqlstore),
+		sqlmigration.NewAddLicenseTuplesFactory(sqlstore),
 	)
 }
 

--- a/pkg/sqlmigration/118_add_license_tuples.go
+++ b/pkg/sqlmigration/118_add_license_tuples.go
@@ -1,0 +1,159 @@
+package sqlmigration
+
+import (
+	"context"
+	"database/sql"
+	"encoding/json"
+	"time"
+
+	"github.com/SigNoz/signoz/pkg/factory"
+	"github.com/SigNoz/signoz/pkg/sqlstore"
+	"github.com/SigNoz/signoz/pkg/types/authtypes"
+	"github.com/SigNoz/signoz/pkg/types/coretypes"
+	"github.com/oklog/ulid/v2"
+	"github.com/uptrace/bun"
+	"github.com/uptrace/bun/dialect"
+	"github.com/uptrace/bun/migrate"
+)
+
+type addLicenseTuples struct {
+	sqlstore sqlstore.SQLStore
+}
+
+func NewAddLicenseTuplesFactory(sqlstore sqlstore.SQLStore) factory.ProviderFactory[SQLMigration, Config] {
+	return factory.NewProviderFactory(factory.MustNewName("add_license_tuples"), func(ctx context.Context, ps factory.ProviderSettings, c Config) (SQLMigration, error) {
+		return &addLicenseTuples{sqlstore: sqlstore}, nil
+	})
+}
+
+func (migration *addLicenseTuples) Register(migrations *migrate.Migrations) error {
+	return migrations.Register(migration.Up, migration.Down)
+}
+
+func (migration *addLicenseTuples) Up(ctx context.Context, db *bun.DB) error {
+	tx, err := db.BeginTx(ctx, nil)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = tx.Rollback() }()
+
+	var storeID string
+	err = tx.QueryRowContext(ctx, `SELECT id FROM store WHERE name = ? LIMIT 1`, "signoz").Scan(&storeID)
+	if err != nil {
+		return err
+	}
+
+	var orgIDs []string
+	err = tx.NewSelect().
+		Table("organizations").
+		Column("id").
+		Scan(ctx, &orgIDs)
+	if err != nil && err != sql.ErrNoRows {
+		return err
+	}
+
+	isPG := migration.sqlstore.BunDB().Dialect().Name() == dialect.PG
+
+	tuples := []migrationTuple{
+		{authtypes.SigNozAdminRoleName, "metaresource", "license", "create"},
+		{authtypes.SigNozAdminRoleName, "metaresource", "license", "read"},
+		{authtypes.SigNozAdminRoleName, "metaresource", "license", "update"},
+		{authtypes.SigNozAdminRoleName, "metaresource", "license", "delete"},
+		{authtypes.SigNozAdminRoleName, "metaresource", "license", "list"},
+	}
+
+	for _, orgID := range orgIDs {
+		for _, tuple := range tuples {
+			entropy := ulid.DefaultEntropy()
+			now := time.Now().UTC()
+			tupleID := ulid.MustNew(ulid.Timestamp(now), entropy).String()
+
+			objectID := "organization/" + orgID + "/" + tuple.objectName + "/*"
+			roleSubject := "organization/" + orgID + "/role/" + tuple.roleName
+
+			if isPG {
+				user := "role:" + roleSubject + "#assignee"
+				result, err := tx.ExecContext(ctx, `
+					INSERT INTO tuple (store, object_type, object_id, relation, _user, user_type, ulid, inserted_at)
+					VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+					ON CONFLICT (store, object_type, object_id, relation, _user) DO NOTHING`,
+					storeID, tuple.objectType, objectID, tuple.relation, user, "userset", tupleID, now,
+				)
+				if err != nil {
+					return err
+				}
+				rowsAffected, err := result.RowsAffected()
+				if err != nil {
+					return err
+				}
+				if rowsAffected == 0 {
+					continue
+				}
+				_, err = tx.ExecContext(ctx, `
+					INSERT INTO changelog (store, object_type, object_id, relation, _user, operation, ulid, inserted_at)
+					VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+					ON CONFLICT (store, ulid, object_type) DO NOTHING`,
+					storeID, tuple.objectType, objectID, tuple.relation, user, 0, tupleID, now,
+				)
+				if err != nil {
+					return err
+				}
+			} else {
+				result, err := tx.ExecContext(ctx, `
+					INSERT INTO tuple (store, object_type, object_id, relation, user_object_type, user_object_id, user_relation, user_type, ulid, inserted_at)
+					VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+					ON CONFLICT (store, object_type, object_id, relation, user_object_type, user_object_id, user_relation) DO NOTHING`,
+					storeID, tuple.objectType, objectID, tuple.relation, "role", roleSubject, "assignee", "userset", tupleID, now,
+				)
+				if err != nil {
+					return err
+				}
+				rowsAffected, err := result.RowsAffected()
+				if err != nil {
+					return err
+				}
+				if rowsAffected == 0 {
+					continue
+				}
+				_, err = tx.ExecContext(ctx, `
+					INSERT INTO changelog (store, object_type, object_id, relation, user_object_type, user_object_id, user_relation, operation, ulid, inserted_at)
+					VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+					ON CONFLICT (store, ulid, object_type) DO NOTHING`,
+					storeID, tuple.objectType, objectID, tuple.relation, "role", roleSubject, "assignee", 0, tupleID, now,
+				)
+				if err != nil {
+					return err
+				}
+			}
+		}
+	}
+
+	managedRoleGroups := make(map[string]string, len(coretypes.ManagedRoleToTransactions))
+	for roleName, transactions := range coretypes.ManagedRoleToTransactions {
+		data, err := json.Marshal(authtypes.NewTransactionGroupsFromTransactions(transactions))
+		if err != nil {
+			return err
+		}
+		managedRoleGroups[roleName] = string(data)
+	}
+
+	for _, orgID := range orgIDs {
+		for roleName, data := range managedRoleGroups {
+			if _, err := tx.NewUpdate().
+				Model(new(roles)).
+				Set("transaction_groups = ?", data).
+				Where("org_id = ?", orgID).
+				Where("type = ?", authtypes.RoleTypeManaged.StringValue()).
+				Where("name = ?", roleName).
+				Exec(ctx); err != nil {
+				return err
+			}
+		}
+	}
+
+	return tx.Commit()
+}
+
+func (migration *addLicenseTuples) Down(context.Context, *bun.DB) error {
+	return nil
+}

--- a/pkg/types/coretypes/registry_managed_role.go
+++ b/pkg/types/coretypes/registry_managed_role.go
@@ -64,10 +64,10 @@ var ManagedRoleToTransactions = map[string][]Transaction{
 		{Verb: VerbCreate, Object: *MustNewObject(ResourceRef{Type: TypeMetaResource, Kind: KindFactorPassword}, WildCardSelectorString)},
 		{Verb: VerbList, Object: *MustNewObject(ResourceRef{Type: TypeMetaResource, Kind: KindFactorPassword}, WildCardSelectorString)},
 		// license — admin only.
-		// Uniform LCRUD shape; actual ee routes are POST /api/v3/licenses (create
-		// = Activate), PUT /api/v3/licenses (update = Refresh), GET
-		// /api/v3/licenses/active (read; currently exposed as ViewAccess on the
-		// route side). delete and list are placeholders for shape parity, no
+		// Uniform LCRUD shape; routes are POST /api/v3/licenses (create =
+		// Activate) and PUT /api/v3/licenses (update = Refresh). GET
+		// /api/v3/licenses/active is OpenAccess, so the read grant is not
+		// route-enforced. delete and list are placeholders for shape parity, no
 		// route serves them today.
 		{Verb: VerbRead, Object: *MustNewObject(ResourceRef{Type: TypeMetaResource, Kind: KindLicense}, WildCardSelectorString)},
 		{Verb: VerbUpdate, Object: *MustNewObject(ResourceRef{Type: TypeMetaResource, Kind: KindLicense}, WildCardSelectorString)},

--- a/tests/fixtures/auth.py
+++ b/tests/fixtures/auth.py
@@ -453,3 +453,34 @@ def change_user_role(
         timeout=5,
     )
     assert response.status_code == HTTPStatus.CREATED, response.text
+
+
+def license_mapping(license_id: str, key: str, valid_from: int) -> Mapping:
+    return Mapping(
+        request=MappingRequest(
+            method=HttpMethods.GET,
+            url="/v2/licenses/me",
+            headers={"X-Signoz-Cloud-Api-Key": {WireMockMatchers.EQUAL_TO: key}},
+        ),
+        response=MappingResponse(
+            status=200,
+            json_body={
+                "status": "success",
+                "data": {
+                    "id": license_id,
+                    "key": key,
+                    "valid_from": valid_from,
+                    "valid_until": -1,
+                    "status": "VALID",
+                    "state": "EVALUATING",
+                    "plan": {
+                        "name": "ENTERPRISE",
+                    },
+                    "platform": "CLOUD",
+                    "features": [],
+                    "event_queue": {},
+                },
+            },
+        ),
+        persistent=False,
+    )

--- a/tests/integration/tests/passwordauthn/09_license_authz.py
+++ b/tests/integration/tests/passwordauthn/09_license_authz.py
@@ -1,0 +1,186 @@
+import http
+from collections.abc import Callable
+
+import requests
+from wiremock.client import Mapping
+
+from fixtures import types
+from fixtures.auth import (
+    USER_ADMIN_EMAIL,
+    USER_ADMIN_PASSWORD,
+    change_user_role,
+    create_active_user,
+    license_mapping,
+)
+from fixtures.role import transaction_group
+
+_EDITOR_EMAIL = "editor+licenseauthz@integration.test"
+_EDITOR_PASSWORD = "password123Z$"
+_VIEWER_EMAIL = "viewer+licenseauthz@integration.test"
+_VIEWER_PASSWORD = "password123Z$"
+
+_ACTOR_ROLE_NAME = "license-fga-actor"
+_ACTOR_EMAIL = "customrole+licenseauthz@integration.test"
+_ACTOR_PASSWORD = "password123Z$"
+
+_LICENSE_ID = "0196360e-90cd-7a74-8313-1aa815ce2a69"
+_LICENSE_KEY = "secret-key-authz"
+
+
+def test_admin_can_activate_license(
+    signoz: types.SigNoz,
+    make_http_mocks: Callable[[types.TestContainerDocker, list[Mapping]], None],
+    get_token: Callable[[str, str], str],
+) -> None:
+    make_http_mocks(signoz.zeus, [license_mapping(_LICENSE_ID, _LICENSE_KEY, valid_from=1732146930)])
+
+    admin_token = get_token(USER_ADMIN_EMAIL, USER_ADMIN_PASSWORD)
+
+    for email, role, password, name in (
+        (_EDITOR_EMAIL, "signoz-editor", _EDITOR_PASSWORD, "license authz editor"),
+        (_VIEWER_EMAIL, "signoz-viewer", _VIEWER_PASSWORD, "license authz viewer"),
+    ):
+        create_active_user(signoz, admin_token, email=email, role=role, password=password, name=name)
+
+    response = requests.post(
+        url=signoz.self.host_configs["8080"].get("/api/v3/licenses"),
+        json={"key": _LICENSE_KEY},
+        headers={"Authorization": "Bearer " + admin_token},
+        timeout=5,
+    )
+
+    assert response.status_code == http.HTTPStatus.ACCEPTED, response.text
+
+
+def test_editor_and_viewer_forbidden(
+    signoz: types.SigNoz,
+    get_token: Callable[[str, str], str],
+) -> None:
+    for email, password in ((_EDITOR_EMAIL, _EDITOR_PASSWORD), (_VIEWER_EMAIL, _VIEWER_PASSWORD)):
+        token = get_token(email, password)
+
+        response = requests.post(
+            url=signoz.self.host_configs["8080"].get("/api/v3/licenses"),
+            json={"key": _LICENSE_KEY},
+            headers={"Authorization": "Bearer " + token},
+            timeout=5,
+        )
+        assert response.status_code == http.HTTPStatus.FORBIDDEN, f"{email} activate: expected 403, got {response.status_code}: {response.text}"
+
+        response = requests.put(
+            url=signoz.self.host_configs["8080"].get("/api/v3/licenses"),
+            headers={"Authorization": "Bearer " + token},
+            timeout=5,
+        )
+        assert response.status_code == http.HTTPStatus.FORBIDDEN, f"{email} refresh: expected 403, got {response.status_code}: {response.text}"
+
+
+def test_all_roles_can_get_active_license(
+    signoz: types.SigNoz,
+    get_token: Callable[[str, str], str],
+) -> None:
+    for email, password in (
+        (USER_ADMIN_EMAIL, USER_ADMIN_PASSWORD),
+        (_EDITOR_EMAIL, _EDITOR_PASSWORD),
+        (_VIEWER_EMAIL, _VIEWER_PASSWORD),
+    ):
+        token = get_token(email, password)
+
+        response = requests.get(
+            url=signoz.self.host_configs["8080"].get("/api/v3/licenses/active"),
+            headers={"Authorization": "Bearer " + token},
+            timeout=5,
+        )
+        assert response.status_code == http.HTTPStatus.OK, f"{email} get active: expected 200, got {response.status_code}: {response.text}"
+        assert response.json()["data"]["key"] == _LICENSE_KEY
+
+
+def test_admin_can_refresh_license(
+    signoz: types.SigNoz,
+    make_http_mocks: Callable[[types.TestContainerDocker, list[Mapping]], None],
+    get_token: Callable[[str, str], str],
+) -> None:
+    make_http_mocks(signoz.zeus, [license_mapping(_LICENSE_ID, _LICENSE_KEY, valid_from=1732146931)])
+
+    admin_token = get_token(USER_ADMIN_EMAIL, USER_ADMIN_PASSWORD)
+
+    response = requests.put(
+        url=signoz.self.host_configs["8080"].get("/api/v3/licenses"),
+        headers={"Authorization": "Bearer " + admin_token},
+        timeout=5,
+    )
+    assert response.status_code == http.HTTPStatus.NO_CONTENT, response.text
+
+    response = requests.get(
+        url=signoz.self.host_configs["8080"].get("/api/v3/licenses/active"),
+        headers={"Authorization": "Bearer " + admin_token},
+        timeout=5,
+    )
+    assert response.status_code == http.HTTPStatus.OK, response.text
+    assert response.json()["data"]["valid_from"] == 1732146931
+
+
+def test_custom_role_license_grant(
+    signoz: types.SigNoz,
+    make_http_mocks: Callable[[types.TestContainerDocker, list[Mapping]], None],
+    get_token: Callable[[str, str], str],
+    create_role: Callable[..., str],
+) -> None:
+    admin_token = get_token(USER_ADMIN_EMAIL, USER_ADMIN_PASSWORD)
+
+    role_id = create_role(admin_token, _ACTOR_ROLE_NAME)
+    user_id = create_active_user(
+        signoz,
+        admin_token,
+        email=_ACTOR_EMAIL,
+        role="signoz-viewer",
+        password=_ACTOR_PASSWORD,
+        name="license authz custom role actor",
+    )
+    change_user_role(signoz, admin_token, user_id, "signoz-viewer", _ACTOR_ROLE_NAME)
+
+    actor_token = get_token(_ACTOR_EMAIL, _ACTOR_PASSWORD)
+
+    response = requests.put(
+        url=signoz.self.host_configs["8080"].get("/api/v3/licenses"),
+        headers={"Authorization": "Bearer " + actor_token},
+        timeout=5,
+    )
+    assert response.status_code == http.HTTPStatus.FORBIDDEN, f"refresh without grant: expected 403, got {response.status_code}: {response.text}"
+
+    response = requests.put(
+        url=signoz.self.host_configs["8080"].get(f"/api/v1/roles/{role_id}"),
+        json={
+            "description": "",
+            "transactionGroups": [
+                transaction_group("update", "metaresource", "license", ["*"]),
+            ],
+        },
+        headers={"Authorization": "Bearer " + admin_token},
+        timeout=5,
+    )
+    assert response.status_code == http.HTTPStatus.NO_CONTENT, response.text
+
+    make_http_mocks(signoz.zeus, [license_mapping(_LICENSE_ID, _LICENSE_KEY, valid_from=1732146932)])
+
+    response = requests.put(
+        url=signoz.self.host_configs["8080"].get("/api/v3/licenses"),
+        headers={"Authorization": "Bearer " + actor_token},
+        timeout=5,
+    )
+    assert response.status_code == http.HTTPStatus.NO_CONTENT, f"refresh with grant: expected 204, got {response.status_code}: {response.text}"
+
+    response = requests.put(
+        url=signoz.self.host_configs["8080"].get(f"/api/v1/roles/{role_id}"),
+        json={"description": "", "transactionGroups": []},
+        headers={"Authorization": "Bearer " + admin_token},
+        timeout=5,
+    )
+    assert response.status_code == http.HTTPStatus.NO_CONTENT, response.text
+
+    response = requests.put(
+        url=signoz.self.host_configs["8080"].get("/api/v3/licenses"),
+        headers={"Authorization": "Bearer " + actor_token},
+        timeout=5,
+    )
+    assert response.status_code == http.HTTPStatus.FORBIDDEN, f"refresh after revoke: expected 403, got {response.status_code}: {response.text}"


### PR DESCRIPTION
#### Description

- Stacked on #12700. Converts `POST/PUT /api/v3/licenses` from `AdminAccess` to `CheckResources` with `license` ResourceDefs (`create`/`update`, wildcard selector); `GET /api/v3/licenses/active` stays `OpenAccess`.
- Adds migration 118 backfilling license FGA tuples for existing orgs and re-syncing managed-role `transaction_groups`.
- Integration tests cover the managed-role 200-vs-403 matrix and a custom-role grant/revoke flip.

#### Issues closed by this PR

Closes https://github.com/SigNoz/platform-pod/issues/2653