### PR TITLE
fix(query-builder): stop the panel-type field list growing on every change

### DIFF
--- a/frontend/src/constants/queryBuilder.ts
+++ b/frontend/src/constants/queryBuilder.ts
@@ -601,18 +601,6 @@ export const listViewInitialLogQuery: Query = {
 	},
 };
 
-export const PANEL_TYPES_INITIAL_QUERY: Record<PANEL_TYPES, Query> = {
-	[PANEL_TYPES.TIME_SERIES]: initialQueriesMap.metrics,
-	[PANEL_TYPES.VALUE]: initialQueriesMap.metrics,
-	[PANEL_TYPES.TABLE]: initialQueriesMap.metrics,
-	[PANEL_TYPES.LIST]: listViewInitialLogQuery,
-	[PANEL_TYPES.TRACE]: initialQueriesMap.traces,
-	[PANEL_TYPES.BAR]: initialQueriesMap.metrics,
-	[PANEL_TYPES.PIE]: initialQueriesMap.metrics,
-	[PANEL_TYPES.HISTOGRAM]: initialQueriesMap.metrics,
-	[PANEL_TYPES.EMPTY_WIDGET]: initialQueriesMap.metrics,
-};
-
 export const listViewInitialTraceQuery: Query = {
 	// it should be the above commented query
 	...initialQueriesMap.traces,

--- a/frontend/src/providers/QueryBuilder.tsx
+++ b/frontend/src/providers/QueryBuilder.tsx
@@ -766,10 +766,15 @@ export function QueryBuilderProvider({
 							queryItem.dataSource
 						].builder.queryData;
 
-					propsRequired?.push('dataSource');
-					propsRequired?.forEach((p: any) => {
-						set(queryItem, p, get(newQueryItem, p));
-					});
+					// `dataSource` travels with the panel type's fields, but is appended to a
+					// copy: `propsRequired` is the list held in
+					// `panelTypeDataSourceFormValuesMap`, and pushing onto it grew that
+					// module-level array by one entry on every call.
+					if (propsRequired) {
+						[...propsRequired, 'dataSource'].forEach((p: any) => {
+							set(queryItem, p, get(newQueryItem, p));
+						});
+					}
 					return queryItem;
 				}
 

--- a/frontend/src/types/common/queryBuilder.ts
+++ b/frontend/src/types/common/queryBuilder.ts
@@ -211,13 +211,11 @@ export enum QueryFunctionsTypes {
 	FILL_ZERO = 'fillZero',
 }
 
-export type PanelTypeKeys =
-	| 'TIME_SERIES'
-	| 'VALUE'
-	| 'TABLE'
-	| 'LIST'
-	| 'TRACE'
-	| 'EMPTY_WIDGET';
+/**
+ * Key names of {@link PANEL_TYPES}. Derived rather than listed: the hand-written
+ * version had fallen behind the enum by three members (`BAR`, `PIE`, `HISTOGRAM`).
+ */
+export type PanelTypeKeys = keyof typeof PANEL_TYPES;
 
 export enum ReduceOperators {
 	LAST = 'last',


### PR DESCRIPTION
#### Description

`updateSuperSetQueryBuilderData` appended `dataSource` to the field list with `propsRequired?.push('dataSource')`. That list is the array held inside `panelTypeDataSourceFormValuesMap`, so the module-level table grew by one entry **on every query-builder change**, unbounded for the life of the page. It was harmless only because the assignment it drives is idempotent — `set(queryItem, 'dataSource', …)` writes the same value each time.

The field now travels on a copy. The guard stays an `if` rather than defaulting to an empty list, because the previous optional chaining meant a panel type outside the builder set copied *nothing at all*, `dataSource` included — defaulting would have changed that.

Two neighbours in the same area came along, both no-ops:

- **`PANEL_TYPES_INITIAL_QUERY` deleted** — it had exactly one reference in the repo, its own definition.
- **`PanelTypeKeys` derived** — it was a hand-written union of the enum's key names that had fallen three members behind (`BAR`, `PIE`, `HISTOGRAM`), and is now `keyof typeof PANEL_TYPES`.

#### Additional Information

- Nothing relied on the stale union: `useChartMutable` builds its key array via `[].slice.call(Object.keys(PANEL_TYPES))`, which is untyped, so all nine keys were already present at runtime and `BAR`/`PIE`/`HISTOGRAM` resolved correctly. The union was a type-level lie with no behavioural effect, and nothing consumes it exhaustively — two component props and that one `.find`.
- Verified with `tsgo`, `oxlint`, and the `providers` / `lib` / `hooks` / `WidgetCard` / Logs+Traces+Metrics explorer / `EmptyLogsSearch` / `DashboardPage` suites: **303 suites, 2442 tests**. The jest run needs `--runInBand` to be trustworthy on a loaded machine.
- Merge-order note: #12742 adds a `TEXT` entry to `PANEL_TYPES_INITIAL_QUERY`. Whichever of the two merges second will see that hunk conflict — resolution is to keep the deletion here, which makes #12742 one entry smaller.