### PR TITLE
fix(rules): propagate initiate error from Manager.Start and ruler provider

### DIFF
--- a/pkg/query-service/rules/manager.go
+++ b/pkg/query-service/rules/manager.go
@@ -223,11 +223,12 @@ func NewManager(o *ManagerOptions) (*Manager, error) {
 	return m, nil
 }
 
-func (m *Manager) Start(ctx context.Context) {
+func (m *Manager) Start(ctx context.Context) error {
 	if err := m.initiate(ctx); err != nil {
-		m.logger.ErrorContext(ctx, "failed to initialize alerting rules manager", errors.Attr(err))
+		return err
 	}
 	m.run(ctx)
+	return nil
 }
 
 func (m *Manager) RuleStore() ruletypes.RuleStore {

--- a/pkg/query-service/rules/manager_start_test.go
+++ b/pkg/query-service/rules/manager_start_test.go
@@ -1,0 +1,72 @@
+package rules
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/SigNoz/signoz/pkg/modules/organization"
+	"github.com/SigNoz/signoz/pkg/types"
+	"github.com/SigNoz/signoz/pkg/valuer"
+	"github.com/stretchr/testify/require"
+)
+
+type stubOrgGetter struct {
+	orgs []*types.Organization
+	err  error
+}
+
+func (s *stubOrgGetter) Get(context.Context, valuer.UUID) (*types.Organization, error) {
+	return nil, s.err
+}
+
+func (s *stubOrgGetter) GetByIDOrName(context.Context, valuer.UUID, string) (*types.Organization, bool, error) {
+	return nil, false, s.err
+}
+
+func (s *stubOrgGetter) ListByOwnedKeyRange(context.Context) ([]*types.Organization, error) {
+	if s.err != nil {
+		return nil, s.err
+	}
+	return s.orgs, nil
+}
+
+func (s *stubOrgGetter) GetByName(context.Context, string) (*types.Organization, error) {
+	return nil, s.err
+}
+
+var _ organization.Getter = (*stubOrgGetter)(nil)
+
+func TestManager_Start_PropagatesInitiateError(t *testing.T) {
+	boom := errors.New("telemetry store unreachable")
+	mgr := NewTestManager(t, &TestManagerOptions{
+		ManagerOptionsHook: func(opts *ManagerOptions) {
+			opts.OrgGetter = &stubOrgGetter{err: boom}
+		},
+	})
+
+	err := mgr.Start(context.Background())
+	require.ErrorIs(t, err, boom)
+
+	select {
+	case <-mgr.block:
+		t.Fatal("run must not unblock tasks when initiate fails")
+	default:
+	}
+}
+
+func TestManager_Start_SucceedsWhenInitiateSucceeds(t *testing.T) {
+	mgr := NewTestManager(t, &TestManagerOptions{
+		ManagerOptionsHook: func(opts *ManagerOptions) {
+			opts.OrgGetter = &stubOrgGetter{orgs: []*types.Organization{}}
+		},
+	})
+
+	require.NoError(t, mgr.Start(context.Background()))
+
+	select {
+	case <-mgr.block:
+	default:
+		t.Fatal("run must unblock tasks once initiate succeeds")
+	}
+}

--- a/pkg/ruler/signozruler/provider.go
+++ b/pkg/ruler/signozruler/provider.go
@@ -78,7 +78,9 @@ func NewFactory(
 }
 
 func (provider *provider) Start(ctx context.Context) error {
-	provider.manager.Start(ctx)
+	if err := provider.manager.Start(ctx); err != nil {
+		return err
+	}
 	close(provider.healthyC)
 	<-provider.stopC
 	return nil


### PR DESCRIPTION
Fixes #12565

Problem
Manager.Start calls initiate(ctx) to load rule groups and queue tasks, but on failure it only logs and falls through to run(ctx). The rules manager then runs in a degraded state with no tasks or configs loaded, while the registry still observes the ruler service as healthy and reports Ready. Alerts silently never fire.

Root cause
Manager.Start returns nothing, so the initiate error is lost at the call site. On top of that, signozruler provider.Start ignores the (non-existent) result, closes healthyC and returns nil, so pkg/factory registry marks the service StateRunning and Wait never sees a failure.

Fix
- rules.Manager.Start now returns error: initiate failure is returned before run is entered, so blocked tasks are never unblocked in a half-initialized manager.
- signozruler provider.Start propagates the error and returns before closing healthyC, so the registry marks the ruler StateFailed and exits, consistent with every other Start error path.

Regression test
- pkg/query-service/rules/manager_start_test.go: failing OrgGetter makes initiate return a sentinel error; asserts Start returns it (ErrorIs) and that run did not unblock tasks. Success case asserts nil error and unblocked tasks.
- Mutant check: restoring return nil makes TestManager_Start_PropagatesInitiateError fail with expected error in chain but got nil.

Verification
- gofmt clean on touched files
- go vet ./pkg/query-service/rules/ ./pkg/ruler/signozruler/
- go test ./pkg/query-service/rules/ -run TestManager_Start_ -v -count=1 (pass)
- go test ./pkg/query-service/rules/ ./pkg/ruler/... ./pkg/factory/... -count=1 (pass)
- Note: repo go.mod pins go 1.25.7; validated with GOTOOLCHAIN=go1.25.7 since the default go1.26.5 toolchain breaks the unrelated bytedance/sonic dependency at build time.

Scope
- Only caller of Manager.Start in the tree is the provider, updated together. No interface or mock changes. No behavior change when initiate succeeds.