### PR TITLE
fix(devenv): update otel-collector healthcheck probe to use bash tcp socket

### DIFF
--- a/.devenv/docker/signoz-otel-collector/compose.yaml
+++ b/.devenv/docker/signoz-otel-collector/compose.yaml
@@ -25,10 +25,9 @@ services:
     healthcheck:
       test:
         - CMD
-        - wget
-        - --spider
-        - -q
-        - localhost:13133
+        - bash
+        - -c
+        - "exec 3<>/dev/tcp/localhost/13133 && printf 'GET / HTTP/1.0\\r\\n\\r\\n' >&3 && head -1 <&3 | grep -q '200 OK'"
       interval: 30s
       timeout: 5s
       retries: 3


### PR DESCRIPTION
#### Description

- Updated the `signoz-otel-collector` service healthcheck probe in `.devenv/docker/signoz-otel-collector/compose.yaml` to use a dependency-free bash TCP socket probe (`/dev/tcp/localhost/13133`).
- `wget`, `curl`, and `nc` are not packaged in the `signoz/signoz-otel-collector` image, which previously caused the container to always fail healthcheck inspection with `exec: "wget": executable file not found in $PATH`.
- Tested the bash probe against both active and closed ports to confirm proper healthy (exit code 0) and unhealthy (exit code 1) behavior.

#### Issues closed by this PR

Fixes #12657