### PR TITLE
fix(tests): guard network teardown raise against None

### DIFF
--- a/tests/fixtures/network.py
+++ b/tests/fixtures/network.py
@@ -52,7 +52,9 @@ def network(request: pytest.FixtureRequest, pytestconfig: pytest.Config) -> type
                         pass
                 time.sleep(1)
 
-        raise last_err
+        if last_err is not None:
+            raise last_err
+        raise RuntimeError(f"Failed to remove network {nw.name} after retries")
 
     def restore(existing: dict) -> types.Network:
         client = docker.from_env()


### PR DESCRIPTION
## Summary

The `network` fixture's `delete()` retry loop in `tests/fixtures/network.py` ends with `raise last_err`, where `last_err` is typed `docker.errors.APIError | None` and initialized to `None`.

In practice `last_err` is always set before that line is reached (any loop iteration that doesn't `return` assigns it), so this isn't a live bug today. But:

- Static type checkers (mypy/pyright) flag `raise last_err` because raising `None` is a runtime `TypeError`.
- A future refactor of the loop could make the `None` path actually reachable, turning the type-checker warning into a real crash during test teardown.

## Change

Guard the raise so it only fires when an error was actually captured, and add an explicit `RuntimeError` fallback so exhausting all 10 retries surfaces a clear failure instead of silently returning `None`:

```python
if last_err is not None:
    raise last_err
raise RuntimeError(f"Failed to remove network {nw.name} after retries")
```

## Testing

`ruff check` passes on `tests/`.