### PR TITLE
fix(instrumentation): stop recording promql engine spans

### DIFF
--- a/pkg/instrumentation/sdk.go
+++ b/pkg/instrumentation/sdk.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/SigNoz/signoz/pkg/errors"
 	"github.com/SigNoz/signoz/pkg/factory"
+	"github.com/SigNoz/signoz/pkg/instrumentation/tracehandler"
 	"github.com/SigNoz/signoz/pkg/version"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/collectors"
@@ -108,7 +109,7 @@ func New(ctx context.Context, cfg Config, build version.Build, serviceName strin
 	}
 
 	// Set the global tracer provider to the sdk tracer provider so that external packages can use this
-	otel.SetTracerProvider(sdk.TracerProvider())
+	otel.SetTracerProvider(tracehandler.New(sdk.TracerProvider(), tracehandler.NewPromQL()))
 
 	return &SDK{
 		sdk:                       sdk,

--- a/pkg/instrumentation/tracehandler/promql.go
+++ b/pkg/instrumentation/tracehandler/promql.go
@@ -1,0 +1,27 @@
+package tracehandler
+
+import (
+	"context"
+	"strings"
+
+	"go.opentelemetry.io/otel/trace"
+	tracenoop "go.opentelemetry.io/otel/trace/noop"
+)
+
+// TODO(srikanthccv): replace with the tracer scope filter (per-scope
+// "enabled") when the otel-go trace SDK ships it
+// (https://github.com/open-telemetry/opentelemetry-go/issues/8411).
+func NewPromQL() Wrapper {
+	noop := tracenoop.NewTracerProvider().Tracer("")
+	return WrapperFunc(func(scope string, next StartFunc) StartFunc {
+		if scope != "" {
+			return next
+		}
+		return func(ctx context.Context, spanName string, opts ...trace.SpanStartOption) (context.Context, trace.Span) {
+			if strings.HasPrefix(spanName, "promql") {
+				return noop.Start(ctx, spanName)
+			}
+			return next(ctx, spanName, opts...)
+		}
+	})
+}

--- a/pkg/instrumentation/tracehandler/tracehandler.go
+++ b/pkg/instrumentation/tracehandler/tracehandler.go
@@ -1,0 +1,53 @@
+package tracehandler
+
+import (
+	"context"
+
+	"go.opentelemetry.io/otel/trace"
+	"go.opentelemetry.io/otel/trace/embedded"
+)
+
+// StartFunc is to trace.Tracer.Start as loghandler.LogHandlerFunc is to
+// loghandler.LogHandler.
+type StartFunc func(ctx context.Context, spanName string, opts ...trace.SpanStartOption) (context.Context, trace.Span)
+
+// Wrapper is an interface implemented by all trace handlers. scope is the
+// instrumentation scope name of the tracer being wrapped; a wrapper that
+// does not apply to a scope returns next unchanged.
+type Wrapper interface {
+	Wrap(scope string, next StartFunc) StartFunc
+}
+
+type WrapperFunc func(scope string, next StartFunc) StartFunc
+
+func (m WrapperFunc) Wrap(scope string, next StartFunc) StartFunc {
+	return m(scope, next)
+}
+
+type provider struct {
+	embedded.TracerProvider
+	base     trace.TracerProvider
+	wrappers []Wrapper
+}
+
+func New(base trace.TracerProvider, wrappers ...Wrapper) trace.TracerProvider {
+	return &provider{base: base, wrappers: wrappers}
+}
+
+func (p *provider) Tracer(name string, opts ...trace.TracerOption) trace.Tracer {
+	base := p.base.Tracer(name, opts...)
+	start := StartFunc(base.Start)
+	for i := len(p.wrappers) - 1; i >= 0; i-- {
+		start = p.wrappers[i].Wrap(name, start)
+	}
+	return &tracer{start: start}
+}
+
+type tracer struct {
+	embedded.Tracer
+	start StartFunc
+}
+
+func (t *tracer) Start(ctx context.Context, spanName string, opts ...trace.SpanStartOption) (context.Context, trace.Span) {
+	return t.start(ctx, spanName, opts...)
+}

--- a/pkg/instrumentation/tracehandler/tracehandler_test.go
+++ b/pkg/instrumentation/tracehandler/tracehandler_test.go
@@ -1,0 +1,87 @@
+package tracehandler
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	sdktrace "go.opentelemetry.io/otel/sdk/trace"
+	"go.opentelemetry.io/otel/sdk/trace/tracetest"
+	"go.opentelemetry.io/otel/trace"
+	tracenoop "go.opentelemetry.io/otel/trace/noop"
+)
+
+func TestWrappersChainInOrder(t *testing.T) {
+	recorder := tracetest.NewSpanRecorder()
+	var order []string
+	observer := func(name string) Wrapper {
+		return WrapperFunc(func(_ string, next StartFunc) StartFunc {
+			return func(ctx context.Context, spanName string, opts ...trace.SpanStartOption) (context.Context, trace.Span) {
+				order = append(order, name)
+				return next(ctx, spanName, opts...)
+			}
+		})
+	}
+	provider := New(sdktrace.NewTracerProvider(sdktrace.WithSpanProcessor(recorder)), observer("first"), observer("second"))
+
+	_, span := provider.Tracer("test").Start(context.Background(), "op")
+	span.End()
+
+	assert.Equal(t, []string{"first", "second"}, order)
+	require.Len(t, recorder.Ended(), 1)
+	assert.Equal(t, "op", recorder.Ended()[0].Name())
+}
+
+func TestScopedWrapperSkipsOtherScopes(t *testing.T) {
+	recorder := tracetest.NewSpanRecorder()
+	noop := tracenoop.NewTracerProvider().Tracer("")
+	dropAnonymous := WrapperFunc(func(scope string, next StartFunc) StartFunc {
+		if scope != "" {
+			return next
+		}
+		return func(ctx context.Context, spanName string, opts ...trace.SpanStartOption) (context.Context, trace.Span) {
+			return noop.Start(ctx, spanName)
+		}
+	})
+	provider := New(sdktrace.NewTracerProvider(sdktrace.WithSpanProcessor(recorder)), dropAnonymous)
+
+	_, dropped := provider.Tracer("").Start(context.Background(), "anon")
+	dropped.End()
+	_, kept := provider.Tracer("named").Start(context.Background(), "op")
+	kept.End()
+
+	require.Len(t, recorder.Ended(), 1)
+	assert.Equal(t, "op", recorder.Ended()[0].Name())
+}
+
+func TestPromQL(t *testing.T) {
+	recorder := tracetest.NewSpanRecorder()
+	provider := New(sdktrace.NewTracerProvider(sdktrace.WithSpanProcessor(recorder)), NewPromQL())
+
+	ctx, root := provider.Tracer("http").Start(context.Background(), "GET /api")
+
+	engineCtx, engineSpan := provider.Tracer("").Start(ctx, "promqlInnerEval eval *promql.BinaryExpr")
+	assert.False(t, engineSpan.IsRecording(), "promql engine spans must not record")
+	assert.Equal(t, root.SpanContext().SpanID(), engineSpan.SpanContext().SpanID(), "the filtered span must keep the parent's span context")
+
+	_, child := provider.Tracer("clickhouse").Start(engineCtx, "clickhouse.query")
+	child.End()
+
+	_, other := provider.Tracer("").Start(ctx, "http.request")
+	other.End()
+	root.End()
+
+	var names []string
+	var childParent string
+	for _, span := range recorder.Ended() {
+		names = append(names, span.Name())
+		if span.Name() == "clickhouse.query" {
+			childParent = span.Parent().SpanID().String()
+		}
+	}
+	require.ElementsMatch(t, []string{"clickhouse.query", "http.request", "GET /api"}, names)
+	assert.Equal(t, root.SpanContext().SpanID().String(), childParent, "descendants of a filtered span must attach to the surrounding span")
+	assert.False(t, strings.HasPrefix(recorder.Ended()[0].Name(), "promql"))
+}


### PR DESCRIPTION
## Description

- The promql engine traces every evaluation through the global tracer provider under an unnamed scope: `promqlExec`, `promqlPrepare`, `promqlExecQueue`, and one `promqlInnerEval eval *promql.<Node>` span per AST node per query. These didn't find much useful as the bottleneck is usually the CH so we remove them.