### PR TITLE
perf(querier): bound trace_summary lookups to avoid full-table scans

### DIFF
--- a/conf/example.yaml
+++ b/conf/example.yaml
@@ -166,6 +166,11 @@ querier:
   # range with padding to include slightly delayed log exports. Logs only; set
   # to 0 to disable.
   log_trace_id_window_padding: 5m
+  # When resolving a trace_id filter against trace_summary, first scan only
+  # the selected window plus this padding (partition prune on toDate(end)).
+  # Falls back to a full scan if the bounded lookup is incomplete. Raise this
+  # if traces commonly last longer than 6h or spans arrive with large delay.
+  trace_id_window_padding: 6h
 
 ##################### TelemetryStore #####################
 telemetrystore:

--- a/pkg/querier/builder_query.go
+++ b/pkg/querier/builder_query.go
@@ -45,6 +45,7 @@ var _ qbtypes.StatementProvider = (*builderQuery[any])(nil)
 
 type builderConfig struct {
 	logTraceIDWindowPaddingMS uint64
+	traceIDWindowPadding      time.Duration
 }
 
 func newBuilderQuery[T any](
@@ -357,7 +358,11 @@ func (q *builderQuery[T]) narrowWindowByTraceID(ctx context.Context, fromMS, toM
 	}
 
 	finder := tracestelemetryschema.NewTraceTimeRangeFinder(q.telemetryStore)
-	traceStart, traceEnd, exists, err := finder.GetTraceTimeRangeMulti(ctx, traceIDs)
+	traceStart, traceEnd, exists, err := finder.GetTraceTimeRangeMulti(ctx, traceIDs, tracestelemetryschema.TraceTimeRangeOpts{
+		FromMS:  fromMS,
+		ToMS:    toMS,
+		Padding: q.builderConfig.traceIDWindowPadding,
+	})
 	if err != nil {
 		return fromMS, toMS, true, ""
 	}

--- a/pkg/querier/config.go
+++ b/pkg/querier/config.go
@@ -20,6 +20,12 @@ type Config struct {
 	MaxConcurrentQueries int `yaml:"max_concurrent_queries" mapstructure:"max_concurrent_queries"`
 	// LogTraceIDWindowPadding is the padding added to narrowed down timerange from trace summary to logs with trace_id filter.
 	LogTraceIDWindowPadding time.Duration `yaml:"log_trace_id_window_padding" mapstructure:"log_trace_id_window_padding"`
+	// TraceIDWindowPadding widens the selected query window when looking up
+	// trace_summary to resolve min(start)/max(end) for a trace_id filter.
+	// The extra width is required because AggregatingMergeTree does not merge
+	// across PARTITION BY toDate(end), so a trace that straddles a date
+	// boundary has rows in adjacent partitions. Default 6h.
+	TraceIDWindowPadding time.Duration `yaml:"trace_id_window_padding" mapstructure:"trace_id_window_padding"`
 
 	// Keys sit under querier.skip_resource_fingerprint.
 	statementbuilder.Config `mapstructure:",squash" yaml:",squash"`
@@ -37,6 +43,7 @@ func newConfig() factory.Config {
 		FluxInterval:            5 * time.Minute,
 		MaxConcurrentQueries:    DefaultMaxConcurrentQueries,
 		LogTraceIDWindowPadding: 5 * time.Minute,
+		TraceIDWindowPadding:    6 * time.Hour,
 		Config:                  statementbuilder.NewConfig(),
 	}
 }
@@ -54,6 +61,9 @@ func (c Config) Validate() error {
 	}
 	if c.LogTraceIDWindowPadding < 0 {
 		return errors.NewInvalidInputf(errors.CodeInvalidInput, "log_trace_id_window_padding must not be negative, got %v", c.LogTraceIDWindowPadding)
+	}
+	if c.TraceIDWindowPadding < 0 {
+		return errors.NewInvalidInputf(errors.CodeInvalidInput, "trace_id_window_padding must not be negative, got %v", c.TraceIDWindowPadding)
 	}
 	// Embedded Validate is shadowed by this one; call it explicitly.
 	if err := c.Config.Validate(); err != nil {

--- a/pkg/querier/querier.go
+++ b/pkg/querier/querier.go
@@ -99,6 +99,7 @@ func New(
 	bucketCache BucketCache,
 	flagger flagger.Flagger,
 	logTraceIDWindowPadding time.Duration,
+	traceIDWindowPadding time.Duration,
 	maxConcurrentQueries int,
 ) *querier {
 	querierSettings := factory.NewScopedProviderSettings(settings, "github.com/SigNoz/signoz/pkg/querier")
@@ -123,6 +124,7 @@ func New(
 		liveDataRefresh:          5 * time.Second,
 		builderConfig: builderConfig{
 			logTraceIDWindowPaddingMS: uint64(logTraceIDWindowPadding.Milliseconds()),
+			traceIDWindowPadding:      traceIDWindowPadding,
 		},
 		maxConcurrentQueries: maxConcurrentQueries,
 		shadowSlots:          make(chan struct{}, maxConcurrentShadows),

--- a/pkg/querier/querier_test.go
+++ b/pkg/querier/querier_test.go
@@ -59,6 +59,7 @@ func TestQueryRange_MetricTypeMissing(t *testing.T) {
 		nil,                // bucketCache
 		flaggertest.New(t), // flagger
 		0,                  // logTraceIDWindowPadding
+		0,                  // traceIDWindowPadding
 		0,                  // maxConcurrentQueries
 	)
 
@@ -133,6 +134,7 @@ func TestQueryRange_MetricTypeFromStore(t *testing.T) {
 		nil,                // bucketCache
 		flaggertest.New(t), // flagger
 		0,                  // logTraceIDWindowPadding
+		0,                  // traceIDWindowPadding
 		0,                  // maxConcurrentQueries
 	)
 

--- a/pkg/querier/signozquerier/provider.go
+++ b/pkg/querier/signozquerier/provider.go
@@ -53,6 +53,7 @@ func NewFactory(
 				bucketCache,
 				flagger,
 				cfg.LogTraceIDWindowPadding,
+				cfg.TraceIDWindowPadding,
 				cfg.MaxConcurrentQueries,
 			), nil
 		},

--- a/pkg/query-service/rules/setups_test.go
+++ b/pkg/query-service/rules/setups_test.go
@@ -51,6 +51,7 @@ func prepareQuerierForMetrics(t *testing.T, telemetryStore telemetrystore.Teleme
 		nil, // bucketCache
 		fl,
 		0,
+		0, // traceIDWindowPadding
 		0, // maxConcurrentQueries (0 means default)
 	), metadataStore
 }
@@ -87,6 +88,7 @@ func prepareQuerierForLogs(t *testing.T, telemetryStore telemetrystore.Telemetry
 		nil, // bucketCache
 		fl,
 		5*time.Minute, // logTraceIDWindowPadding
+		0,             // traceIDWindowPadding
 		0,             // maxConcurrentQueries (0 means default)
 	)
 }
@@ -124,6 +126,7 @@ func prepareQuerierForTraces(t *testing.T, telemetryStore telemetrystore.Telemet
 		nil, // bucketCache
 		fl,
 		0,
+		0, // traceIDWindowPadding
 		0, // maxConcurrentQueries (0 means default)
 	)
 }

--- a/pkg/telemetryschema/tracestelemetryschema/trace_time_range.go
+++ b/pkg/telemetryschema/tracestelemetryschema/trace_time_range.go
@@ -4,12 +4,26 @@ import (
 	"context"
 	"fmt"
 	"strings"
+	"time"
 
 	"github.com/SigNoz/signoz/pkg/telemetrystore"
 	"github.com/SigNoz/signoz/pkg/types/ctxtypes"
 	"github.com/SigNoz/signoz/pkg/types/instrumentationtypes"
 	"github.com/SigNoz/signoz/pkg/types/telemetrytypes"
 )
+
+// TraceTimeRangeOpts optionally restricts the trace_summary lookup to a
+// padded time window so ClickHouse can prune PARTITION BY toDate(end).
+//
+// When FromMS and ToMS are both zero the lookup scans the whole table, which
+// is the historical behaviour. A non-zero window first queries
+// [FromMS-Padding, ToMS+Padding] and only falls back to the unbounded scan
+// if that fast path cannot prove it saw every requested trace in full.
+type TraceTimeRangeOpts struct {
+	FromMS  uint64
+	ToMS    uint64
+	Padding time.Duration
+}
 
 type TraceTimeRangeFinder struct {
 	telemetryStore telemetrystore.TelemetryStore
@@ -22,11 +36,10 @@ func NewTraceTimeRangeFinder(telemetryStore telemetrystore.TelemetryStore) *Trac
 }
 
 func (f *TraceTimeRangeFinder) GetTraceTimeRange(ctx context.Context, traceID string) (startNano, endNano int64, exists bool, error error) {
-	traceIDs := []string{traceID}
-	return f.GetTraceTimeRangeMulti(ctx, traceIDs)
+	return f.GetTraceTimeRangeMulti(ctx, []string{traceID}, TraceTimeRangeOpts{})
 }
 
-func (f *TraceTimeRangeFinder) GetTraceTimeRangeMulti(ctx context.Context, traceIDs []string) (startNano, endNano int64, exists bool, error error) {
+func (f *TraceTimeRangeFinder) GetTraceTimeRangeMulti(ctx context.Context, traceIDs []string, opts TraceTimeRangeOpts) (startNano, endNano int64, exists bool, error error) {
 	ctx = ctxtypes.NewContextWithCommentVals(ctx, map[string]string{
 		instrumentationtypes.TelemetrySignal:  telemetrytypes.SignalTraces.StringValue(),
 		instrumentationtypes.CodeNamespace:    "trace-time-range",
@@ -41,40 +54,117 @@ func (f *TraceTimeRangeFinder) GetTraceTimeRangeMulti(ctx context.Context, trace
 		cleanedIDs[i] = strings.Trim(id, "'\"")
 	}
 
-	placeholders := make([]string, len(cleanedIDs))
-	args := make([]any, len(cleanedIDs))
-	for i, id := range cleanedIDs {
+	windowStartNano, windowEndNano, bounded := paddedWindowNanos(opts)
+	if bounded {
+		query, args := buildTraceTimeRangeQuery(cleanedIDs, windowStartNano, windowEndNano)
+		uniqueCount, startNano, endNano, err := f.scanTraceTimeRange(ctx, query, args)
+		if err != nil {
+			return 0, 0, false, err
+		}
+		if uniqueCount == uint64(len(cleanedIDs)) && !isCloseToWindowEdge(startNano, endNano, windowStartNano, windowEndNano, opts.Padding.Nanoseconds()) {
+			startNano, endNano = applySecondPadding(startNano, endNano)
+			return startNano, endNano, true, nil
+		}
+	}
+
+	query, args := buildTraceTimeRangeQuery(cleanedIDs, 0, 0)
+	uniqueCount, startNano, endNano, err := f.scanTraceTimeRange(ctx, query, args)
+	if err != nil {
+		return 0, 0, false, err
+	}
+	// Preserve pre-optimisation exists semantics: any matching row is enough.
+	// uniqExact is used instead of count() because AggregatingMergeTree can
+	// keep more than one summary row per trace_id across date partitions.
+	if uniqueCount == 0 {
+		return 0, 0, false, nil
+	}
+	startNano, endNano = applySecondPadding(startNano, endNano)
+	return startNano, endNano, true, nil
+}
+
+func (f *TraceTimeRangeFinder) scanTraceTimeRange(ctx context.Context, query string, args []any) (uniqueCount uint64, startNano, endNano int64, err error) {
+	err = f.telemetryStore.ClickhouseDB().QueryRow(ctx, query, args...).Scan(&uniqueCount, &startNano, &endNano)
+	return uniqueCount, startNano, endNano, err
+}
+
+// buildTraceTimeRangeQuery returns the trace_summary lookup. When windowStartNano
+// and windowEndNano are both non-zero the predicate on `end` lets ClickHouse
+// prune PARTITION BY toDate(end). uniqExact(trace_id) is required because a
+// single trace can occupy more than one partition (and therefore more than one
+// row) when its insert batches straddle a date boundary.
+func buildTraceTimeRangeQuery(traceIDs []string, windowStartNano, windowEndNano int64) (string, []any) {
+	placeholders := make([]string, len(traceIDs))
+	args := make([]any, 0, len(traceIDs)+2)
+	for i, id := range traceIDs {
 		placeholders[i] = "?"
-		args[i] = id
+		args = append(args, id)
+	}
+
+	timePredicate := ""
+	if windowStartNano > 0 || windowEndNano > 0 {
+		timePredicate = `
+			AND end >= fromUnixTimestamp64Nano(?)
+			AND end <= fromUnixTimestamp64Nano(?)`
+		args = append(args, windowStartNano, windowEndNano)
 	}
 
 	query := fmt.Sprintf(`
 		SELECT
-			count(),
+			uniqExact(trace_id),
 			%s,
 			%s
 		FROM %s.%s
-		WHERE trace_id IN (%s)
-	`, UnixNanoExpr("min(start)"), UnixNanoExpr("max(end)"), DBName, TraceSummaryTableName, strings.Join(placeholders, ", "))
+		WHERE trace_id IN (%s)%s
+	`, UnixNanoExpr("min(start)"), UnixNanoExpr("max(end)"), DBName, TraceSummaryTableName, strings.Join(placeholders, ", "), timePredicate)
 
-	row := f.telemetryStore.ClickhouseDB().QueryRow(ctx, query, args...)
+	return query, args
+}
 
-	var rowCount uint64
-	err := row.Scan(&rowCount, &startNano, &endNano)
-	if err != nil {
-		return 0, 0, false, err
+func paddedWindowNanos(opts TraceTimeRangeOpts) (startNano, endNano int64, ok bool) {
+	if opts.FromMS == 0 && opts.ToMS == 0 {
+		return 0, 0, false
 	}
-
-	if rowCount == 0 {
-		return 0, 0, false, nil
+	if opts.ToMS < opts.FromMS {
+		return 0, 0, false
 	}
+	pad := opts.Padding.Nanoseconds()
+	startNano = int64(opts.FromMS)*1_000_000 - pad
+	if startNano < 0 {
+		startNano = 0
+	}
+	endNano = int64(opts.ToMS)*1_000_000 + pad
+	return startNano, endNano, true
+}
 
+// isCloseToWindowEdge reports that the aggregated bounds sit within `marginNano`
+// of the padded scan window. That is the failure mode for a trace whose insert
+// batches straddle the window: some rows (and their contribution to min/max)
+// are dropped, but uniqExact still reports the trace as found.
+//
+// Using the padding as the margin is equivalent to comparing against the
+// original unpadded [FromMS, ToMS] when Padding is the configured value.
+// Traces whose surviving rows sit well inside the window after a much larger
+// gap (hours beyond the padding) are not detected; the unbounded fallback
+// covers missing IDs, not that rare shape.
+func isCloseToWindowEdge(startNano, endNano, windowStartNano, windowEndNano, marginNano int64) bool {
+	if marginNano < 0 {
+		marginNano = 0
+	}
+	if startNano <= windowStartNano+marginNano {
+		return true
+	}
+	if endNano >= windowEndNano-marginNano {
+		return true
+	}
+	return false
+}
+
+func applySecondPadding(startNano, endNano int64) (int64, int64) {
 	if startNano > 1_000_000_000 {
 		startNano -= 1_000_000_000
 	}
 	endNano += 1_000_000_000
-
-	return startNano, endNano, true, nil
+	return startNano, endNano
 }
 
 // UnixNanoExpr renders the conversion of a timestamp-typed column expression

--- a/pkg/telemetryschema/tracestelemetryschema/trace_time_range_multi_test.go
+++ b/pkg/telemetryschema/tracestelemetryschema/trace_time_range_multi_test.go
@@ -43,7 +43,7 @@ func TestGetTraceTimeRangeMulti(t *testing.T) {
 			finder := &TraceTimeRangeFinder{telemetryStore: nil}
 
 			if !tt.expectOK {
-				_, _, ok, _ := finder.GetTraceTimeRangeMulti(ctx, tt.traceIDs)
+				_, _, ok, _ := finder.GetTraceTimeRangeMulti(ctx, tt.traceIDs, TraceTimeRangeOpts{})
 				assert.False(t, ok)
 			}
 		})

--- a/pkg/telemetryschema/tracestelemetryschema/trace_time_range_test.go
+++ b/pkg/telemetryschema/tracestelemetryschema/trace_time_range_test.go
@@ -1,0 +1,201 @@
+package tracestelemetryschema
+
+import (
+	"context"
+	"regexp"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/DATA-DOG/go-sqlmock"
+	cmock "github.com/SigNoz/clickhouse-go-mock"
+	"github.com/SigNoz/signoz/pkg/telemetrystore"
+	"github.com/SigNoz/signoz/pkg/telemetrystore/telemetrystoretest"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestBuildTraceTimeRangeQuery_UnboundedUsesUniqExact(t *testing.T) {
+	query, args := buildTraceTimeRangeQuery([]string{"abc", "def"}, 0, 0)
+	assert.Contains(t, query, "uniqExact(trace_id)")
+	assert.NotContains(t, query, "fromUnixTimestamp64Nano")
+	assert.Equal(t, []any{"abc", "def"}, args)
+}
+
+func TestBuildTraceTimeRangeQuery_BoundedPrunesOnEnd(t *testing.T) {
+	query, args := buildTraceTimeRangeQuery([]string{"abc"}, 100, 200)
+	assert.Contains(t, query, "uniqExact(trace_id)")
+	assert.Contains(t, query, "end >= fromUnixTimestamp64Nano(?)")
+	assert.Contains(t, query, "end <= fromUnixTimestamp64Nano(?)")
+	assert.Equal(t, []any{"abc", int64(100), int64(200)}, args)
+}
+
+func TestPaddedWindowNanos(t *testing.T) {
+	fromMS := uint64(time.Date(2026, 8, 2, 0, 0, 0, 0, time.UTC).UnixMilli())
+	toMS := uint64(time.Date(2026, 8, 3, 0, 0, 0, 0, time.UTC).UnixMilli())
+	start, end, ok := paddedWindowNanos(TraceTimeRangeOpts{
+		FromMS:  fromMS,
+		ToMS:    toMS,
+		Padding: 6 * time.Hour,
+	})
+	require.True(t, ok)
+	pad := (6 * time.Hour).Nanoseconds()
+	assert.Equal(t, int64(fromMS)*1_000_000-pad, start)
+	assert.Equal(t, int64(toMS)*1_000_000+pad, end)
+
+	_, _, ok = paddedWindowNanos(TraceTimeRangeOpts{})
+	assert.False(t, ok)
+}
+
+func TestIsCloseToWindowEdge(t *testing.T) {
+	// Padded window for user [from, to] with 6h padding.
+	from := time.Date(2026, 8, 2, 0, 0, 0, 0, time.UTC)
+	to := time.Date(2026, 8, 3, 0, 0, 0, 0, time.UTC)
+	pad := 6 * time.Hour
+	windowStart := from.Add(-pad).UnixNano()
+	windowEnd := to.Add(pad).UnixNano()
+	margin := pad.Nanoseconds()
+
+	t.Run("midnight-straddle surviving row sits on the user window edge", func(t *testing.T) {
+		// Remaining row starts at the original from; dropped row was just before.
+		start := from.UnixNano()
+		end := from.Add(2 * time.Minute).UnixNano()
+		assert.True(t, isCloseToWindowEdge(start, end, windowStart, windowEnd, margin))
+	})
+
+	t.Run("trace fully inside the selected window is not suspicious", func(t *testing.T) {
+		start := from.Add(12 * time.Hour).UnixNano()
+		end := from.Add(12*time.Hour + 2*time.Minute).UnixNano()
+		assert.False(t, isCloseToWindowEdge(start, end, windowStart, windowEnd, margin))
+	})
+}
+
+func TestGetTraceTimeRangeMulti_BoundedFastPath(t *testing.T) {
+	store := telemetrystoretest.New(telemetrystore.Config{}, sqlmock.QueryMatcherRegexp)
+	mock := store.Mock()
+
+	from := time.Date(2026, 8, 2, 12, 0, 0, 0, time.UTC)
+	to := time.Date(2026, 8, 2, 13, 0, 0, 0, time.UTC)
+	startNano := from.Add(10 * time.Minute).UnixNano()
+	endNano := from.Add(20 * time.Minute).UnixNano()
+
+	mock.ExpectQueryRow(`(?s)uniqExact\(trace_id\).*fromUnixTimestamp64Nano`).
+		WillReturnRow(cmock.NewRow([]cmock.ColumnType{
+			{Name: "uniq", Type: "UInt64"},
+			{Name: "start", Type: "Int64"},
+			{Name: "end", Type: "Int64"},
+		}, []any{uint64(1), startNano, endNano}))
+
+	finder := NewTraceTimeRangeFinder(store)
+	gotStart, gotEnd, exists, err := finder.GetTraceTimeRangeMulti(context.Background(), []string{"t1"}, TraceTimeRangeOpts{
+		FromMS:  uint64(from.UnixMilli()),
+		ToMS:    uint64(to.UnixMilli()),
+		Padding: 6 * time.Hour,
+	})
+	require.NoError(t, err)
+	assert.True(t, exists)
+	assert.Equal(t, startNano-1_000_000_000, gotStart)
+	assert.Equal(t, endNano+1_000_000_000, gotEnd)
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestGetTraceTimeRangeMulti_FallsBackWhenBoundedMisses(t *testing.T) {
+	store := telemetrystoretest.New(telemetrystore.Config{}, sqlmock.QueryMatcherRegexp)
+	mock := store.Mock()
+
+	from := time.Date(2026, 8, 2, 0, 0, 0, 0, time.UTC)
+	to := time.Date(2026, 8, 3, 0, 0, 0, 0, time.UTC)
+	trueStart := time.Date(2026, 7, 1, 10, 0, 0, 0, time.UTC).UnixNano()
+	trueEnd := time.Date(2026, 7, 1, 10, 2, 0, 0, time.UTC).UnixNano()
+
+	mock.ExpectQueryRow(`(?s)uniqExact\(trace_id\).*fromUnixTimestamp64Nano`).
+		WillReturnRow(cmock.NewRow([]cmock.ColumnType{
+			{Name: "uniq", Type: "UInt64"},
+			{Name: "start", Type: "Int64"},
+			{Name: "end", Type: "Int64"},
+		}, []any{uint64(0), int64(0), int64(0)}))
+	mock.ExpectQueryRow(`uniqExact\(trace_id\)`).
+		WillReturnRow(cmock.NewRow([]cmock.ColumnType{
+			{Name: "uniq", Type: "UInt64"},
+			{Name: "start", Type: "Int64"},
+			{Name: "end", Type: "Int64"},
+		}, []any{uint64(1), trueStart, trueEnd}))
+
+	finder := NewTraceTimeRangeFinder(store)
+	gotStart, _, exists, err := finder.GetTraceTimeRangeMulti(context.Background(), []string{"t-outside"}, TraceTimeRangeOpts{
+		FromMS:  uint64(from.UnixMilli()),
+		ToMS:    uint64(to.UnixMilli()),
+		Padding: 6 * time.Hour,
+	})
+	require.NoError(t, err)
+	assert.True(t, exists)
+	assert.Equal(t, trueStart-1_000_000_000, gotStart)
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestGetTraceTimeRangeMulti_UnboundedPartialMatchStillExists(t *testing.T) {
+	// Three IDs requested, only one retained: exists must stay true (legacy
+	// count()!=0 semantics), not uniqueCount != len(ids).
+	store := telemetrystoretest.New(telemetrystore.Config{}, sqlmock.QueryMatcherRegexp)
+	mock := store.Mock()
+
+	startNano := time.Date(2026, 8, 1, 0, 0, 0, 0, time.UTC).UnixNano()
+	endNano := startNano + int64(time.Minute)
+
+	mock.ExpectQueryRow(`uniqExact\(trace_id\)`).
+		WillReturnRow(cmock.NewRow([]cmock.ColumnType{
+			{Name: "uniq", Type: "UInt64"},
+			{Name: "start", Type: "Int64"},
+			{Name: "end", Type: "Int64"},
+		}, []any{uint64(1), startNano, endNano}))
+
+	finder := NewTraceTimeRangeFinder(store)
+	_, _, exists, err := finder.GetTraceTimeRangeMulti(context.Background(), []string{"a", "b", "c"}, TraceTimeRangeOpts{})
+	require.NoError(t, err)
+	assert.True(t, exists)
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestGetTraceTimeRangeMulti_EdgeTriggersFallback(t *testing.T) {
+	store := telemetrystoretest.New(telemetrystore.Config{}, sqlmock.QueryMatcherRegexp)
+	mock := store.Mock()
+
+	from := time.Date(2026, 8, 2, 0, 0, 0, 0, time.UTC)
+	to := time.Date(2026, 8, 3, 0, 0, 0, 0, time.UTC)
+	truncatedStart := from.UnixNano()
+	truncatedEnd := from.Add(2 * time.Minute).UnixNano()
+	trueStart := from.Add(-30 * time.Minute).UnixNano()
+
+	mock.ExpectQueryRow(`(?s)fromUnixTimestamp64Nano`).
+		WillReturnRow(cmock.NewRow([]cmock.ColumnType{
+			{Name: "uniq", Type: "UInt64"},
+			{Name: "start", Type: "Int64"},
+			{Name: "end", Type: "Int64"},
+		}, []any{uint64(1), truncatedStart, truncatedEnd}))
+	mock.ExpectQueryRow(`uniqExact\(trace_id\)`).
+		WillReturnRow(cmock.NewRow([]cmock.ColumnType{
+			{Name: "uniq", Type: "UInt64"},
+			{Name: "start", Type: "Int64"},
+			{Name: "end", Type: "Int64"},
+		}, []any{uint64(1), trueStart, truncatedEnd}))
+
+	finder := NewTraceTimeRangeFinder(store)
+	gotStart, _, exists, err := finder.GetTraceTimeRangeMulti(context.Background(), []string{"straddle"}, TraceTimeRangeOpts{
+		FromMS:  uint64(from.UnixMilli()),
+		ToMS:    uint64(to.UnixMilli()),
+		Padding: 6 * time.Hour,
+	})
+	require.NoError(t, err)
+	assert.True(t, exists)
+	assert.Equal(t, trueStart-1_000_000_000, gotStart)
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestBuildTraceTimeRangeQuery_DoesNotUseCount(t *testing.T) {
+	query, _ := buildTraceTimeRangeQuery([]string{"x"}, 1, 2)
+	unbounded, _ := buildTraceTimeRangeQuery([]string{"x"}, 0, 0)
+	for _, q := range []string{query, unbounded} {
+		assert.False(t, strings.Contains(q, "count()"), q)
+		assert.Regexp(t, regexp.MustCompile(`uniqExact\(trace_id\)`), q)
+	}
+}


### PR DESCRIPTION
## Summary
- `GetTraceTimeRangeMulti` (used by the trace explorer to clamp the query window for a `trace_id` filter) scanned `signoz_traces.distributed_trace_summary` with no time predicate, so ClickHouse considered every retained partition (`PARTITION BY toDate(end)`). With long retention that is tens of GB and expensive S3 reads.
- The lookup now tries a bounded fast path first: `end` in `[selected range − padding, selected range + padding]`. That is enough for partition pruning. If the fast path does not find every requested trace, or the aggregated bounds sit on the padded window edge (cross-partition insert batches), it falls back to the original unbounded query.
- New `trace_id_window_padding` querier config (default `6h`) mirrors `log_trace_id_window_padding`. Raise it if traces commonly last longer than 6h or spans arrive with large delay.

Closes #12361

## Behaviour notes
- Both the bounded and unbounded queries use `uniqExact(trace_id)`, not `count()`. `trace_summary` can keep more than one row per trace across date partitions; comparing `count()` to `len(traceIDs)` would mark a real trace as missing and short-circuit the explorer to empty.
- Unbounded `exists` stays `uniqueCount > 0` (same as the previous `count() != 0`). A partial match still narrows the window to the traces that were found.
- The edge check uses the configured padding as its margin. A trace whose insert batches are farther apart than that padding can still be truncated on the fast path; missing IDs always fall back.

## Test plan
- [x] `go test ./pkg/telemetryschema/tracestelemetryschema/ ./pkg/querier/`
- [ ] Confirm `EXPLAIN indexes = 1` on a multi-partition `trace_summary` prunes parts when the `end` predicate is present
- [ ] Trace explorer: filter `trace_id in ['…']` inside the selected window still returns the trace
- [ ] Same filter for a trace outside the selected window still resolves via fallback (warning / empty, same as today)
- [ ] `trace_id IN` with a mix of present and missing IDs still narrows to the found traces


Made with [Cursor](https://cursor.com)