### PR TITLE
fix: quick filters old migration cleanup

### DIFF
--- a/pkg/sqlmigration/030_create_quick_filters.go
+++ b/pkg/sqlmigration/030_create_quick_filters.go
@@ -3,12 +3,13 @@ package sqlmigration
 import (
 	"context"
 	"database/sql"
+	"encoding/json"
+	"time"
 
 	"github.com/SigNoz/signoz/pkg/errors"
 	"github.com/SigNoz/signoz/pkg/factory"
 	"github.com/SigNoz/signoz/pkg/sqlstore"
 	"github.com/SigNoz/signoz/pkg/types"
-	"github.com/SigNoz/signoz/pkg/types/quickfiltertypes"
 	"github.com/SigNoz/signoz/pkg/valuer"
 	"github.com/uptrace/bun"
 	"github.com/uptrace/bun/migrate"
@@ -39,6 +40,52 @@ func (m *createQuickFilters) Register(migrations *migrate.Migrations) error {
 }
 
 func (m *createQuickFilters) Up(ctx context.Context, db *bun.DB) error {
+	// Frozen copy of the defaults as this migration shipped (hence the old
+	// camelCase keys); migrations must not read live types. 031 replaces these rows.
+	defaultFilters := []struct {
+		signal  string
+		filters []map[string]any
+	}{
+		{"traces", []map[string]any{
+			{"key": "duration_nano", "dataType": "float64", "type": "tag"},
+			{"key": "deployment.environment", "dataType": "string", "type": "resource"},
+			{"key": "hasError", "dataType": "bool", "type": "tag"},
+			{"key": "serviceName", "dataType": "string", "type": "tag"},
+			{"key": "name", "dataType": "string", "type": "resource"},
+			{"key": "rpcMethod", "dataType": "string", "type": "tag"},
+			{"key": "responseStatusCode", "dataType": "string", "type": "resource"},
+			{"key": "httpHost", "dataType": "string", "type": "tag"},
+			{"key": "httpMethod", "dataType": "string", "type": "tag"},
+			{"key": "httpRoute", "dataType": "string", "type": "tag"},
+			{"key": "httpUrl", "dataType": "string", "type": "tag"},
+			{"key": "traceID", "dataType": "string", "type": "tag"},
+		}},
+		{"logs", []map[string]any{
+			{"key": "severity_text", "dataType": "string", "type": "resource"},
+			{"key": "deployment.environment", "dataType": "string", "type": "resource"},
+			{"key": "serviceName", "dataType": "string", "type": "tag"},
+			{"key": "host.name", "dataType": "string", "type": "resource"},
+			{"key": "k8s.cluster.name", "dataType": "string", "type": "resource"},
+			{"key": "k8s.deployment.name", "dataType": "string", "type": "resource"},
+			{"key": "k8s.namespace.name", "dataType": "string", "type": "resource"},
+			{"key": "k8s.pod.name", "dataType": "string", "type": "resource"},
+		}},
+		{"api_monitoring", []map[string]any{
+			{"key": "deployment.environment", "dataType": "string", "type": "resource"},
+			{"key": "serviceName", "dataType": "string", "type": "tag"},
+			{"key": "rpcMethod", "dataType": "string", "type": "tag"},
+		}},
+		{"exceptions", []map[string]any{
+			{"key": "deployment.environment", "dataType": "string", "type": "resource"},
+			{"key": "serviceName", "dataType": "string", "type": "tag"},
+			{"key": "host.name", "dataType": "string", "type": "resource"},
+			{"key": "k8s.cluster.name", "dataType": "string", "type": "tag"},
+			{"key": "k8s.deployment.name", "dataType": "string", "type": "resource"},
+			{"key": "k8s.namespace.name", "dataType": "string", "type": "tag"},
+			{"key": "k8s.pod.name", "dataType": "string", "type": "tag"},
+		}},
+	}
+
 	tx, err := db.BeginTx(ctx, nil)
 	if err != nil {
 		return err
@@ -72,15 +119,31 @@ func (m *createQuickFilters) Up(ctx context.Context, db *bun.DB) error {
 		return err
 	}
 
-	// Get the default quick filters
-	storableQuickFilters, err := quickfiltertypes.NewDefaultQuickFilter(defaultOrg)
-	if err != nil {
-		return err
+	now := time.Now()
+	quickFilters := make([]*quickFilter, 0, len(defaultFilters))
+	for _, defaultFilter := range defaultFilters {
+		filterJSON, err := json.Marshal(defaultFilter.filters)
+		if err != nil {
+			return err
+		}
+
+		quickFilters = append(quickFilters, &quickFilter{
+			Identifiable: types.Identifiable{
+				ID: valuer.GenerateUUID(),
+			},
+			OrgID:  defaultOrg.StringValue(),
+			Filter: string(filterJSON),
+			Signal: defaultFilter.signal,
+			TimeAuditable: types.TimeAuditable{
+				CreatedAt: now,
+				UpdatedAt: now,
+			},
+		})
 	}
 
 	// Insert all filters at once
 	_, err = tx.NewInsert().
-		Model(&storableQuickFilters).
+		Model(&quickFilters).
 		Exec(ctx)
 
 	if err != nil {

--- a/pkg/sqlmigration/031_update_quick_filters.go
+++ b/pkg/sqlmigration/031_update_quick_filters.go
@@ -3,11 +3,13 @@ package sqlmigration
 import (
 	"context"
 	"database/sql"
+	"encoding/json"
+	"time"
 
 	"github.com/SigNoz/signoz/pkg/errors"
 	"github.com/SigNoz/signoz/pkg/factory"
 	"github.com/SigNoz/signoz/pkg/sqlstore"
-	"github.com/SigNoz/signoz/pkg/types/quickfiltertypes"
+	"github.com/SigNoz/signoz/pkg/types"
 	"github.com/SigNoz/signoz/pkg/valuer"
 	"github.com/uptrace/bun"
 	"github.com/uptrace/bun/migrate"
@@ -38,6 +40,61 @@ func (migration *updateQuickFilters) Register(migrations *migrate.Migrations) er
 }
 
 func (migration *updateQuickFilters) Up(ctx context.Context, db *bun.DB) error {
+	// Frozen copy of the defaults as this migration shipped; migrations must not
+	// read live types. api_monitoring's service.name is "tag" here — 035 fixes it.
+	defaultFilters := []struct {
+		signal  string
+		filters []map[string]any
+	}{
+		{"traces", []map[string]any{
+			{"key": "duration_nano", "dataType": "float64", "type": "tag"},
+			{"key": "deployment.environment", "dataType": "string", "type": "resource"},
+			{"key": "hasError", "dataType": "bool", "type": "tag"},
+			{"key": "service.name", "dataType": "string", "type": "resource"},
+			{"key": "name", "dataType": "string", "type": "tag"},
+			{"key": "rpc.method", "dataType": "string", "type": "tag"},
+			{"key": "response_status_code", "dataType": "string", "type": "tag"},
+			{"key": "http_host", "dataType": "string", "type": "tag"},
+			{"key": "http.method", "dataType": "string", "type": "tag"},
+			{"key": "http.route", "dataType": "string", "type": "tag"},
+			{"key": "http_url", "dataType": "string", "type": "tag"},
+			{"key": "trace_id", "dataType": "string", "type": "tag"},
+		}},
+		{"logs", []map[string]any{
+			{"key": "severity_text", "dataType": "string", "type": "resource"},
+			{"key": "deployment.environment", "dataType": "string", "type": "resource"},
+			{"key": "service.name", "dataType": "string", "type": "resource"},
+			{"key": "host.name", "dataType": "string", "type": "resource"},
+			{"key": "k8s.cluster.name", "dataType": "string", "type": "resource"},
+			{"key": "k8s.deployment.name", "dataType": "string", "type": "resource"},
+			{"key": "k8s.namespace.name", "dataType": "string", "type": "resource"},
+			{"key": "k8s.pod.name", "dataType": "string", "type": "resource"},
+		}},
+		{"api_monitoring", []map[string]any{
+			{"key": "deployment.environment", "dataType": "string", "type": "resource"},
+			{"key": "service.name", "dataType": "string", "type": "tag"},
+			{"key": "rpc.method", "dataType": "string", "type": "tag"},
+		}},
+		{"exceptions", []map[string]any{
+			{"key": "deployment.environment", "dataType": "string", "type": "resource"},
+			{"key": "service.name", "dataType": "string", "type": "resource"},
+			{"key": "host.name", "dataType": "string", "type": "resource"},
+			{"key": "k8s.cluster.name", "dataType": "string", "type": "resource"},
+			{"key": "k8s.deployment.name", "dataType": "string", "type": "resource"},
+			{"key": "k8s.namespace.name", "dataType": "string", "type": "resource"},
+			{"key": "k8s.pod.name", "dataType": "string", "type": "resource"},
+		}},
+	}
+
+	signalFilters := make([]struct{ signal, filter string }, 0, len(defaultFilters))
+	for _, defaultFilter := range defaultFilters {
+		filterJSON, err := json.Marshal(defaultFilter.filters)
+		if err != nil {
+			return err
+		}
+		signalFilters = append(signalFilters, struct{ signal, filter string }{defaultFilter.signal, string(filterJSON)})
+	}
+
 	tx, err := db.BeginTx(ctx, nil)
 	if err != nil {
 		return err
@@ -73,17 +130,28 @@ func (migration *updateQuickFilters) Up(ctx context.Context, db *bun.DB) error {
 		return err
 	}
 
-	// For each organization, create new quick filters with the updated NewDefaultQuickFilter function
+	// For each organization, create new quick filters with the updated defaults
 	for _, orgID := range orgIDs {
-		// Get the updated default quick filters
-		storableQuickFilters, err := quickfiltertypes.NewDefaultQuickFilter(valuer.MustNewUUID(orgID))
-		if err != nil {
-			return err
+		now := time.Now()
+		quickFilters := make([]*quickFilter, 0, len(signalFilters))
+		for _, signalFilter := range signalFilters {
+			quickFilters = append(quickFilters, &quickFilter{
+				Identifiable: types.Identifiable{
+					ID: valuer.GenerateUUID(),
+				},
+				OrgID:  orgID,
+				Filter: signalFilter.filter,
+				Signal: signalFilter.signal,
+				TimeAuditable: types.TimeAuditable{
+					CreatedAt: now,
+					UpdatedAt: now,
+				},
+			})
 		}
 
 		// Insert all filters for this organization
 		_, err = tx.NewInsert().
-			Model(&storableQuickFilters).
+			Model(&quickFilters).
 			Exec(ctx)
 
 		if err != nil {

--- a/pkg/sqlmigration/035_update_api_monitoring_filters.go
+++ b/pkg/sqlmigration/035_update_api_monitoring_filters.go
@@ -2,20 +2,16 @@ package sqlmigration
 
 import (
 	"context"
-	"database/sql"
+	"encoding/json"
 	"time"
 
 	"github.com/SigNoz/signoz/pkg/factory"
 	"github.com/SigNoz/signoz/pkg/sqlstore"
-	"github.com/SigNoz/signoz/pkg/types/quickfiltertypes"
-	"github.com/SigNoz/signoz/pkg/valuer"
 	"github.com/uptrace/bun"
 	"github.com/uptrace/bun/migrate"
 )
 
-type updateApiMonitoringFilters struct {
-	store sqlstore.SQLStore
-}
+type updateApiMonitoringFilters struct{}
 
 func NewUpdateApiMonitoringFiltersFactory(store sqlstore.SQLStore) factory.ProviderFactory[SQLMigration, Config] {
 	return factory.NewProviderFactory(factory.MustNewName("update_api_monitoring_filters"), func(ctx context.Context, ps factory.ProviderSettings, c Config) (SQLMigration, error) {
@@ -23,10 +19,8 @@ func NewUpdateApiMonitoringFiltersFactory(store sqlstore.SQLStore) factory.Provi
 	})
 }
 
-func newUpdateApiMonitoringFilters(_ context.Context, _ factory.ProviderSettings, _ Config, store sqlstore.SQLStore) (SQLMigration, error) {
-	return &updateApiMonitoringFilters{
-		store: store,
-	}, nil
+func newUpdateApiMonitoringFilters(_ context.Context, _ factory.ProviderSettings, _ Config, _ sqlstore.SQLStore) (SQLMigration, error) {
+	return &updateApiMonitoringFilters{}, nil
 }
 
 func (migration *updateApiMonitoringFilters) Register(migrations *migrate.Migrations) error {
@@ -38,63 +32,29 @@ func (migration *updateApiMonitoringFilters) Register(migrations *migrate.Migrat
 }
 
 func (migration *updateApiMonitoringFilters) Up(ctx context.Context, db *bun.DB) error {
-	tx, err := db.BeginTx(ctx, nil)
+	// Frozen copy of the api_monitoring defaults as this migration shipped; the
+	// change over 031 is service.name moving from "tag" to "resource".
+	apiMonitoringFilters := []map[string]any{
+		{"key": "deployment.environment", "dataType": "string", "type": "resource"},
+		{"key": "service.name", "dataType": "string", "type": "resource"},
+		{"key": "rpc.method", "dataType": "string", "type": "tag"},
+	}
+
+	apiMonitoringFilterJSON, err := json.Marshal(apiMonitoringFilters)
 	if err != nil {
 		return err
 	}
 
-	defer func() {
-		_ = tx.Rollback()
-	}()
-
-	// Get all organization IDs as strings
-	var orgIDs []string
-	err = tx.NewSelect().
-		Table("organizations").
-		Column("id").
-		Scan(ctx, &orgIDs)
+	// The filter JSON is org-independent, so one update covers every org's row.
+	_, err = db.NewUpdate().
+		Table("quick_filter").
+		Set("filter = ?, updated_at = ?", string(apiMonitoringFilterJSON), time.Now()).
+		Where("signal = ?", "api_monitoring").
+		Exec(ctx)
 	if err != nil {
-		if err == sql.ErrNoRows {
-			if err := tx.Commit(); err != nil {
-				return err
-			}
-			return nil
-		}
 		return err
 	}
 
-	for _, orgID := range orgIDs {
-		// Get the updated default quick filters which includes the new API monitoring filters
-		storableQuickFilters, err := quickfiltertypes.NewDefaultQuickFilter(valuer.MustNewUUID(orgID))
-		if err != nil {
-			return err
-		}
-
-		// Find the API monitoring filter from the storable quick filters
-		var apiMonitoringFilterJSON string
-		for _, filter := range storableQuickFilters {
-			if filter.Signal == quickfiltertypes.SignalApiMonitoring {
-				apiMonitoringFilterJSON = filter.Filter
-				break
-			}
-		}
-
-		if apiMonitoringFilterJSON != "" {
-			_, err = tx.NewUpdate().
-				Table("quick_filter").
-				Set("filter = ?, updated_at = ?", apiMonitoringFilterJSON, time.Now()).
-				Where("signal = ? AND org_id = ?", quickfiltertypes.SignalApiMonitoring, orgID).
-				Exec(ctx)
-
-			if err != nil {
-				return err
-			}
-		}
-	}
-
-	if err := tx.Commit(); err != nil {
-		return err
-	}
 	return nil
 }
 


### PR DESCRIPTION

#### Description
This PR makes sure that the old migrations of quick filters are decoupled from types as they should and not imported.

<!--Reference issues using `Closes #issue-number` to enable automatic closure on merge. -->
Part of https://github.com/SigNoz/engineering-pod/issues/5947

