### PR TITLE
alertmanager: remove redundant compat.InitFromFlags(NoopFlags) per SyncServers

### DIFF
--- a/pkg/alertmanager/service.go
+++ b/pkg/alertmanager/service.go
@@ -5,9 +5,6 @@ import (
 	"log/slog"
 	"sync"
 
-	"github.com/prometheus/alertmanager/featurecontrol"
-	"github.com/prometheus/alertmanager/matcher/compat"
-
 	"github.com/SigNoz/signoz/pkg/alertmanager/alertmanagerserver"
 	"github.com/SigNoz/signoz/pkg/alertmanager/nfmanager"
 	"github.com/SigNoz/signoz/pkg/errors"
@@ -68,7 +65,6 @@ func New(
 }
 
 func (service *Service) SyncServers(ctx context.Context) error {
-	compat.InitFromFlags(service.settings.Logger(), featurecontrol.NoopFlags{})
 	orgs, err := service.orgGetter.ListByOwnedKeyRange(ctx)
 	if err != nil {
 		return err


### PR DESCRIPTION
Fixes #12566

Remove the redundant `compat.InitFromFlags(service.settings.Logger(), featurecontrol.NoopFlags{})` call from `SyncServers`.

This call is stateless — it reassigns the same closures to the same package-level globals on every iteration, since `NoopFlags` always selects the UTF8-Fallback path. The compat flag policy is already established once at server creation in `alertmanagerserver/server.go`.

Removing it eliminates an unnecessary race surface over the package globals without changing matcher behavior. The unused `featurecontrol` and `matcher/compat` imports are also removed.

Co-authored-by: opencode <opencode@opencode.ai>