### PR TITLE
test(service-account): fix flaky ServiceAccountDrawer authz test

### DIFF
--- a/frontend/src/components/ServiceAccountDrawer/__tests__/ServiceAccountDrawer.authz.test.tsx
+++ b/frontend/src/components/ServiceAccountDrawer/__tests__/ServiceAccountDrawer.authz.test.tsx
@@ -4,7 +4,7 @@ import {
 } from 'mocks-server/__mockdata__/roles';
 import { rest, server } from 'mocks-server/server';
 import { NuqsTestingAdapter } from 'nuqs/adapters/testing';
-import { fireEvent, render, screen, waitFor } from 'tests/test-utils';
+import { render, screen, waitFor } from 'tests/test-utils';
 import {
 	setupAuthzAdmin,
 	setupAuthzDeny,
@@ -110,10 +110,7 @@ describe('ServiceAccountDrawer — permissions', () => {
 	it('shows PermissionDeniedCallout in Keys tab when list-keys permission is denied', async () => {
 		server.use(setupAuthzDeny(APIKeyListPermission));
 
-		renderDrawer();
-		await screen.findByDisplayValue('CI Bot');
-
-		fireEvent.click(screen.getByRole('radio', { name: /keys/i }));
+		renderDrawer({ account: 'sa-1', tab: 'keys' });
 
 		await waitFor(() => {
 			expect(screen.getByText(/list:factor-api-key/)).toBeInTheDocument();


### PR DESCRIPTION
#### Description

- The `shows PermissionDeniedCallout in Keys tab when list-keys permission is denied` test intermittently failed in CI: the `fireEvent.click` on the Keys tab races with the nuqs testing adapter, which can abort the queued `tab=keys` URL update mid-flight, leaving the drawer stuck on the Overview tab.
- Since the tab is URL state, the test now lands directly on the Keys tab via initial search params (`{ account: 'sa-1', tab: 'keys' }`), avoiding the userEvent/click interaction altogether. The click-to-Keys flow remains covered in `ServiceAccountDrawer.test.tsx`.

#### Issues closed by this PR

closes SigNoz/platform-pod#3053