### PR TITLE
fix(query-service): reject non-positive custom retention TTL instead of silently wiping data

### DIFF
--- a/pkg/query-service/app/clickhouseReader/reader.go
+++ b/pkg/query-service/app/clickhouseReader/reader.go
@@ -1265,6 +1265,10 @@ func (r *ClickHouseReader) hasCustomRetentionColumn(ctx context.Context) (bool, 
 
 func (r *ClickHouseReader) SetTTLV2(ctx context.Context, orgID string, params *retentiontypes.CustomRetentionTTLParams) (*retentiontypes.CustomRetentionTTLResponse, error) {
 
+	if params.DefaultTTLDays <= 0 {
+		return nil, errorsV2.Newf(errorsV2.TypeInvalidInput, errorsV2.CodeInvalidInput, "defaultTTLDays should be a positive integer, got %d", params.DefaultTTLDays)
+	}
+
 	ctx = ctxtypes.NewContextWithCommentVals(ctx, map[string]string{
 		instrumentationtypes.TelemetrySignal:  telemetrytypes.SignalLogs.StringValue(),
 		instrumentationtypes.CodeNamespace:    "clickhouse-reader",

--- a/pkg/query-service/app/clickhouseReader/reader_test.go
+++ b/pkg/query-service/app/clickhouseReader/reader_test.go
@@ -1,8 +1,10 @@
 package clickhouseReader
 
 import (
+	"context"
 	"testing"
 
+	"github.com/SigNoz/signoz/pkg/types/retentiontypes"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -25,5 +27,27 @@ func TestGetStatusFilters(t *testing.T) {
 	}
 	for _, test := range tests {
 		assert.Equal(getStatusFilters(test.query, test.statusParams, test.excludeMap), test.expected)
+	}
+}
+
+// SetTTLV2 must reject a non-positive default TTL before issuing any
+// ClickHouse ALTER, otherwise _retention_days is set to DEFAULT 0 and new
+// rows expire immediately. The zero-value reader has no database handles,
+// so any attempted DB access would panic; NotPanics proves no ALTER ran.
+func TestSetTTLV2RejectsNonPositiveDefaultTTL(t *testing.T) {
+	reader := &ClickHouseReader{}
+
+	for _, days := range []int{0, -7} {
+		params := &retentiontypes.CustomRetentionTTLParams{
+			Type:           retentiontypes.LogsTTL,
+			DefaultTTLDays: days,
+		}
+
+		var err error
+		assert.NotPanics(t, func() {
+			_, err = reader.SetTTLV2(context.Background(), "test-org", params)
+		}, "SetTTLV2 must reject invalid TTL before touching the database")
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "defaultTTLDays")
 	}
 }

--- a/pkg/query-service/app/http_handler.go
+++ b/pkg/query-service/app/http_handler.go
@@ -1419,8 +1419,20 @@ func (aH *APIHandler) setCustomRetentionTTL(w http.ResponseWriter, r *http.Reque
 	}
 
 	var params retentiontypes.CustomRetentionTTLParams
-	if err := json.NewDecoder(r.Body).Decode(&params); err != nil {
+	decoder := json.NewDecoder(r.Body)
+	decoder.DisallowUnknownFields()
+	if err := decoder.Decode(&params); err != nil {
 		render.Error(w, errors.Newf(errors.TypeInvalidInput, errors.CodeInvalidInput, "Invalid data"))
+		return
+	}
+
+	if params.Type == "" {
+		render.Error(w, errors.Newf(errors.TypeInvalidInput, errors.CodeInvalidInput, "type param cannot be empty"))
+		return
+	}
+
+	if params.DefaultTTLDays <= 0 {
+		render.Error(w, errors.Newf(errors.TypeInvalidInput, errors.CodeInvalidInput, "defaultTTLDays should be a positive integer, got %d", params.DefaultTTLDays))
 		return
 	}
 

--- a/pkg/query-service/app/http_handler_test.go
+++ b/pkg/query-service/app/http_handler_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 
 	"github.com/SigNoz/signoz/pkg/query-service/model"
+	"github.com/SigNoz/signoz/pkg/types/authtypes"
 )
 
 func TestPrepareQuery(t *testing.T) {
@@ -126,6 +127,52 @@ func TestPrepareQuery(t *testing.T) {
 				if query != tc.query {
 					t.Errorf("expected query: %s, but got: %s", tc.query, query)
 				}
+			}
+		})
+	}
+}
+
+// POST /api/v2/settings/ttl previously accepted payloads that decode to a
+// zero-value CustomRetentionTTLParams (e.g. the snake_case shape returned by
+// GET, or defaultTTLDays <= 0) and wrote _retention_days DEFAULT 0 to
+// ClickHouse, expiring new log rows immediately. The handler must reject
+// these with 400 before the reader is ever called (the reader is nil here,
+// so reaching it would panic).
+func TestSetCustomRetentionTTLRejectsInvalidPayload(t *testing.T) {
+	handler := &APIHandler{}
+
+	testCases := []struct {
+		name string
+		body string
+	}{
+		{
+			name: "snake_case payload from GET response shape",
+			body: `{"type":"logs","default_ttl_days":15,"ttl_conditions":[]}`,
+		},
+		{
+			name: "zero defaultTTLDays",
+			body: `{"type":"logs","defaultTTLDays":0}`,
+		},
+		{
+			name: "negative defaultTTLDays",
+			body: `{"type":"logs","defaultTTLDays":-5}`,
+		},
+		{
+			name: "missing type",
+			body: `{"defaultTTLDays":15}`,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			req := httptest.NewRequest(http.MethodPost, "/api/v2/settings/ttl", strings.NewReader(tc.body))
+			req = req.WithContext(authtypes.NewContextWithClaims(req.Context(), authtypes.Claims{OrgID: "test-org"}))
+			w := httptest.NewRecorder()
+
+			handler.setCustomRetentionTTL(w, req)
+
+			if w.Code != http.StatusBadRequest {
+				t.Errorf("expected status %d, got %d (body: %s)", http.StatusBadRequest, w.Code, w.Body.String())
 			}
 		})
 	}


### PR DESCRIPTION
Fixes #12701

## Problem

On self-hosted SigNoz (reported on v0.137.1), setting a custom retention TTL via the API/UI can **silently delete all retained data** for a table. The retention-management path writes a `ttl=0` into the Distributed table defaults, which ClickHouse interprets as "expire immediately," wiping the data instead of applying the intended retention.

## Root cause

Two compounding gaps:

1. `setCustomRetentionTTL` decodes the request body with a permissive decoder. A payload in the snake_case shape that `GET` returns (`default_ttl_days`) does not bind to the camelCase struct field, so `DefaultTTLDays` silently stays at its zero value instead of surfacing an error.
2. `SetTTLV2` does not validate the duration, so a missing/zero `DefaultTTLDays` is treated as valid and an `ALTER ... MODIFY TTL` of 0 days is issued against ClickHouse.

## Fix

Guard at both layers:

- The handler now decodes with `DisallowUnknownFields` and returns **400** when `type` is empty or `DefaultTTLDays <= 0`, so a malformed/mismatched payload is rejected at the boundary.
- `SetTTLV2` guards `DefaultTTLDays <= 0` before any database access, returning a `TypeInvalidInput` error, so a bad duration can never reach the TTL mutation even if called from another path.

No change to the happy path: a valid positive TTL behaves exactly as before.

## Regression test

- `TestSetCustomRetentionTTLRejectsInvalidPayload` drives the handler with the snake_case GET-response shape, a zero, a negative, and a missing-type payload — all must return 400 (previously they slipped through as a zero TTL).
- `TestSetTTLV2RejectsNonPositiveDefaultTTL` proves `SetTTLV2` rejects non-positive durations before any DB access (a zero-value reader proves no DB is touched).

Both fail against pristine upstream and pass with this change.

## Verification

Run in `golang:1.25-bookworm` (the Go version this repo pins; the package's pinned `bytedance/sonic` v1.14.1 does not compile under the newer Go 1.26 on the dev machine — a pre-existing, unrelated issue that reproduces on pristine upstream):

```
go vet ./pkg/query-service/app/...                                            # clean
go test ./pkg/query-service/app/clickhouseReader/ -run TestSetTTLV2 -v         # PASS
go test ./pkg/query-service/app/ -run TestSetCustomRetentionTTL -v             # PASS (4 subtests)
gofmt -l pkg/query-service/app/...                                             # clean
```

## Scope

Intentionally not changed: the underlying snake_case-vs-camelCase contract between GET and POST (that broader API-consistency fix would change the wire format and belongs in its own change), the TTL sweep scheduling, and the `bytedance/sonic` toolchain pin.
