### PR TITLE
fix: reject trailing / in jira urls instead of trimming

### DIFF
--- a/pkg/alertmanager/alertmanagernotify/jira/jira.go
+++ b/pkg/alertmanager/alertmanagernotify/jira/jira.go
@@ -433,7 +433,7 @@ func (n *Notifier) resolveAPIBaseURL(ctx context.Context) (string, bool, error) 
 // resolveCloudID fetches the site's cloud id from its unauthenticated
 // tenant_info endpoint; transport failures are retryable, bad responses are not.
 func (n *Notifier) resolveCloudID(ctx context.Context) (string, bool, error) {
-	url := strings.TrimRight(n.conf.Site, "/") + "/_edge/tenant_info"
+	url := n.conf.Site + "/_edge/tenant_info"
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
 	if err != nil {
 		return "", false, err

--- a/pkg/types/alertmanagertypes/jira.go
+++ b/pkg/types/alertmanagertypes/jira.go
@@ -80,12 +80,18 @@ func (c *JiraReceiverConfig) UnmarshalYAML(unmarshal func(any) error) error {
 		c.Description = DefaultJiraDescriptionTemplate
 	}
 
-	site := strings.TrimRight(strings.TrimSpace(c.Site), "/")
-	u, err := url.Parse(site)
-	if site == "" || err != nil || u.Scheme != "https" || !strings.HasSuffix(strings.ToLower(u.Hostname()), jiraCloudHostSuffix) {
+	// Values are stored and sent exactly as configured, so anything that is
+	// not already canonical is rejected rather than rewritten.
+	if c.Site != strings.TrimSpace(c.Site) {
+		return errors.New(errors.TypeInvalidInput, errors.CodeInvalidInput, "jira site must not have leading or trailing whitespace")
+	}
+	u, err := url.Parse(c.Site)
+	if c.Site == "" || err != nil || u.Scheme != "https" || !strings.HasSuffix(strings.ToLower(u.Hostname()), jiraCloudHostSuffix) {
 		return errors.New(errors.TypeInvalidInput, errors.CodeInvalidInput, fmt.Sprintf("jira site must be a Jira Cloud URL (https://<site>%s)", jiraCloudHostSuffix))
 	}
-	c.Site = site
+	if strings.HasSuffix(c.Site, "/") {
+		return errors.New(errors.TypeInvalidInput, errors.CodeInvalidInput, "jira site must not end with a trailing slash")
+	}
 
 	if c.Project == "" {
 		return errors.New(errors.TypeInvalidInput, errors.CodeInvalidInput, "jira project is required")
@@ -115,5 +121,5 @@ func (c *JiraReceiverConfig) APIBaseURL(cloudID string) string {
 	if cloudID != "" {
 		return fmt.Sprintf("%s%s/rest/api/3", jiraGatewayBaseURL, cloudID)
 	}
-	return fmt.Sprintf("%s/rest/api/3", strings.TrimRight(c.Site, "/"))
+	return fmt.Sprintf("%s/rest/api/3", c.Site)
 }

--- a/pkg/types/alertmanagertypes/jira_test.go
+++ b/pkg/types/alertmanagertypes/jira_test.go
@@ -87,13 +87,6 @@ func TestJiraIsServiceAccount(t *testing.T) {
 	assert.False(t, (&JiraReceiverConfig{}).IsServiceAccount())
 }
 
-func TestJiraReceiverConfigTrailingSlashSite(t *testing.T) {
-	r, err := NewReceiver(jiraReceiverJSON("https://acme.atlassian.net/", "KAN", "Task", true))
-	require.NoError(t, err)
-	assert.Equal(t, "https://acme.atlassian.net", r.JiraConfigs[0].Site)
-	assert.Equal(t, "https://acme.atlassian.net/rest/api/3", r.JiraConfigs[0].APIBaseURL(""))
-}
-
 func TestJiraReceiverConfigValidation(t *testing.T) {
 	cases := []struct {
 		name string
@@ -104,6 +97,8 @@ func TestJiraReceiverConfigValidation(t *testing.T) {
 		{"non-cloud host", jiraReceiverJSON("https://jira.acme.com", "KAN", "Task", true)},
 		{"lookalike host suffix", jiraReceiverJSON("https://www.iamnotatlassian.net", "KAN", "Task", true)},
 		{"bare atlassian.net", jiraReceiverJSON("https://atlassian.net", "KAN", "Task", true)},
+		{"trailing slash site", jiraReceiverJSON("https://acme.atlassian.net/", "KAN", "Task", true)},
+		{"padded site", jiraReceiverJSON(" https://acme.atlassian.net ", "KAN", "Task", true)},
 		{"missing project", jiraReceiverJSON("https://acme.atlassian.net", "", "Task", true)},
 		{"missing issue_type", jiraReceiverJSON("https://acme.atlassian.net", "KAN", "", true)},
 		{"missing basic auth", jiraReceiverJSON("https://acme.atlassian.net", "KAN", "Task", false)},


### PR DESCRIPTION
<!--A few plain bullets saying what changed and why, for a reviewer skimming it - not a wall of text, not a restatement of the diff, not generated boilerplate.-->
#### Description

This is so that a round trip drift doesn't happen. This was caught for incident io in its PR but we missed it out here.

<!--Anything reviewers should keep in mind while reviewing -->
#### Additional Information

Found as a part of round trip testing in v2 notification channels create API

<!--Please delete paragraphs that you did not use before submitting.-->
