### PR TITLE
fix(dashboards): resolve both gen_ai.usage.cost and _signoz.gen_ai.total_cost in LLM Overview

### DIFF
--- a/frontend/src/container/LLMObservability/Overview/json/dashboard.json
+++ b/frontend/src/container/LLMObservability/Overview/json/dashboard.json
@@ -161,7 +161,7 @@
         "spec": {
           "display": {
             "name": "Total cost",
-            "description": "Total LLM cost across all calls. Requires gen_ai.usage.cost attribute."
+            "description": "Total LLM cost across all calls. Resolves gen_ai.usage.cost and _signoz.gen_ai.total_cost attributes."
           },
           "plugin": {
             "kind": "signoz/NumberPanel",
@@ -185,7 +185,7 @@
                           "name": "A",
                           "signal": "traces",
                           "stepInterval": 60,
-                          "disabled": false,
+                          "disabled": true,
                           "filter": {
                             "expression": ""
                           },
@@ -197,6 +197,34 @@
                               "expression": "sum(gen_ai.usage.cost)"
                             }
                           ]
+                        }
+                      },
+                      {
+                        "type": "builder_query",
+                        "spec": {
+                          "name": "B",
+                          "signal": "traces",
+                          "stepInterval": 60,
+                          "disabled": true,
+                          "filter": {
+                            "expression": ""
+                          },
+                          "having": {
+                            "expression": ""
+                          },
+                          "aggregations": [
+                            {
+                              "expression": "sum(_signoz.gen_ai.total_cost)"
+                            }
+                          ]
+                        }
+                      },
+                      {
+                        "type": "builder_formula",
+                        "spec": {
+                          "name": "F1",
+                          "expression": "A + B",
+                          "disabled": false
                         }
                       }
                     ]
@@ -454,7 +482,7 @@
                           "name": "A",
                           "signal": "traces",
                           "stepInterval": 60,
-                          "disabled": false,
+                          "disabled": true,
                           "filter": {
                             "expression": ""
                           },
@@ -474,6 +502,43 @@
                               "expression": "sum(gen_ai.usage.cost)"
                             }
                           ]
+                        }
+                      },
+                      {
+                        "type": "builder_query",
+                        "spec": {
+                          "name": "B",
+                          "signal": "traces",
+                          "stepInterval": 60,
+                          "disabled": true,
+                          "filter": {
+                            "expression": ""
+                          },
+                          "groupBy": [
+                            {
+                              "name": "gen_ai.request.model",
+                              "fieldDataType": "string",
+                              "fieldContext": "tag"
+                            }
+                          ],
+                          "legend": "{{gen_ai.request.model}}",
+                          "having": {
+                            "expression": ""
+                          },
+                          "aggregations": [
+                            {
+                              "expression": "sum(_signoz.gen_ai.total_cost)"
+                            }
+                          ]
+                        }
+                      },
+                      {
+                        "type": "builder_formula",
+                        "spec": {
+                          "name": "F1",
+                          "expression": "A + B",
+                          "disabled": false,
+                          "legend": "{{gen_ai.request.model}}"
                         }
                       }
                     ]

--- a/pkg/telemetryschema/aitelemetryschema/const.go
+++ b/pkg/telemetryschema/aitelemetryschema/const.go
@@ -19,6 +19,7 @@ var (
 		aiobservabilitytypes.GenAIUsageOutputTokens:             genAIAttribute(aiobservabilitytypes.GenAIUsageOutputTokens, telemetrytypes.FieldDataTypeFloat64),
 		aiobservabilitytypes.GenAIUsageCacheReadInputTokens:     genAIAttribute(aiobservabilitytypes.GenAIUsageCacheReadInputTokens, telemetrytypes.FieldDataTypeFloat64),
 		aiobservabilitytypes.GenAIUsageCacheCreationInputTokens: genAIAttribute(aiobservabilitytypes.GenAIUsageCacheCreationInputTokens, telemetrytypes.FieldDataTypeFloat64),
+		aiobservabilitytypes.GenAIUsageCost:                     genAIAttribute(aiobservabilitytypes.GenAIUsageCost, telemetrytypes.FieldDataTypeFloat64),
 		aiobservabilitytypes.SignozGenAITotalCost:               genAIAttribute(aiobservabilitytypes.SignozGenAITotalCost, telemetrytypes.FieldDataTypeFloat64),
 
 		aiobservabilitytypes.GenAIInputMessages:  genAIAttribute(aiobservabilitytypes.GenAIInputMessages, telemetrytypes.FieldDataTypeString),

--- a/pkg/types/aiobservabilitytypes/keys.go
+++ b/pkg/types/aiobservabilitytypes/keys.go
@@ -15,6 +15,7 @@ const (
 	GenAIUsageOutputTokens             = "gen_ai.usage.output_tokens"
 	GenAIUsageCacheReadInputTokens     = "gen_ai.usage.cache_read.input_tokens"
 	GenAIUsageCacheCreationInputTokens = "gen_ai.usage.cache_creation.input_tokens"
+	GenAIUsageCost                     = "gen_ai.usage.cost"
 
 	GenAIInputMessages  = "gen_ai.input.messages"
 	GenAIOutputMessages = "gen_ai.output.messages"


### PR DESCRIPTION
## Description
Aligns the LLM Observability Overview dashboard's **Total cost** and **Cost over time** panels so that they gracefully resolve costs whether emitted via standard OpenTelemetry semantic conventions (`gen_ai.usage.cost`) or calculated by the SigNoz Model Pricing processor (`_signoz.gen_ai.total_cost`).

- Combines both cost sources via formula evaluation (`A + B`).
- Updates `pkg/types/aiobservabilitytypes` and `pkg/telemetryschema/aitelemetryschema` to recognize `gen_ai.usage.cost` in the AI schema.

Fixes #12738