### PR TITLE
chore: add type for strings that should be unset or non empty

### DIFF
--- a/pkg/valuer/unset_or_non_empty_string.go
+++ b/pkg/valuer/unset_or_non_empty_string.go
@@ -1,0 +1,113 @@
+package valuer
+
+import (
+	"database/sql/driver"
+	"encoding/json"
+
+	"github.com/SigNoz/signoz/pkg/errors"
+)
+
+var _ Valuer = (*UnsetOrNonEmptyString)(nil)
+
+// UnsetOrNonEmptyString separates a field left out of the input from one
+// explicitly set to "". Decoding rejects "", and json calls UnmarshalJSON only
+// for a field that is present, so a field holding "" is a field nobody set.
+type UnsetOrNonEmptyString struct {
+	val string
+}
+
+func NewUnsetOrNonEmptyString(val string) (UnsetOrNonEmptyString, error) {
+	if val == "" {
+		return UnsetOrNonEmptyString{}, errors.Newf(errors.TypeInvalidInput, ErrCodeInvalidValuer, "string must not be empty")
+	}
+
+	return UnsetOrNonEmptyString{val: val}, nil
+}
+
+func MustNewUnsetOrNonEmptyString(val string) UnsetOrNonEmptyString {
+	nonEmptyString, err := NewUnsetOrNonEmptyString(val)
+	if err != nil {
+		panic(err)
+	}
+
+	return nonEmptyString
+}
+
+func (enum UnsetOrNonEmptyString) IsZero() bool {
+	return enum.val == ""
+}
+
+func (enum UnsetOrNonEmptyString) StringValue() string {
+	return enum.val
+}
+
+func (enum UnsetOrNonEmptyString) String() string {
+	return enum.val
+}
+
+func (enum UnsetOrNonEmptyString) MarshalJSON() ([]byte, error) {
+	return json.Marshal(enum.StringValue())
+}
+
+func (enum *UnsetOrNonEmptyString) UnmarshalJSON(data []byte) error {
+	var str string
+	if err := json.Unmarshal(data, &str); err != nil {
+		return err
+	}
+
+	var err error
+	*enum, err = NewUnsetOrNonEmptyString(str)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (enum UnsetOrNonEmptyString) Value() (driver.Value, error) {
+	return enum.StringValue(), nil
+}
+
+func (enum *UnsetOrNonEmptyString) Scan(val any) error {
+	if enum == nil {
+		return errors.Newf(errors.TypeInternal, ErrCodeUnknownValuerScan, "unset_or_non_empty_string: (nil \"%T\")", enum)
+	}
+
+	str, ok := val.(string)
+	if !ok {
+		return errors.Newf(errors.TypeInternal, ErrCodeUnknownValuerScan, "unset_or_non_empty_string: (non-string \"%T\")", val)
+	}
+
+	var err error
+	*enum, err = NewUnsetOrNonEmptyString(str)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (enum *UnsetOrNonEmptyString) UnmarshalText(text []byte) error {
+	var err error
+	*enum, err = NewUnsetOrNonEmptyString(string(text))
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (enum UnsetOrNonEmptyString) MarshalText() (text []byte, err error) {
+	return []byte(enum.StringValue()), nil
+}
+
+func (enum *UnsetOrNonEmptyString) UnmarshalParam(param string) error {
+	nonEmptyString, err := NewUnsetOrNonEmptyString(param)
+	if err != nil {
+		return err
+	}
+
+	*enum = nonEmptyString
+
+	return nil
+}

--- a/pkg/valuer/unset_or_non_empty_string_test.go
+++ b/pkg/valuer/unset_or_non_empty_string_test.go
@@ -1,0 +1,92 @@
+package valuer
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewUnsetOrNonEmptyString(t *testing.T) {
+	testCases := []struct {
+		description     string
+		value           string
+		expectedError   bool
+		expectedWrapped UnsetOrNonEmptyString
+	}{
+		{description: "plain value", value: "oncall", expectedWrapped: UnsetOrNonEmptyString{val: "oncall"}},
+		{description: "case and surrounding space are kept", value: "  On Call  ", expectedWrapped: UnsetOrNonEmptyString{val: "  On Call  "}},
+		{description: "whitespace alone is not empty", value: " ", expectedWrapped: UnsetOrNonEmptyString{val: " "}},
+		{description: "empty", value: "", expectedError: true},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.description, func(t *testing.T) {
+			nonEmptyString, err := NewUnsetOrNonEmptyString(testCase.value)
+			if testCase.expectedError {
+				assert.Error(t, err)
+				return
+			}
+
+			require.NoError(t, err)
+			assert.Equal(t, testCase.expectedWrapped, nonEmptyString)
+		})
+	}
+}
+
+func TestUnsetOrNonEmptyStringUnmarshalJSONRejectsAnEmptyString(t *testing.T) {
+	var target struct {
+		Title UnsetOrNonEmptyString `json:"title"`
+	}
+
+	require.NoError(t, json.Unmarshal([]byte(`{"title":"Alert"}`), &target))
+	assert.Equal(t, "Alert", target.Title.StringValue())
+
+	assert.Error(t, json.Unmarshal([]byte(`{"title":""}`), &target))
+}
+
+// The zero value is the only way an empty UnsetOrNonEmptyString comes about, and it is
+// what lets a caller omit the field and take a default filled in elsewhere.
+func TestUnsetOrNonEmptyStringUnmarshalJSONLeavesAnAbsentFieldZero(t *testing.T) {
+	var target struct {
+		Title UnsetOrNonEmptyString `json:"title"`
+	}
+
+	require.NoError(t, json.Unmarshal([]byte(`{}`), &target))
+	assert.True(t, target.Title.IsZero())
+}
+
+func TestUnsetOrNonEmptyStringMarshalJSON(t *testing.T) {
+	raw, err := json.Marshal(MustNewUnsetOrNonEmptyString("Alert"))
+	require.NoError(t, err)
+	assert.JSONEq(t, `"Alert"`, string(raw))
+}
+
+func TestUnsetOrNonEmptyStringScanRejectsAnEmptyString(t *testing.T) {
+	var nonEmptyString UnsetOrNonEmptyString
+
+	require.NoError(t, nonEmptyString.Scan("oncall"))
+	assert.Equal(t, "oncall", nonEmptyString.StringValue())
+
+	assert.Error(t, nonEmptyString.Scan(""))
+	assert.Error(t, nonEmptyString.Scan(nil))
+}
+
+func TestUnsetOrNonEmptyStringUnmarshalTextRejectsAnEmptyString(t *testing.T) {
+	var nonEmptyString UnsetOrNonEmptyString
+
+	require.NoError(t, nonEmptyString.UnmarshalText([]byte("oncall")))
+	assert.Equal(t, "oncall", nonEmptyString.StringValue())
+
+	assert.Error(t, nonEmptyString.UnmarshalText([]byte("")))
+}
+
+func TestUnsetOrNonEmptyStringUnmarshalParamRejectsAnEmptyString(t *testing.T) {
+	var nonEmptyString UnsetOrNonEmptyString
+
+	require.NoError(t, nonEmptyString.UnmarshalParam("oncall"))
+	assert.Equal(t, "oncall", nonEmptyString.StringValue())
+
+	assert.Error(t, nonEmptyString.UnmarshalParam(""))
+}


### PR DESCRIPTION
<!--A few plain bullets saying what changed and why, for a reviewer skimming it - not a wall of text, not a restatement of the diff, not generated boilerplate.-->
#### Description

If an API request body has a field that cannot be empty, but backend can fill in a default value for it, then backend should fill that default value only when the field is omitted in the request. If the user has explicitly sent `""`, then backend should reject it so that there is no request-response drift.

Such fields can be typed as the new `UnsetOrNonEmptyString` which has custom unmarshalling logic. If the field is set in the request json, then the custom unmarshal logic is called and explicit `""` is rejected. If the field is not set, then the function is not called, and further backend logic is free to fill in the default value.

<!--Anything reviewers should keep in mind while reviewing -->
#### Additional Information

Came out of notification channels V2 API work.

<!--Please delete paragraphs that you did not use before submitting.-->
