### PR TITLE
chore: update sample json in test ai-o11y

### DIFF
--- a/frontend/src/container/LLMObservability/AttributeMapping/TestTab/__tests__/TestTab.test.tsx
+++ b/frontend/src/container/LLMObservability/AttributeMapping/TestTab/__tests__/TestTab.test.tsx
@@ -38,19 +38,22 @@ import {
 	TEST_ENDPOINT,
 } from '../../__tests__/fixtures';
 
+const SAMPLE_SPAN = JSON.parse(SAMPLE_SPAN_JSON) as {
+	attributes: Record<string, unknown>;
+	resource: Record<string, unknown>;
+};
+
+const MAPPED_ATTRIBUTE_KEY = 'gen_ai.content.prompt';
+
+// The backend echoes the submitted span back with the mapper output merged in.
+// Deriving from the sample keeps exactly one key added, which is what makes the
+// single `populated` badge assertion below exact.
 const RESULT_SPAN = {
 	attributes: {
-		'my_company.llm.input': 'What is quantum computing?',
-		'llm.input_messages': 'What is quantum computing?',
-		'gen_ai.request.model': 'gpt-4',
-		'gen_ai.usage.total_tokens': 1250,
-		'gen_ai.content.completion': 'Quantum computing leverages...',
-		'gen_ai.content.prompt': 'What is quantum computing?',
+		...SAMPLE_SPAN.attributes,
+		[MAPPED_ATTRIBUTE_KEY]: SAMPLE_SPAN.attributes['input.value'],
 	},
-	resource: {
-		'service.name': 'llm-gateway',
-		'deployment.environment': 'production',
-	},
+	resource: SAMPLE_SPAN.resource,
 };
 
 const EDITED_SPAN_JSON = `{
@@ -97,7 +100,7 @@ describe('TestTab — sample-span flow', () => {
 		).resolves.toBeInTheDocument();
 		expect(screen.getByTestId('test-result-0')).toBeInTheDocument();
 		expect(screen.getByTestId('test-result-0-attributes')).toHaveTextContent(
-			'gen_ai.content.prompt',
+			MAPPED_ATTRIBUTE_KEY,
 		);
 		expect(screen.getByText('populated')).toBeInTheDocument();
 		expect(screen.queryByTestId('test-error')).not.toBeInTheDocument();

--- a/frontend/src/container/LLMObservability/AttributeMapping/TestTab/__tests__/TestTab.test.tsx
+++ b/frontend/src/container/LLMObservability/AttributeMapping/TestTab/__tests__/TestTab.test.tsx
@@ -45,9 +45,7 @@ const SAMPLE_SPAN = JSON.parse(SAMPLE_SPAN_JSON) as {
 
 const MAPPED_ATTRIBUTE_KEY = 'gen_ai.content.prompt';
 
-// The backend echoes the submitted span back with the mapper output merged in.
-// Deriving from the sample keeps exactly one key added, which is what makes the
-// single `populated` badge assertion below exact.
+// Deriving from the sample keeps exactly one key added, so the single `populated` badge assertion below stays exact.
 const RESULT_SPAN = {
 	attributes: {
 		...SAMPLE_SPAN.attributes,

--- a/frontend/src/container/LLMObservability/AttributeMapping/TestTab/spanInputStorage.ts
+++ b/frontend/src/container/LLMObservability/AttributeMapping/TestTab/spanInputStorage.ts
@@ -7,11 +7,14 @@ import { parseSpanInput } from './testPayload';
 
 export const SAMPLE_SPAN_JSON = `{
   "attributes": {
-    "my_company.llm.input": "What is quantum computing?",
-    "llm.input_messages": "What is quantum computing?",
-    "gen_ai.request.model": "gpt-4",
-    "gen_ai.usage.total_tokens": 1250,
-    "gen_ai.content.completion": "Quantum computing leverages..."
+    "llm.model_name": "gpt-4o",
+    "llm.provider": "openai",
+    "llm.token_count.prompt": 1024,
+    "llm.token_count.completion": 226,
+    "llm.token_count.prompt_details.cache_read": 512,
+    "input.value": "What is quantum computing?",
+    "output.value": "Quantum computing leverages superposition and entanglement...",
+    "session.id": "chat-8f2e41"
   },
   "resource": {
     "service.name": "llm-gateway",


### PR DESCRIPTION
#### Description

- Update the sample span JSON in the LLM Observability attribute-mapping Test tab to use OpenInference-style attribute keys (`llm.model_name`, `llm.provider`, `llm.token_count.*`, `input.value`, `output.value`) instead of the earlier mix of `gen_ai.*` and placeholder `my_company.*` keys.
- The sample is what users see first when trying out attribute mapping, so it should reflect the attribute shape they'll actually be mapping from.

#### Issues closed by this PR

Closes https://github.com/orgs/SigNoz/projects/39/views/20?pane=issue&itemId=238442542&issue=SigNoz%7Cengineering-pod%7C5997 

#### Screenshots / Screen Recordings

<img width="911" height="572" alt="image" src="https://github.com/user-attachments/assets/88df20e9-0131-415c-9770-67ea8196075a" />


#### Additional Information

- Constant-only change (`SAMPLE_SPAN_JSON` in `spanInputStorage.ts`); no parsing or mapping logic touched.
- Worth a sanity check that the new keys line up with the attribute names the mapping UI is expected to suggest.
