### PR TITLE
chore(rules): remove unused RuleTask.Interval method (#12371)

### DIFF
--- a/pkg/query-service/rules/rule_task.go
+++ b/pkg/query-service/rules/rule_task.go
@@ -75,10 +75,6 @@ func (g *RuleTask) Type() TaskType { return TaskTypeCh }
 // Rules returns the group's rules.
 func (g *RuleTask) Rules() []Rule { return g.rules }
 
-// Interval returns the group's interval.
-// TODO(jatinderjit): remove (unused)?
-func (g *RuleTask) Interval() time.Duration { return g.frequency }
-
 func (g *RuleTask) Pause(b bool) {
 	g.mtx.Lock()
 	defer g.mtx.Unlock()


### PR DESCRIPTION
## Description
Closes #12371

- Removes the unused `Interval() time.Duration` method from `*RuleTask` and its TODO comment in `pkg/query-service/rules/rule_task.go`.
- `Interval()` is not part of the `Task` interface in `pkg/query-service/rules/task.go`, and the `frequency` field is accessed directly where needed.

## Testing
- Code builds and adheres to existing Task interface contracts.