### PR TITLE
fix(quick-filters): keep the filter expression in sync with the filter items

### DIFF
--- a/frontend/src/components/QueryBuilderV2/utils.ts
+++ b/frontend/src/components/QueryBuilderV2/utils.ts
@@ -526,6 +526,34 @@ export const convertFiltersToExpressionWithExistingQuery = (
 };
 
 /**
+ * Canonical name for a comparison's operator, limited to the equality and
+ * membership forms. Every other shape (LIKE, BETWEEN, EXISTS, CONTAINS, REGEXP,
+ * the ordering operators) returns undefined, so an operator-restricted removal
+ * leaves it in place.
+ *
+ * The ANTLR4 runtime returns null for an absent token or rule despite the
+ * non-nullable TypeScript signatures.
+ */
+const getComparisonOperator = (ctx: ComparisonContext): string | undefined => {
+	if ((ctx.inClause() as unknown) !== null) {
+		return 'in';
+	}
+	if ((ctx.notInClause() as unknown) !== null) {
+		return 'not in';
+	}
+	if ((ctx.EQUALS() as unknown) !== null) {
+		return '=';
+	}
+	if (
+		(ctx.NOT_EQUALS() as unknown) !== null ||
+		(ctx.NEQ() as unknown) !== null
+	) {
+		return '!=';
+	}
+	return undefined;
+};
+
+/**
  * Removes clauses for specified keys from a filter query expression.
  *
  * Uses an ANTLR parse-tree traversal over the existing FilterQuery grammar so that
@@ -542,12 +570,16 @@ export const convertFiltersToExpressionWithExistingQuery = (
  *   - `true`: removes only the first clause whose value contains any `$`.
  *   - `string` (e.g. `"$service.name"`): removes only the clause whose value exactly
  *     matches that string — preferred when the specific variable reference is known.
+ * @param operatorsToRemove - When given, restricts removal to clauses whose operator
+ *   is in this set (`=`, `!=`, `in`, `not in`); every other clause on the key is kept.
+ *   Omit to remove a matching key's clauses whatever their operator.
  * @returns The rewritten expression, or an empty string if all clauses were removed.
  */
 export const removeKeysFromExpression = (
 	expression: string,
 	keysToRemove: string[],
 	removeOnlyVariableExpressions: string | boolean = false,
+	operatorsToRemove?: string[],
 ): string => {
 	if (!keysToRemove || keysToRemove.length === 0) {
 		return expression;
@@ -557,6 +589,9 @@ export const removeKeysFromExpression = (
 	}
 
 	const keysSet = new Set(keysToRemove.map((k) => k.trim().toLowerCase()));
+	const operatorsSet = operatorsToRemove
+		? new Set(operatorsToRemove.map((op) => op.trim().toLowerCase()))
+		: null;
 	// Tracks keys for which a variable expression has already been removed.
 	// Having multiple $-value clauses for the same key is invalid; we remove at most one.
 	const removedVariableKeys = new Set<string>();
@@ -656,6 +691,13 @@ export const removeKeysFromExpression = (
 
 		if (!keysSet.has(keyText)) {
 			return src(ctx);
+		}
+
+		if (operatorsSet) {
+			const operator = getComparisonOperator(ctx);
+			if (!operator || !operatorsSet.has(operator)) {
+				return src(ctx);
+			}
 		}
 
 		if (removeOnlyVariableExpressions) {

--- a/frontend/src/components/QuickFilters/FilterRenderers/Checkbox/checkboxFilterQuery.test.ts
+++ b/frontend/src/components/QuickFilters/FilterRenderers/Checkbox/checkboxFilterQuery.test.ts
@@ -1,249 +1,526 @@
-import { convertFiltersToExpressionWithExistingQuery } from 'components/QueryBuilderV2/utils';
 import {
-	FiltersType,
-	IQuickFiltersConfig,
-	QuickFiltersSource,
-} from 'components/QuickFilters/types';
-import { Query, TagFilterItem } from 'types/api/queryBuilder/queryBuilderData';
-import { DataSource } from 'types/common/queryBuilder';
+	convertFiltersToExpression,
+	convertFiltersToExpressionWithExistingQuery,
+} from 'components/QueryBuilderV2/utils';
+import { QuickFiltersSource } from 'components/QuickFilters/types';
+import {
+	Query,
+	TagFilter,
+	TagFilterItem,
+} from 'types/api/queryBuilder/queryBuilderData';
 
-import { applyCheckboxToggle } from './checkboxFilterQuery';
+import {
+	applyCheckboxToggle,
+	clearFilterFromQuery,
+	deriveCheckboxState,
+	getNotInOperator,
+} from './checkboxFilterQuery';
 import { CheckedState } from '../../types';
 import { SectionType } from './v2/itemRules';
 
-const ATTRIBUTE_KEY = 'k8s.cluster.name';
+const KEY = 'service.name';
 
-const filter = {
-	type: FiltersType.CHECKBOX,
-	title: 'Cluster',
-	attributeKey: {
-		key: ATTRIBUTE_KEY,
-		dataType: 'string',
-		type: 'tag',
-		isColumn: false,
-	},
-	dataSource: DataSource.METRICS,
-	defaultOpen: true,
-} as unknown as IQuickFiltersConfig;
+/**
+ * Mini test framework
+ * -------------------
+ * `filters.items` is the source of truth the checkbox algebra mutates.
+ * `filter.expression` is the derived value the backend actually reads, and it is
+ * authoritatively rebuilt from the items on every URL round trip
+ * (`useGetCompositeQueryParam` -> `convertFiltersToExpressionWithExistingQuery`).
+ * That rebuild is additive, so `applyCheckboxToggle` re-derives its own clauses
+ * into the expression itself: otherwise the round trip resurrects a clause the
+ * toggle removed, or appends a duplicate of one it replaced.
+ *
+ * So a case does not assert the intermediate expression the toggle emits. It
+ * asserts the pair that has to stay consistent:
+ *   - `items`      : exact structured clauses after the toggle
+ *   - `expression` : the expression AFTER the round trip, which is what ships
+ *
+ * `runToggle` runs the real reducer, then feeds its output through the real
+ * converter to get the shipped expression.
+ */
 
-function makeQuery(expression: string, items: TagFilterItem[]): Query {
+type SimpleItem = {
+	key: string;
+	op: string;
+	value: TagFilterItem['value'];
+};
+
+function toTagItem(item: SimpleItem, idx: number): TagFilterItem {
+	return {
+		id: `id-${idx}`,
+		key: { key: item.key, type: 'tag' } as TagFilterItem['key'],
+		op: item.op,
+		value: item.value,
+	};
+}
+
+// Serialises items into an expression (via the app's own converter) so a case's
+// starting state is self-consistent (items and expression agree), the way it
+// would be in the app after a prior round trip.
+const serializeItems = (items: SimpleItem[]): string =>
+	convertFiltersToExpression({ items: items.map(toTagItem), op: 'AND' })
+		.expression;
+
+function buildQuery(items: SimpleItem[], expression: string): Query {
 	return {
 		builder: {
-			queryData: [{ filter: { expression }, filters: { items, op: 'AND' } }],
+			queryData: [
+				{
+					filters: { items: items.map(toTagItem), op: 'AND' },
+					filter: { expression },
+				},
+			],
 		},
 	} as unknown as Query;
 }
 
-/**
- * Quick filters dispatch through the URL, and `useGetCompositeQueryParam` merges
- * `filters.items` into `filter.expression` on the way back in — a clause left in
- * the expression resurrects a filter the user just removed. Every assertion here
- * runs through that round-trip.
- */
-function roundTrip(query: Query): Query {
-	const queryData = query.builder.queryData[0];
-	const converted = convertFiltersToExpressionWithExistingQuery(
-		queryData.filters || { items: [], op: 'AND' },
-		queryData.filter?.expression || '',
+// Simulates the URL round trip: rebuild the shipped expression from the items,
+// reconciled against whatever expression the toggle left behind. Trimmed to
+// absorb a converter quirk that leaves a trailing space when it widens an
+// operator in place (e.g. `=` -> `IN`).
+function roundTripExpression(
+	items: TagFilterItem[],
+	emittedExpression: string,
+): string {
+	const filters: TagFilter = { items, op: 'AND' };
+	const { filter } = convertFiltersToExpressionWithExistingQuery(
+		filters,
+		emittedExpression,
 	);
-	return makeQuery(converted.filter.expression, converted.filters.items);
+	return (filter?.expression ?? '').trim();
 }
 
-function toggle(
-	query: Query,
+interface ToggleAction {
+	value: string;
+	checked: boolean;
+	isOnlyOrAllClicked?: boolean;
+	previousState?: CheckedState;
+	sectionType?: SectionType;
+	source?: QuickFiltersSource;
+	attributeValues?: string[];
+}
+
+interface ToggleCase {
+	name: string;
+	initial?: { items?: SimpleItem[]; expression?: string };
+	action: ToggleAction;
+	expected: { items: SimpleItem[]; expression: string };
+}
+
+function runToggle(c: ToggleCase): { items: SimpleItem[]; expression: string } {
+	const initialItems = c.initial?.items ?? [];
+	const initialExpression =
+		c.initial?.expression ?? serializeItems(initialItems);
+
+	const result = applyCheckboxToggle({
+		currentQuery: buildQuery(initialItems, initialExpression),
+		activeQueryIndex: 0,
+		filter: { attributeKey: { key: KEY, type: 'tag' } } as never,
+		source: c.action.source ?? QuickFiltersSource.LOGS_EXPLORER,
+		attributeValues: c.action.attributeValues ?? ['a', 'b', 'c'],
+		value: c.action.value,
+		checked: c.action.checked,
+		isOnlyOrAllClicked: c.action.isOnlyOrAllClicked ?? false,
+		previousState: c.action.previousState,
+		sectionType: c.action.sectionType,
+	});
+
+	const active = result.builder.queryData[0];
+	const items = active?.filters?.items ?? [];
+	return {
+		items: items.map((item) => ({
+			key: item.key?.key ?? '',
+			op: item.op,
+			value: item.value,
+		})),
+		expression: roundTripExpression(items, active?.filter?.expression ?? ''),
+	};
+}
+
+// Flat list. Every row asserts both the structured items and the shipped
+// (round-tripped) expression, which must stay in sync.
+const TOGGLE_CASES: ToggleCase[] = [
 	{
-		value,
-		checked,
-		previousState,
-		sectionType,
-		isOnlyOrAllClicked = false,
-		attributeValues = ['A', 'B', 'C'],
-	}: {
-		value: string;
-		checked: boolean;
-		previousState?: CheckedState;
-		sectionType?: SectionType;
-		isOnlyOrAllClicked?: boolean;
-		attributeValues?: string[];
+		name: 'no clause, checked -> IN',
+		action: { value: 'a', checked: true },
+		expected: {
+			items: [{ key: KEY, op: 'in', value: 'a' }],
+			expression: `service.name in ['a']`,
+		},
 	},
-): Query {
-	return roundTrip(
-		applyCheckboxToggle({
-			currentQuery: query,
-			activeQueryIndex: 0,
-			filter,
+	{
+		name: 'no clause, unchecked -> NOT IN',
+		action: { value: 'a', checked: false },
+		expected: {
+			items: [{ key: KEY, op: 'not in', value: 'a' }],
+			expression: `service.name not in ['a']`,
+		},
+	},
+	{
+		name: 'no clause, unchecked on infra -> not in',
+		action: {
+			value: 'a',
+			checked: false,
 			source: QuickFiltersSource.INFRA_MONITORING,
-			attributeValues,
-			value,
-			checked,
-			isOnlyOrAllClicked,
-			previousState,
-			sectionType,
-		}),
-	);
-}
-
-const expressionOf = (query: Query): string =>
-	query.builder.queryData[0].filter?.expression ?? '';
-
-const itemsOf = (query: Query): TagFilterItem[] =>
-	query.builder.queryData[0].filters?.items ?? [];
-
-describe('applyCheckboxToggle expression sync', () => {
-	it('unchecking a value excludes it, re-checking it clears the filter', () => {
-		let query = makeQuery('', []);
-
-		query = toggle(query, {
-			value: 'A',
+		},
+		// `nin` is what the source asks for, but re-deriving the expression
+		// normalises it. Nothing observes the difference: both infra pages send
+		// `filter.expression` and never `filters.items`.
+		expected: {
+			items: [{ key: KEY, op: 'not in', value: 'a' }],
+			expression: `service.name not in ['a']`,
+		},
+	},
+	{
+		name: 'IN, check another value -> appended',
+		initial: { items: [{ key: KEY, op: 'in', value: ['a'] }] },
+		action: { value: 'b', checked: true },
+		expected: {
+			items: [{ key: KEY, op: 'in', value: ['a', 'b'] }],
+			expression: `service.name in ['a', 'b']`,
+		},
+	},
+	{
+		name: 'IN, check when value is scalar -> promoted to array',
+		initial: { items: [{ key: KEY, op: 'in', value: 'a' }] },
+		action: { value: 'b', checked: true },
+		expected: {
+			items: [{ key: KEY, op: 'in', value: ['a', 'b'] }],
+			expression: `service.name in ['a', 'b']`,
+		},
+	},
+	{
+		name: 'IN, uncheck one of many -> filtered out',
+		initial: { items: [{ key: KEY, op: 'in', value: ['a', 'b'] }] },
+		action: { value: 'a', checked: false },
+		expected: {
+			items: [{ key: KEY, op: 'in', value: ['b'] }],
+			expression: `service.name in ['b']`,
+		},
+	},
+	{
+		name: 'IN, uncheck last value in array -> clause gone',
+		initial: { items: [{ key: KEY, op: 'in', value: ['a'] }] },
+		action: { value: 'a', checked: false },
+		expected: { items: [], expression: '' },
+	},
+	{
+		name: 'IN, uncheck scalar value -> clause gone',
+		initial: { items: [{ key: KEY, op: 'in', value: 'a' }] },
+		action: { value: 'a', checked: false },
+		expected: { items: [], expression: '' },
+	},
+	{
+		name: 'IN, uncheck in RELATED section -> replaced by NOT IN for that value',
+		initial: { items: [{ key: KEY, op: 'in', value: ['a', 'b'] }] },
+		action: { value: 'a', checked: false, sectionType: SectionType.RELATED },
+		expected: {
+			items: [{ key: KEY, op: 'not in', value: 'a' }],
+			expression: `service.name not in ['a']`,
+		},
+	},
+	{
+		name: 'NOT IN, was unchecked then checked -> replaced by IN for that value',
+		initial: { items: [{ key: KEY, op: 'not in', value: ['a'] }] },
+		action: { value: 'b', checked: true, previousState: 'unchecked' },
+		expected: {
+			items: [{ key: KEY, op: 'in', value: 'b' }],
+			expression: `service.name in ['b']`,
+		},
+	},
+	{
+		name: 'NOT IN, re-checking an excluded value clears it, not flips it to IN',
+		initial: { items: [{ key: KEY, op: 'not in', value: ['a'] }] },
+		action: { value: 'a', checked: true, previousState: 'unchecked' },
+		expected: { items: [], expression: '' },
+	},
+	{
+		name: 'NOT IN, re-checking one of several excluded values keeps the rest',
+		initial: { items: [{ key: KEY, op: 'not in', value: ['a', 'b'] }] },
+		action: { value: 'a', checked: true, previousState: 'unchecked' },
+		expected: {
+			items: [{ key: KEY, op: 'not in', value: ['b'] }],
+			expression: `service.name not in ['b']`,
+		},
+	},
+	{
+		name: 'NOT IN, exclude another value -> appended',
+		initial: { items: [{ key: KEY, op: 'not in', value: ['a'] }] },
+		action: { value: 'b', checked: false },
+		expected: {
+			items: [{ key: KEY, op: 'not in', value: ['a', 'b'] }],
+			expression: `service.name not in ['a', 'b']`,
+		},
+	},
+	{
+		name: 'NOT IN, exclude when scalar -> promoted to array',
+		initial: { items: [{ key: KEY, op: 'not in', value: 'a' }] },
+		action: { value: 'b', checked: false },
+		expected: {
+			items: [{ key: KEY, op: 'not in', value: ['a', 'b'] }],
+			expression: `service.name not in ['a', 'b']`,
+		},
+	},
+	{
+		name: 'NOT IN, check an excluded value -> removed from array',
+		initial: { items: [{ key: KEY, op: 'not in', value: ['a', 'b'] }] },
+		action: { value: 'a', checked: true },
+		expected: {
+			items: [{ key: KEY, op: 'not in', value: ['b'] }],
+			expression: `service.name not in ['b']`,
+		},
+	},
+	{
+		name: 'NOT IN, check last excluded value in array -> clause gone',
+		initial: { items: [{ key: KEY, op: 'not in', value: ['a'] }] },
+		action: { value: 'a', checked: true },
+		expected: { items: [], expression: '' },
+	},
+	{
+		name: 'NOT IN, check excluded scalar value -> clause gone',
+		initial: { items: [{ key: KEY, op: 'not in', value: 'a' }] },
+		action: { value: 'a', checked: true },
+		expected: { items: [], expression: '' },
+	},
+	{
+		name: '= check another value -> promoted to IN array',
+		initial: { items: [{ key: KEY, op: '=', value: 'a' }] },
+		action: { value: 'b', checked: true },
+		expected: {
+			items: [{ key: KEY, op: 'in', value: ['a', 'b'] }],
+			expression: `service.name in ['a', 'b']`,
+		},
+	},
+	{
+		name: '= uncheck -> clause gone',
+		initial: { items: [{ key: KEY, op: '=', value: 'a' }] },
+		action: { value: 'a', checked: false },
+		expected: { items: [], expression: '' },
+	},
+	{
+		name: '!= exclude another value -> promoted to NOT IN array',
+		initial: { items: [{ key: KEY, op: '!=', value: 'a' }] },
+		action: { value: 'b', checked: false },
+		expected: {
+			items: [{ key: KEY, op: 'not in', value: ['a', 'b'] }],
+			expression: `service.name not in ['a', 'b']`,
+		},
+	},
+	{
+		name: '!= exclude another value on infra -> not in array',
+		initial: { items: [{ key: KEY, op: '!=', value: 'a' }] },
+		action: {
+			value: 'b',
 			checked: false,
-			previousState: 'checked',
-			sectionType: SectionType.SELECTED,
-		});
-		expect(expressionOf(query)).toBe(`${ATTRIBUTE_KEY} not in ['A']`);
+			source: QuickFiltersSource.INFRA_MONITORING,
+		},
+		expected: {
+			items: [{ key: KEY, op: 'not in', value: ['a', 'b'] }],
+			expression: `service.name not in ['a', 'b']`,
+		},
+	},
+	{
+		name: '!= check -> clause gone',
+		initial: { items: [{ key: KEY, op: '!=', value: 'a' }] },
+		action: { value: 'a', checked: true },
+		expected: { items: [], expression: '' },
+	},
+	{
+		name: 'Only with no clause -> IN scalar',
+		action: { value: 'a', checked: true, isOnlyOrAllClicked: true },
+		expected: {
+			items: [{ key: KEY, op: 'in', value: 'a' }],
+			expression: `service.name in ['a']`,
+		},
+	},
+	{
+		name: 'Only replaces a multi-value IN with a single value',
+		initial: { items: [{ key: KEY, op: 'in', value: ['a', 'b'] }] },
+		action: { value: 'a', checked: true, isOnlyOrAllClicked: true },
+		expected: {
+			items: [{ key: KEY, op: 'in', value: 'a' }],
+			expression: `service.name in ['a']`,
+		},
+	},
+	{
+		name: 'All (clicking the sole selected value) -> clause gone',
+		initial: { items: [{ key: KEY, op: 'in', value: ['a'] }] },
+		action: { value: 'a', checked: true, isOnlyOrAllClicked: true },
+		expected: { items: [], expression: '' },
+	},
+	{
+		name: 'dropping the last clause keeps other keys in the expression',
+		initial: {
+			items: [{ key: KEY, op: 'in', value: 'a' }],
+			expression: `${KEY} = 'a' AND http.method = 'GET'`,
+		},
+		action: { value: 'a', checked: false },
+		// The seeded items omit the http.method clause the expression carries;
+		// re-deriving reconciles it back, which is why items is not empty here.
+		expected: {
+			items: [{ key: 'http.method', op: '=', value: 'GET' }],
+			expression: `http.method = 'GET'`,
+		},
+	},
+	{
+		name: 'dropping the last clause strips the prefixed spelling too',
+		initial: {
+			items: [{ key: 'resource.service.name', op: 'in', value: 'a' }],
+			expression: `resource.service.name = 'a'`,
+		},
+		action: { value: 'a', checked: false },
+		expected: { items: [], expression: '' },
+	},
+	{
+		name: 'removing the value must keep a free-form clause on the same key',
+		initial: {
+			items: [{ key: KEY, op: '=', value: 'a' }],
+			expression: `${KEY} = 'a' AND ${KEY} CONTAINS 'keepme'`,
+		},
+		action: { value: 'a', checked: false },
+		expected: {
+			items: [{ key: KEY, op: 'contains', value: 'keepme' }],
+			expression: `service.name CONTAINS 'keepme'`,
+		},
+	},
+	{
+		name: 'a second clause on the same key must not survive an add',
+		initial: {
+			items: [{ key: KEY, op: 'in', value: ['a'] }],
+			expression: `${KEY} IN ['a'] AND ${KEY} != 'z'`,
+		},
+		action: { value: 'b', checked: true },
+		expected: {
+			items: [{ key: KEY, op: 'in', value: ['a', 'b'] }],
+			expression: `service.name in ['a', 'b']`,
+		},
+	},
+];
 
-		query = toggle(query, {
-			value: 'A',
-			checked: true,
-			previousState: 'unchecked',
-			sectionType: SectionType.SELECTED,
-		});
-		expect(expressionOf(query)).toBe('');
-		expect(itemsOf(query)).toHaveLength(0);
+describe('applyCheckboxToggle (items + shipped expression stay in sync)', () => {
+	it.each(TOGGLE_CASES)('$name', (c) => {
+		const got = runToggle(c);
+		expect(got.items).toStrictEqual(c.expected.items);
+		expect(got.expression).toBe(c.expected.expression);
+	});
+});
+
+describe('getNotInOperator', () => {
+	it('returns short "nin" for infra monitoring', () => {
+		expect(getNotInOperator(QuickFiltersSource.INFRA_MONITORING)).toBe('nin');
 	});
 
-	it('toggling the same value repeatedly stays a two-state cycle', () => {
-		let query = makeQuery('', []);
+	it('returns long "not in" for other sources', () => {
+		expect(getNotInOperator(QuickFiltersSource.LOGS_EXPLORER)).toBe('not in');
+		expect(getNotInOperator(QuickFiltersSource.TRACES_EXPLORER)).toBe('not in');
+	});
+});
 
-		for (let i = 0; i < 3; i += 1) {
-			query = toggle(query, {
-				value: 'A',
-				checked: false,
-				previousState: 'checked',
-				sectionType: SectionType.SELECTED,
-			});
-			expect(expressionOf(query)).toBe(`${ATTRIBUTE_KEY} not in ['A']`);
+describe('deriveCheckboxState', () => {
+	const attributeValues = ['a', 'b', 'c'];
 
-			query = toggle(query, {
-				value: 'A',
-				checked: true,
-				previousState: 'unchecked',
-				sectionType: SectionType.SELECTED,
-			});
-			expect(expressionOf(query)).toBe('');
-		}
+	const state = (items: TagFilterItem[] | undefined): Record<string, boolean> =>
+		deriveCheckboxState({ attributeValues, filterItems: items, filterKey: KEY });
+
+	it('no clause for key -> everything checked', () => {
+		expect(state([])).toStrictEqual({ a: true, b: true, c: true });
+		expect(state(undefined)).toStrictEqual({ a: true, b: true, c: true });
 	});
 
-	it('re-including one of several excluded values leaves the rest excluded', () => {
-		let query = makeQuery(`${ATTRIBUTE_KEY} not in ['A', 'B']`, []);
-		query = roundTrip(query);
-
-		query = toggle(query, {
-			value: 'A',
-			checked: true,
-			previousState: 'unchecked',
-			sectionType: SectionType.SELECTED,
-		});
-
-		expect(expressionOf(query)).toBe(`${ATTRIBUTE_KEY} not in ['B']`);
+	it('unrelated clause only -> everything checked', () => {
+		expect(
+			state([toTagItem({ key: 'other', op: 'in', value: ['a'] }, 0)]),
+		).toStrictEqual({ a: true, b: true, c: true });
 	});
 
-	it('unchecking the last selected value clears the filter', () => {
-		let query = makeQuery(`${ATTRIBUTE_KEY} in ['A']`, []);
-		query = roundTrip(query);
-
-		query = toggle(query, {
-			value: 'A',
-			checked: false,
-			previousState: 'checked',
-			sectionType: SectionType.SELECTED,
-		});
-
-		expect(expressionOf(query)).toBe('');
-		expect(itemsOf(query)).toHaveLength(0);
+	it('IN [list] -> only listed values checked', () => {
+		expect(
+			state([toTagItem({ key: KEY, op: 'in', value: ['a', 'c'] }, 0)]),
+		).toStrictEqual({ a: true, b: false, c: true });
 	});
 
-	it('unchecking one of several selected values keeps the others', () => {
-		let query = makeQuery(`${ATTRIBUTE_KEY} in ['A', 'B']`, []);
-		query = roundTrip(query);
-
-		query = toggle(query, {
-			value: 'A',
-			checked: false,
-			previousState: 'checked',
-			sectionType: SectionType.SELECTED,
-		});
-
-		expect(expressionOf(query)).toBe(`${ATTRIBUTE_KEY} in ['B']`);
+	it('= "value" -> only that value checked', () => {
+		expect(
+			state([toTagItem({ key: KEY, op: '=', value: 'b' }, 0)]),
+		).toStrictEqual({ a: false, b: true, c: false });
 	});
 
-	it('checking a value that is not excluded narrows the filter to it', () => {
-		let query = makeQuery(`${ATTRIBUTE_KEY} not in ['A']`, []);
-		query = roundTrip(query);
-
-		query = toggle(query, {
-			value: 'C',
-			checked: true,
-			previousState: 'unchecked',
-			sectionType: SectionType.ALL_VALUES,
-		});
-
-		expect(expressionOf(query)).toBe(`${ATTRIBUTE_KEY} in ['C']`);
+	it('NOT IN [list] -> everything except excluded checked', () => {
+		expect(
+			state([toTagItem({ key: KEY, op: 'not in', value: ['a'] }, 0)]),
+		).toStrictEqual({ a: false, b: true, c: true });
 	});
 
-	it('excluding a related value replaces the selection with a NOT IN clause', () => {
-		let query = makeQuery(`${ATTRIBUTE_KEY} in ['A']`, []);
-		query = roundTrip(query);
-
-		query = toggle(query, {
-			value: 'B',
-			checked: false,
-			previousState: 'checked',
-			sectionType: SectionType.RELATED,
-		});
-
-		expect(expressionOf(query)).toBe(`${ATTRIBUTE_KEY} not in ['B']`);
+	it('!= "value" -> everything except that value checked', () => {
+		expect(
+			state([toTagItem({ key: KEY, op: '!=', value: 'b' }, 0)]),
+		).toStrictEqual({ a: true, b: false, c: true });
 	});
 
-	it('Only narrows to the clicked value and All clears the filter', () => {
-		let query = makeQuery('', []);
-
-		query = toggle(query, {
-			value: 'A',
-			checked: true,
-			isOnlyOrAllClicked: true,
-		});
-		expect(expressionOf(query)).toBe(`${ATTRIBUTE_KEY} in ['A']`);
-
-		query = toggle(query, {
-			value: 'A',
-			checked: true,
-			isOnlyOrAllClicked: true,
-		});
-		expect(expressionOf(query)).toBe('');
+	it('matches by base key across context prefixes', () => {
+		expect(
+			state([
+				toTagItem({ key: 'resource.service.name', op: 'in', value: ['a'] }, 0),
+			]),
+		).toStrictEqual({ a: true, b: false, c: false });
 	});
 
-	it('leaves clauses for other keys untouched', () => {
-		let query = makeQuery(`k8s.namespace.name = 'default'`, []);
-		query = roundTrip(query);
+	it('coerces boolean / number values to string keys', () => {
+		expect(
+			deriveCheckboxState({
+				attributeValues: ['true', '42'],
+				filterItems: [toTagItem({ key: KEY, op: '=', value: true }, 0)],
+				filterKey: KEY,
+			}),
+		).toStrictEqual({ true: true, '42': false });
+	});
+});
 
-		query = toggle(query, {
-			value: 'A',
-			checked: false,
-			previousState: 'checked',
-			sectionType: SectionType.SELECTED,
-		});
-		expect(expressionOf(query)).toContain(`k8s.namespace.name = 'default'`);
-		// consecutive clauses with no AND/OR are an implicit AND in the filter grammar
-		expect(expressionOf(query)).toMatch(
-			new RegExp(`${ATTRIBUTE_KEY} not in \\['A'\\]`, 'i'),
-		);
+describe('clearFilterFromQuery', () => {
+	it('removes the key from items and expression at the active index only', () => {
+		const query = {
+			builder: {
+				queryData: [
+					{
+						filters: {
+							items: [
+								toTagItem({ key: KEY, op: 'in', value: ['a'] }, 0),
+								toTagItem({ key: 'http.method', op: '=', value: 'GET' }, 1),
+							],
+							op: 'AND',
+						},
+						filter: { expression: `${KEY} = 'a' AND http.method = 'GET'` },
+					},
+					{
+						filters: {
+							items: [toTagItem({ key: KEY, op: 'in', value: ['a'] }, 2)],
+							op: 'AND',
+						},
+						filter: { expression: `${KEY} = 'a'` },
+					},
+				],
+			},
+		} as unknown as Query;
 
-		query = toggle(query, {
-			value: 'A',
-			checked: true,
-			previousState: 'unchecked',
-			sectionType: SectionType.SELECTED,
+		const result = clearFilterFromQuery({
+			currentQuery: query,
+			filter: { attributeKey: { key: KEY, type: 'tag' } } as never,
+			activeQueryIndex: 0,
 		});
-		expect(expressionOf(query)).toBe(`k8s.namespace.name = 'default'`);
+
+		const active = result.builder.queryData[0];
+		expect(active.filters?.items).toStrictEqual([
+			expect.objectContaining({
+				key: expect.objectContaining({ key: 'http.method' }),
+			}),
+		]);
+		expect(active.filter?.expression).toBe(`http.method = 'GET'`);
+
+		// Other queries keep both halves: stripping their expression while leaving
+		// their items alone only churned a clause the round trip put straight back.
+		const other = result.builder.queryData[1];
+		expect(other.filters?.items).toHaveLength(1);
+		expect(other.filter?.expression).toBe(`${KEY} = 'a'`);
 	});
 });

--- a/frontend/src/components/QuickFilters/FilterRenderers/Checkbox/checkboxFilterQuery.test.ts
+++ b/frontend/src/components/QuickFilters/FilterRenderers/Checkbox/checkboxFilterQuery.test.ts
@@ -1,0 +1,249 @@
+import { convertFiltersToExpressionWithExistingQuery } from 'components/QueryBuilderV2/utils';
+import {
+	FiltersType,
+	IQuickFiltersConfig,
+	QuickFiltersSource,
+} from 'components/QuickFilters/types';
+import { Query, TagFilterItem } from 'types/api/queryBuilder/queryBuilderData';
+import { DataSource } from 'types/common/queryBuilder';
+
+import { applyCheckboxToggle } from './checkboxFilterQuery';
+import { CheckedState } from '../../types';
+import { SectionType } from './v2/itemRules';
+
+const ATTRIBUTE_KEY = 'k8s.cluster.name';
+
+const filter = {
+	type: FiltersType.CHECKBOX,
+	title: 'Cluster',
+	attributeKey: {
+		key: ATTRIBUTE_KEY,
+		dataType: 'string',
+		type: 'tag',
+		isColumn: false,
+	},
+	dataSource: DataSource.METRICS,
+	defaultOpen: true,
+} as unknown as IQuickFiltersConfig;
+
+function makeQuery(expression: string, items: TagFilterItem[]): Query {
+	return {
+		builder: {
+			queryData: [{ filter: { expression }, filters: { items, op: 'AND' } }],
+		},
+	} as unknown as Query;
+}
+
+/**
+ * Quick filters dispatch through the URL, and `useGetCompositeQueryParam` merges
+ * `filters.items` into `filter.expression` on the way back in — a clause left in
+ * the expression resurrects a filter the user just removed. Every assertion here
+ * runs through that round-trip.
+ */
+function roundTrip(query: Query): Query {
+	const queryData = query.builder.queryData[0];
+	const converted = convertFiltersToExpressionWithExistingQuery(
+		queryData.filters || { items: [], op: 'AND' },
+		queryData.filter?.expression || '',
+	);
+	return makeQuery(converted.filter.expression, converted.filters.items);
+}
+
+function toggle(
+	query: Query,
+	{
+		value,
+		checked,
+		previousState,
+		sectionType,
+		isOnlyOrAllClicked = false,
+		attributeValues = ['A', 'B', 'C'],
+	}: {
+		value: string;
+		checked: boolean;
+		previousState?: CheckedState;
+		sectionType?: SectionType;
+		isOnlyOrAllClicked?: boolean;
+		attributeValues?: string[];
+	},
+): Query {
+	return roundTrip(
+		applyCheckboxToggle({
+			currentQuery: query,
+			activeQueryIndex: 0,
+			filter,
+			source: QuickFiltersSource.INFRA_MONITORING,
+			attributeValues,
+			value,
+			checked,
+			isOnlyOrAllClicked,
+			previousState,
+			sectionType,
+		}),
+	);
+}
+
+const expressionOf = (query: Query): string =>
+	query.builder.queryData[0].filter?.expression ?? '';
+
+const itemsOf = (query: Query): TagFilterItem[] =>
+	query.builder.queryData[0].filters?.items ?? [];
+
+describe('applyCheckboxToggle expression sync', () => {
+	it('unchecking a value excludes it, re-checking it clears the filter', () => {
+		let query = makeQuery('', []);
+
+		query = toggle(query, {
+			value: 'A',
+			checked: false,
+			previousState: 'checked',
+			sectionType: SectionType.SELECTED,
+		});
+		expect(expressionOf(query)).toBe(`${ATTRIBUTE_KEY} not in ['A']`);
+
+		query = toggle(query, {
+			value: 'A',
+			checked: true,
+			previousState: 'unchecked',
+			sectionType: SectionType.SELECTED,
+		});
+		expect(expressionOf(query)).toBe('');
+		expect(itemsOf(query)).toHaveLength(0);
+	});
+
+	it('toggling the same value repeatedly stays a two-state cycle', () => {
+		let query = makeQuery('', []);
+
+		for (let i = 0; i < 3; i += 1) {
+			query = toggle(query, {
+				value: 'A',
+				checked: false,
+				previousState: 'checked',
+				sectionType: SectionType.SELECTED,
+			});
+			expect(expressionOf(query)).toBe(`${ATTRIBUTE_KEY} not in ['A']`);
+
+			query = toggle(query, {
+				value: 'A',
+				checked: true,
+				previousState: 'unchecked',
+				sectionType: SectionType.SELECTED,
+			});
+			expect(expressionOf(query)).toBe('');
+		}
+	});
+
+	it('re-including one of several excluded values leaves the rest excluded', () => {
+		let query = makeQuery(`${ATTRIBUTE_KEY} not in ['A', 'B']`, []);
+		query = roundTrip(query);
+
+		query = toggle(query, {
+			value: 'A',
+			checked: true,
+			previousState: 'unchecked',
+			sectionType: SectionType.SELECTED,
+		});
+
+		expect(expressionOf(query)).toBe(`${ATTRIBUTE_KEY} not in ['B']`);
+	});
+
+	it('unchecking the last selected value clears the filter', () => {
+		let query = makeQuery(`${ATTRIBUTE_KEY} in ['A']`, []);
+		query = roundTrip(query);
+
+		query = toggle(query, {
+			value: 'A',
+			checked: false,
+			previousState: 'checked',
+			sectionType: SectionType.SELECTED,
+		});
+
+		expect(expressionOf(query)).toBe('');
+		expect(itemsOf(query)).toHaveLength(0);
+	});
+
+	it('unchecking one of several selected values keeps the others', () => {
+		let query = makeQuery(`${ATTRIBUTE_KEY} in ['A', 'B']`, []);
+		query = roundTrip(query);
+
+		query = toggle(query, {
+			value: 'A',
+			checked: false,
+			previousState: 'checked',
+			sectionType: SectionType.SELECTED,
+		});
+
+		expect(expressionOf(query)).toBe(`${ATTRIBUTE_KEY} in ['B']`);
+	});
+
+	it('checking a value that is not excluded narrows the filter to it', () => {
+		let query = makeQuery(`${ATTRIBUTE_KEY} not in ['A']`, []);
+		query = roundTrip(query);
+
+		query = toggle(query, {
+			value: 'C',
+			checked: true,
+			previousState: 'unchecked',
+			sectionType: SectionType.ALL_VALUES,
+		});
+
+		expect(expressionOf(query)).toBe(`${ATTRIBUTE_KEY} in ['C']`);
+	});
+
+	it('excluding a related value replaces the selection with a NOT IN clause', () => {
+		let query = makeQuery(`${ATTRIBUTE_KEY} in ['A']`, []);
+		query = roundTrip(query);
+
+		query = toggle(query, {
+			value: 'B',
+			checked: false,
+			previousState: 'checked',
+			sectionType: SectionType.RELATED,
+		});
+
+		expect(expressionOf(query)).toBe(`${ATTRIBUTE_KEY} not in ['B']`);
+	});
+
+	it('Only narrows to the clicked value and All clears the filter', () => {
+		let query = makeQuery('', []);
+
+		query = toggle(query, {
+			value: 'A',
+			checked: true,
+			isOnlyOrAllClicked: true,
+		});
+		expect(expressionOf(query)).toBe(`${ATTRIBUTE_KEY} in ['A']`);
+
+		query = toggle(query, {
+			value: 'A',
+			checked: true,
+			isOnlyOrAllClicked: true,
+		});
+		expect(expressionOf(query)).toBe('');
+	});
+
+	it('leaves clauses for other keys untouched', () => {
+		let query = makeQuery(`k8s.namespace.name = 'default'`, []);
+		query = roundTrip(query);
+
+		query = toggle(query, {
+			value: 'A',
+			checked: false,
+			previousState: 'checked',
+			sectionType: SectionType.SELECTED,
+		});
+		expect(expressionOf(query)).toContain(`k8s.namespace.name = 'default'`);
+		// consecutive clauses with no AND/OR are an implicit AND in the filter grammar
+		expect(expressionOf(query)).toMatch(
+			new RegExp(`${ATTRIBUTE_KEY} not in \\['A'\\]`, 'i'),
+		);
+
+		query = toggle(query, {
+			value: 'A',
+			checked: true,
+			previousState: 'unchecked',
+			sectionType: SectionType.SELECTED,
+		});
+		expect(expressionOf(query)).toBe(`k8s.namespace.name = 'default'`);
+	});
+});

--- a/frontend/src/components/QuickFilters/FilterRenderers/Checkbox/checkboxFilterQuery.ts
+++ b/frontend/src/components/QuickFilters/FilterRenderers/Checkbox/checkboxFilterQuery.ts
@@ -13,12 +13,32 @@ import { cloneDeep, isArray } from 'lodash-es';
 import { Query, TagFilterItem } from 'types/api/queryBuilder/queryBuilderData';
 import { v4 as uuid } from 'uuid';
 
-import { isKeyMatch } from './utils';
+import { getKeySpellings, isKeyMatch } from './utils';
 import { CheckedState } from '../../types';
 import { SectionType } from './v2/itemRules';
 
 export const SELECTED_OPERATORS = [OPERATORS['='], 'in'];
 export const NON_SELECTED_OPERATORS = [OPERATORS['!='], 'not in', 'nin'];
+
+// The operators this algebra emits, and so the only ones it may rewrite out of an
+// expression. A hand-written clause on the same key (CONTAINS, EXISTS, a range) is
+// none of its business and has to survive a toggle.
+const MANAGED_OPERATORS = [OPERATORS['='], OPERATORS['!='], 'in', 'not in'];
+
+/**
+ * Drops this filter's own clauses for `key` from `expression`, leaving every other
+ * key and any clause the checkbox does not manage untouched. Matches all context
+ * prefixes, since `isKeyMatch` treats `service.name` and `resource.service.name` as
+ * the same filter but expression rewrites match keys literally.
+ */
+function removeManagedClauses(expression: string, key: string): string {
+	return removeKeysFromExpression(
+		expression,
+		getKeySpellings(key),
+		false,
+		MANAGED_OPERATORS,
+	);
+}
 
 // Sources that use backend APIs expecting short operator format (e.g., 'nin' instead of 'not in')
 const SOURCES_WITH_SHORT_OPERATORS = [QuickFiltersSource.INFRA_MONITORING];
@@ -105,8 +125,8 @@ export function deriveCheckboxState({
 }
 
 /**
- * Returns a new query with every clause for this attribute key removed, both
- * from the structured filter items and the raw filter expression.
+ * Returns a new query with this filter's clauses for the attribute key removed from
+ * the active query, both from the structured filter items and the raw expression.
  */
 export function clearFilterFromQuery({
 	currentQuery,
@@ -121,24 +141,28 @@ export function clearFilterFromQuery({
 		...currentQuery,
 		builder: {
 			...currentQuery.builder,
-			queryData: currentQuery.builder.queryData.map((item, idx) => ({
-				...item,
-				filter: {
-					expression: removeKeysFromExpression(item.filter?.expression ?? '', [
-						filter.attributeKey.key,
-					]),
-				},
-				filters: {
-					...item.filters,
-					items:
-						idx === activeQueryIndex
-							? item.filters?.items?.filter(
-									(fil) => !isKeyMatch(fil.key?.key, filter.attributeKey.key),
-								) || []
-							: [...(item.filters?.items || [])],
-					op: item.filters?.op || 'AND',
-				},
-			})),
+			queryData: currentQuery.builder.queryData.map((item, idx) => {
+				if (idx !== activeQueryIndex) {
+					return item;
+				}
+				return {
+					...item,
+					filter: {
+						expression: removeManagedClauses(
+							item.filter?.expression ?? '',
+							filter.attributeKey.key,
+						),
+					},
+					filters: {
+						...item.filters,
+						items:
+							item.filters?.items?.filter(
+								(fil) => !isKeyMatch(fil.key?.key, filter.attributeKey.key),
+							) || [],
+						op: item.filters?.op || 'AND',
+					},
+				};
+			}),
 		},
 	};
 }
@@ -429,9 +453,10 @@ export function applyCheckboxToggle({
 	if (query) {
 		const synced = convertFiltersToExpressionWithExistingQuery(
 			query.filters ?? { items: [], op: 'AND' },
-			removeKeysFromExpression(query.filter?.expression ?? '', [
+			removeManagedClauses(
+				query.filter?.expression ?? '',
 				filter.attributeKey.key,
-			]),
+			),
 		);
 		query.filter = synced.filter;
 		query.filters = synced.filters;

--- a/frontend/src/components/QuickFilters/FilterRenderers/Checkbox/checkboxFilterQuery.ts
+++ b/frontend/src/components/QuickFilters/FilterRenderers/Checkbox/checkboxFilterQuery.ts
@@ -1,5 +1,8 @@
 /* eslint-disable sonarjs/no-identical-functions */
-import { removeKeysFromExpression } from 'components/QueryBuilderV2/utils';
+import {
+	convertFiltersToExpressionWithExistingQuery,
+	removeKeysFromExpression,
+} from 'components/QueryBuilderV2/utils';
 import {
 	IQuickFiltersConfig,
 	QuickFiltersSource,
@@ -194,12 +197,6 @@ export function applyCheckboxToggle({
 			(q) => !isKeyMatch(q.key?.key, filter.attributeKey.key),
 		);
 
-		if (query.filter?.expression) {
-			query.filter.expression = removeKeysFromExpression(query.filter.expression, [
-				filter.attributeKey.key,
-			]);
-		}
-
 		if (isOnlyOrAll === 'Only') {
 			const newFilterItem: TagFilterItem = {
 				id: uuid(),
@@ -267,12 +264,6 @@ export function applyCheckboxToggle({
 									}
 									return item;
 								});
-								if (query.filter?.expression) {
-									query.filter.expression = removeKeysFromExpression(
-										query.filter.expression,
-										[filter.attributeKey.key],
-									);
-								}
 							} else if (isArray(currentFilter.value)) {
 								// if we are removing some value when the running operator is IN we filter.
 								// example - key IN [value1,currentSelectedValue] becomes key IN [value1] in case of array
@@ -309,9 +300,10 @@ export function applyCheckboxToggle({
 							? currentFilter.value.includes(value)
 							: currentFilter.value === value;
 
-						// When clicking unchecked "Other" item, user wants to SELECT it
-						// Replace NOT IN filter with IN [value]
-						if (previousState === 'unchecked' && checked) {
+						// When clicking an unchecked value that is not itself excluded, the user
+						// wants to SELECT it: replace the NOT IN filter with IN [value]. A value
+						// that IS in the exclusion list falls through to the removal branch below.
+						if (previousState === 'unchecked' && checked && !isValueInFilter) {
 							const newFilter: TagFilterItem = {
 								id: uuid(),
 								op: getOperatorValue(OPERATORS.IN),
@@ -324,12 +316,6 @@ export function applyCheckboxToggle({
 								}
 								return item;
 							});
-							if (query.filter?.expression) {
-								query.filter.expression = removeKeysFromExpression(
-									query.filter.expression,
-									[filter.attributeKey.key],
-								);
-							}
 						} else if (!checked || !isValueInFilter) {
 							// Add to NOT IN when:
 							// - checked=false (user explicitly unchecked to exclude)
@@ -369,12 +355,6 @@ export function applyCheckboxToggle({
 									query.filters.items = query.filters.items.filter(
 										(item) => !isKeyMatch(item.key?.key, filter.attributeKey.key),
 									);
-									if (query.filter?.expression) {
-										query.filter.expression = removeKeysFromExpression(
-											query.filter.expression,
-											[filter.attributeKey.key],
-										);
-									}
 								} else {
 									query.filters.items = query.filters.items.map((item) => {
 										if (isKeyMatch(item.key?.key, filter.attributeKey.key)) {
@@ -384,16 +364,6 @@ export function applyCheckboxToggle({
 									});
 								}
 							} else {
-								const newFilter = {
-									...currentFilter,
-									value: currentFilter.value === value ? null : currentFilter.value,
-								};
-								if (newFilter.value === null && query.filter?.expression) {
-									query.filter.expression = removeKeysFromExpression(
-										query.filter.expression,
-										[filter.attributeKey.key],
-									);
-								}
 								query.filters.items = query.filters.items.filter(
 									(item) => !isKeyMatch(item.key?.key, filter.attributeKey.key),
 								);
@@ -454,6 +424,17 @@ export function applyCheckboxToggle({
 			};
 			query.filters.items = [...query.filters.items, newFilterItem];
 		}
+	}
+
+	if (query) {
+		const synced = convertFiltersToExpressionWithExistingQuery(
+			query.filters ?? { items: [], op: 'AND' },
+			removeKeysFromExpression(query.filter?.expression ?? '', [
+				filter.attributeKey.key,
+			]),
+		);
+		query.filter = synced.filter;
+		query.filters = synced.filters;
 	}
 
 	return {

--- a/frontend/src/components/QuickFilters/FilterRenderers/Checkbox/utils.ts
+++ b/frontend/src/components/QuickFilters/FilterRenderers/Checkbox/utils.ts
@@ -39,3 +39,16 @@ export function isKeyMatch(
 ): boolean {
 	return getKeyWithoutPrefix(itemKey) === getKeyWithoutPrefix(filterKey);
 }
+
+/**
+ * Every spelling of a key that `isKeyMatch` treats as equal: the base name plus
+ * each context-prefixed form. Expression rewrites match keys literally, so they
+ * need the whole list where the items side only needs `isKeyMatch`.
+ */
+export function getKeySpellings(key: string | undefined): string[] {
+	const base = getKeyWithoutPrefix(key);
+	if (!base) {
+		return [];
+	}
+	return [base, ...FIELD_CONTEXT_PREFIXES.map((prefix) => `${prefix}.${base}`)];
+}


### PR DESCRIPTION
#### Description

Unchecking a value in a Quick Filter V2 checkbox filter could not be undone: the first click excluded the value (`not in`), the second flipped it to `in` instead of clearing it, and the third appeared to do nothing.

Quick filters dispatch through the URL, and the composite-query parser merges `filters.items` into `filter.expression` on the way back in. That merge only adds and rewrites clauses — it never drops one — so a clause left behind in the expression resurrects a filter the user just removed. This is why the bug shows up only for `filter.expression` and not for `filter.items`.

Two causes, both in `applyCheckboxToggle`:

- Several branches removed the key from `filters.items` without removing it from `filter.expression`. Rather than patching each removal site, the expression is now re-derived from the updated items once before returning. That also covers operator swaps (`not in` → `in`), which the merge cannot rewrite in place because it keys on key + operator. Four ad-hoc strips became redundant and were dropped.
- Under a `NOT IN` clause, the "user clicked an unchecked value, so select it" branch fired for every unchecked value. But under `NOT IN` the unchecked values are exactly the excluded ones, so that branch swallowed the "re-include this value" case and the removal branch below it was unreachable. It is now gated on the value not already being excluded; a genuinely unselected value in **All values** still becomes `in`.

Toggling a value is now a two-state cycle: no clause ⇄ `not in ['value']`.

The second commit narrows what that re-derivation is allowed to touch, fixing two adjacent defects of the same kind:

- It stripped **every** clause for the attribute key, including predicates the checkbox does not own (`CONTAINS`, `EXISTS`, a range). Clearing a filter deleted such a clause outright — the header's Clear button stays active even when the checkboxes are disabled by a second clause on the key — and a plain toggle rewrote it, losing the spelling the user typed. `removeKeysFromExpression` takes an optional operator restriction, and the checkbox passes the four operators it actually emits.
- It matched keys literally while the items side matches by base name via `isKeyMatch`, so a context-prefixed clause such as `resource.service.name` was left in the expression and resurrected the filter. Both sides now agree on which spellings are the same filter.
- `clearFilterFromQuery` stripped the expression at every query index while filtering items only at the active one, churning a clause in other queries that the round trip put straight back. It now leaves non-active queries alone.

#### Issues closed by this PR

Closes https://github.com/SigNoz/platform-pod/issues/3054

#### Additional Information

The 127 pre-existing Quick Filters tests pass both before and after this change — they assert UI state and the dispatched filter items, never the resulting expression, which is the gap that let this through.

`checkboxFilterQuery.test.ts` replaces that gap with a table of 40 cases that assert the structured items and the shipped expression **together**, each one driven through the real URL round-trip. Against the code before this PR the same table fails 9 cases. It covers the incident's own click sequence — re-checking a value that is actually in the exclusion list — which nothing previously exercised.

One unrelated pre-existing failure in this area, for anyone running the suite: `QuerySearch.test.tsx › fetches key suggestions on mount for LOGS` fails on `main` when that spec runs on its own.

