### PR TITLE
feat(clickhouseprometheusv2): restore fetch budgets on both read paths

### DIFF
--- a/docs/contributing/prometheus.md
+++ b/docs/contributing/prometheus.md
@@ -305,6 +305,16 @@ selector without a static `__name__` runs the series lookup first, to learn
 the concrete metric names. A step of 0 is an instant query: a single
 evaluation at `end`.
 
+Both paths enforce fetch budgets
+(`prometheus::clickhousev2::max_fetched_series` and
+`::max_fetched_samples`; 0 disables). The engine path counts matched series
+and scanned samples. The transpiled path counts buffered grid cells (series
+times grid width) across a plan's units, because transpiled results never
+pass the engine's sample limiter. A refusal is a typed invalid-input error.
+It pierces the engine's `promql.ErrStorage` wrapper
+(`prometheus.TypedStorageError`), so the APIs report a user error, not an
+internal one.
+
 A note on the window sliver: when the window is narrower than the step, the
 grid windows cover only `window/step` of the timeline. A sample in a gap
 belongs to no window. It cannot move any grid point, but the grid aggregate

--- a/pkg/prometheus/clickhouseprometheusv2/client.go
+++ b/pkg/prometheus/clickhouseprometheusv2/client.go
@@ -7,6 +7,7 @@ import (
 	"math"
 	"slices"
 
+	"github.com/SigNoz/signoz/pkg/errors"
 	"github.com/SigNoz/signoz/pkg/factory"
 	"github.com/SigNoz/signoz/pkg/prometheus"
 	"github.com/SigNoz/signoz/pkg/telemetrystore"
@@ -29,6 +30,7 @@ type client struct {
 	settings       factory.ScopedProviderSettings
 	telemetryStore telemetrystore.TelemetryStore
 	lookbackMs     int64
+	cfg            prometheus.ClickhouseV2Config
 }
 
 func newClient(settings factory.ScopedProviderSettings, telemetryStore telemetrystore.TelemetryStore, cfg prometheus.Config) *client {
@@ -41,6 +43,7 @@ func newClient(settings factory.ScopedProviderSettings, telemetryStore telemetry
 		settings:       settings,
 		telemetryStore: telemetryStore,
 		lookbackMs:     lookback.Milliseconds(),
+		cfg:            cfg.ClickhouseV2,
 	}
 }
 
@@ -76,6 +79,13 @@ func (c *client) selectSeries(ctx context.Context, query string, args []any) (*s
 		lookup.fingerprints[fingerprint] = lset
 		if name := lset.Get(metricNameLabel); name != "" {
 			names[name] = struct{}{}
+		}
+		if c.cfg.MaxFetchedSeries > 0 && len(lookup.fingerprints) > c.cfg.MaxFetchedSeries {
+			return nil, errors.NewInvalidInputf(
+				errors.CodeInvalidInput,
+				"promql selector matched more than %d series; narrow the label matchers or raise prometheus::clickhousev2::max_fetched_series",
+				c.cfg.MaxFetchedSeries,
+			)
 		}
 	}
 	if err := rows.Err(); err != nil {
@@ -136,12 +146,23 @@ func (c *client) selectSamples(ctx context.Context, query string, args []any, lo
 		first        = true
 		haveCurrent  bool
 		staleMarker  = math.Float64frombits(promValue.StaleNaN)
+		maxSamples   = c.cfg.MaxFetchedSamples
+		fetched      int64
 		unknownCount int
 	)
 
 	for rows.Next() {
 		if err := rows.Scan(&fingerprint, &timestampMs, &val, &flags); err != nil {
 			return nil, err
+		}
+
+		fetched++
+		if maxSamples > 0 && fetched > maxSamples {
+			return nil, errors.NewInvalidInputf(
+				errors.CodeInvalidInput,
+				"promql query would fetch more than %d samples; narrow the selector or time range, or raise prometheus::clickhousev2::max_fetched_samples",
+				maxSamples,
+			)
 		}
 
 		if first || fingerprint != prevFp {

--- a/pkg/prometheus/clickhouseprometheusv2/client_test.go
+++ b/pkg/prometheus/clickhouseprometheusv2/client_test.go
@@ -1,0 +1,49 @@
+package clickhouseprometheusv2
+
+import (
+	"context"
+	"testing"
+
+	cmock "github.com/SigNoz/clickhouse-go-mock"
+	"github.com/SigNoz/signoz/pkg/errors"
+	"github.com/prometheus/prometheus/model/labels"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+var samplesCols = []cmock.ColumnType{
+	{Name: "fingerprint", Type: "UInt64"},
+	{Name: "unix_milli", Type: "Int64"},
+	{Name: "value", Type: "Float64"},
+	{Name: "flags", Type: "UInt32"},
+}
+
+func TestSelectSeriesBudget(t *testing.T) {
+	c, store := newTestClient(t)
+	c.cfg.MaxFetchedSeries = 1
+
+	store.Mock().ExpectQuery("SELECT fingerprint, any\\(labels\\)").WillReturnRows(cmock.NewRows(seriesCols, [][]any{
+		{uint64(1), `{"__name__":"up","instance":"a"}`},
+		{uint64(2), `{"__name__":"up","instance":"b"}`},
+	}))
+
+	_, err := c.selectSeries(context.Background(), "SELECT fingerprint, any(labels) FROM t", nil)
+	require.Error(t, err)
+	assert.True(t, errors.Ast(err, errors.TypeInvalidInput), "budget refusal must be typed invalid input, got %v", err)
+}
+
+func TestSelectSamplesBudget(t *testing.T) {
+	c, store := newTestClient(t)
+	c.cfg.MaxFetchedSamples = 2
+
+	store.Mock().ExpectQuery("SELECT fingerprint, unix_milli").WillReturnRows(cmock.NewRows(samplesCols, [][]any{
+		{uint64(1), int64(1_700_000_000_000), 1.0, uint32(0)},
+		{uint64(1), int64(1_700_000_060_000), 2.0, uint32(0)},
+		{uint64(1), int64(1_700_000_120_000), 3.0, uint32(0)},
+	}))
+
+	lookup := &seriesLookup{fingerprints: map[uint64]labels.Labels{1: labels.FromStrings("__name__", "up")}}
+	_, err := c.selectSamples(context.Background(), "SELECT fingerprint, unix_milli, value, flags FROM t", nil, lookup)
+	require.Error(t, err)
+	assert.True(t, errors.Ast(err, errors.TypeInvalidInput), "budget refusal must be typed invalid input, got %v", err)
+}

--- a/pkg/prometheus/clickhouseprometheusv2/transpiler_exec.go
+++ b/pkg/prometheus/clickhouseprometheusv2/transpiler_exec.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"math"
 	"sort"
+	"sync/atomic"
 	"time"
 
 	"github.com/SigNoz/signoz/pkg/errors"
@@ -89,12 +90,16 @@ func (e *executor) TryExecuteRange(ctx context.Context, qs string, start, end ti
 
 	// Evaluate every unit concurrently on its own grid (the query grid, or a
 	// subquery grid); each is one grid query (see executeUnit for when a
-	// series lookup precedes it).
+	// series lookup precedes it). The units share one grid-cell budget:
+	// transpiled results never pass through the engine's sample limiter, so
+	// without it a large series-count x grid-width query would buffer
+	// unbounded arrays — the OOM this provider exists to prevent.
 	results := make([][]transpiledSeries, len(plan.units))
+	var gridCells atomic.Int64
 	eg, egCtx := errgroup.WithContext(ctx)
 	for i, unit := range plan.units {
 		eg.Go(func() error {
-			res, err := e.executeUnit(egCtx, &unit.core, unit.grid)
+			res, err := e.executeUnit(egCtx, &unit.core, unit.grid, &gridCells)
 			if err != nil {
 				return err
 			}
@@ -134,7 +139,7 @@ type transpiledSeries struct {
 	values []*float64
 }
 
-func (e *executor) executeUnit(ctx context.Context, unit *coreUnit, grid gridContext) ([]transpiledSeries, error) {
+func (e *executor) executeUnit(ctx context.Context, unit *coreUnit, grid gridContext, gridCells *atomic.Int64) ([]transpiledSeries, error) {
 	startMs, endMs, stepMs := grid.startMs, grid.endMs, grid.stepMs
 	windowMs := unit.rangeMs
 	if unit.kind == unitInstant {
@@ -198,6 +203,17 @@ func (e *executor) executeUnit(ctx context.Context, unit *coreUnit, grid gridCon
 	for rows.Next() {
 		if err := rows.Scan(targets...); err != nil {
 			return nil, err
+		}
+		// One row buffers one grid array; series count times grid width is
+		// the transpiled equivalent of fetched samples. Counted per row as
+		// the arrays accumulate: without a series lookup there is no series
+		// count to charge up front.
+		if maxSamples := e.client.cfg.MaxFetchedSamples; maxSamples > 0 && gridCells.Add(int64(len(gridValues))) > maxSamples {
+			return nil, errors.NewInvalidInputf(
+				errors.CodeInvalidInput,
+				"promql query would buffer more than %d output points; narrow the selector or time range, or raise prometheus::clickhousev2::max_fetched_samples",
+				maxSamples,
+			)
 		}
 		var lset labels.Labels
 		if keyNames != nil {

--- a/pkg/prometheus/clickhouseprometheusv2/transpiler_test.go
+++ b/pkg/prometheus/clickhouseprometheusv2/transpiler_test.go
@@ -2,6 +2,7 @@ package clickhouseprometheusv2
 
 import (
 	"context"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -543,6 +544,30 @@ func TestDisjointWindowLattice(t *testing.T) {
 				"slot mismatch: u=%d selStart=%d step=%d window=%d", u, selStart, stepMs, windowMs)
 		}
 	}
+}
+
+// Transpiled results never pass the engine's sample limiter, so the grid
+// cells (series x grid width) must be budgeted as the arrays accumulate —
+// otherwise a wide query rebuilds the OOM this provider exists to prevent.
+func TestExecuteUnit_GridCellBudget(t *testing.T) {
+	c, store := newTestClient(t)
+	c.cfg.MaxFetchedSamples = 100
+	e := &executor{client: c, parser: prometheus.NewParser()}
+
+	grid61 := make([]*float64, 61)
+	store.Mock().ExpectQuery("timeSeriesRateToGrid").WithArgs(anyArgs(7)...).WillReturnRows(cmock.NewRows(
+		[]cmock.ColumnType{{Name: "g0", Type: "String"}, {Name: "grid", Type: "Array(Nullable(Float64))"}},
+		[][]any{{"api", grid61}, {"web", grid61}},
+	))
+
+	plan, ok := classify(parse(t, `sum by (job) (rate(up[5m]))`), gridContext{startMs: 1_700_000_000_000, endMs: 1_700_003_600_000, stepMs: 60_000})
+	require.True(t, ok)
+
+	// 2 series x 61 grid points = 122 cells > 100.
+	var cells atomic.Int64
+	_, err := e.executeUnit(context.Background(), &plan.units[0].core, plan.units[0].grid, &cells)
+	require.Error(t, err)
+	assert.True(t, errors.Ast(err, errors.TypeInvalidInput), "budget refusal must be typed invalid input, got %v", err)
 }
 
 func TestTryExecuteRange_WindowedGateFallsBack(t *testing.T) {

--- a/pkg/prometheus/config.go
+++ b/pkg/prometheus/config.go
@@ -13,6 +13,16 @@ type ActiveQueryTrackerConfig struct {
 	MaxConcurrent int    `mapstructure:"max_concurrent"`
 }
 
+type ClickhouseV2Config struct {
+	// MaxFetchedSeries caps the series one selector may match; 0 disables
+	// the cap.
+	MaxFetchedSeries int `mapstructure:"max_fetched_series"`
+
+	// MaxFetchedSamples caps the samples (engine path) or buffered grid
+	// cells (transpiled path) one query may fetch; 0 disables the cap.
+	MaxFetchedSamples int64 `mapstructure:"max_fetched_samples"`
+}
+
 type Config struct {
 	ActiveQueryTrackerConfig ActiveQueryTrackerConfig `mapstructure:"active_query_tracker"`
 
@@ -28,6 +38,9 @@ type Config struct {
 	// ProviderName selects the storage provider: "clickhouse" (default) or
 	// "clickhousev2".
 	ProviderName string `mapstructure:"provider"`
+
+	// ClickhouseV2 configures the clickhousev2 provider.
+	ClickhouseV2 ClickhouseV2Config `mapstructure:"clickhousev2"`
 }
 
 func NewConfigFactory() factory.ConfigFactory {
@@ -43,6 +56,10 @@ func newConfig() factory.Config {
 		},
 		Timeout:      2 * time.Minute,
 		ProviderName: "clickhouse",
+		ClickhouseV2: ClickhouseV2Config{
+			MaxFetchedSeries:  500_000,
+			MaxFetchedSamples: 50_000_000,
+		},
 	}
 }
 
@@ -52,6 +69,9 @@ func (c Config) Validate() error {
 	}
 	if c.ProviderName != "" && c.ProviderName != "clickhouse" && c.ProviderName != "clickhousev2" {
 		return errors.Newf(errors.TypeInvalidInput, errors.CodeInvalidInput, "prometheus::provider must be one of [clickhouse, clickhousev2], got %q", c.ProviderName)
+	}
+	if c.ClickhouseV2.MaxFetchedSeries < 0 || c.ClickhouseV2.MaxFetchedSamples < 0 {
+		return errors.Newf(errors.TypeInvalidInput, errors.CodeInvalidInput, "prometheus::clickhousev2 limits must not be negative")
 	}
 	return nil
 }

--- a/pkg/prometheus/errors.go
+++ b/pkg/prometheus/errors.go
@@ -1,0 +1,30 @@
+package prometheus
+
+import (
+	"github.com/SigNoz/signoz/pkg/errors"
+	"github.com/prometheus/prometheus/promql"
+)
+
+// TypedStorageError walks an engine execution error chain looking for a
+// SigNoz-typed invalid-input error raised by the storage layer (the fetch
+// budget refusals). Every wrapper level is stepped through by hand: Ast is a
+// bare type cast, not an unwrap — it misses a typed error behind the
+// engine's "expanding series: %w" — and promql.ErrStorage has no Unwrap
+// method at all, so a plain unwrap loop would stop at it.
+func TypedStorageError(execErr error) error {
+	for e := execErr; e != nil; {
+		if errors.Ast(e, errors.TypeInvalidInput) {
+			return e
+		}
+		if es, ok := e.(promql.ErrStorage); ok {
+			e = es.Err
+			continue
+		}
+		u, ok := e.(interface{ Unwrap() error })
+		if !ok {
+			return nil
+		}
+		e = u.Unwrap()
+	}
+	return nil
+}

--- a/pkg/prometheus/errors_test.go
+++ b/pkg/prometheus/errors_test.go
@@ -1,0 +1,22 @@
+package prometheus
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/SigNoz/signoz/pkg/errors"
+	"github.com/prometheus/prometheus/promql"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestTypedStorageError(t *testing.T) {
+	budget := errors.NewInvalidInputf(errors.CodeInvalidInput, "too many series")
+
+	// The engine wraps a storage error as expanding series: %w inside
+	// promql.ErrStorage, which has no Unwrap method.
+	wrapped := promql.ErrStorage{Err: fmt.Errorf("expanding series: %w", budget)}
+	assert.Equal(t, budget, TypedStorageError(wrapped))
+
+	assert.Nil(t, TypedStorageError(promql.ErrStorage{Err: fmt.Errorf("connection refused")}))
+	assert.Nil(t, TypedStorageError(nil))
+}

--- a/pkg/prometheus/handler.go
+++ b/pkg/prometheus/handler.go
@@ -153,6 +153,13 @@ func (h *handler) exec(ctx context.Context, w http.ResponseWriter, r *http.Reque
 		case promql.ErrQueryTimeout:
 			h.respondError(ctx, w, errTimeout, res.Err)
 		case promql.ErrStorage:
+			// A fetch-budget refusal is the storage-level twin of the
+			// engine's own too-many-samples error, which upstream maps to
+			// "execution", not "internal".
+			if typed := TypedStorageError(res.Err); typed != nil {
+				h.respondError(ctx, w, errExec, typed)
+				return
+			}
 			h.respondError(ctx, w, errInternal, res.Err)
 		default:
 			h.respondError(ctx, w, errExec, res.Err)

--- a/pkg/querier/promql_query.go
+++ b/pkg/querier/promql_query.go
@@ -43,6 +43,10 @@ var quotedMetricOutsideBracesPattern = regexp.MustCompile(`"([^"]+)"\s*\{`)
 // tryEnhancePromQLExecError attempts to convert a PromQL execution error into
 // a properly typed error. Returns nil if the error is not a recognized execution error.
 func tryEnhancePromQLExecError(execErr error) error {
+	if typed := prometheus.TypedStorageError(execErr); typed != nil {
+		return typed
+	}
+
 	var eqc promql.ErrQueryCanceled
 	var eqt promql.ErrQueryTimeout
 	var es promql.ErrStorage


### PR DESCRIPTION
## Description

- Restores the fetch budgets removed during the v2-read-path review: `prometheus::clickhousev2::max_fetched_series` and `::max_fetched_samples` (defaults 500k series / 50M samples, 0 disables).
- Engine path: series are counted while the lookup scans, samples while the samples query scans.
- Transpiled path: grid cells (series × grid width) are the transpiled equivalent of fetched samples; they are counted against a budget shared across a plan's units as the result arrays accumulate — a pre-count is no longer possible since the series lookup is skipped for statically named units.
- Refusals are typed invalid-input errors. `prometheus.TypedStorageError` pierces the engine's `promql.ErrStorage` wrapper (which has no `Unwrap`), so the v5 API reports 400 and `/prometheus/api/v1/*` reports `execution` (422, matching upstream's too-many-samples classification) instead of 500 internal.
