### PR TITLE
fix(billing): keep spacing and link styling consistent when permissions are denied

### DIFF
--- a/frontend/src/container/AppLayout/AppLayout.styles.scss
+++ b/frontend/src/container/AppLayout/AppLayout.styles.scss
@@ -184,6 +184,11 @@
 		text-decoration-thickness: 2px;
 		text-underline-offset: 2px;
 	}
+
+	&[disabled] {
+		opacity: 0.6;
+		text-decoration: none;
+	}
 }
 
 .workspace-restricted-banner,

--- a/frontend/src/container/AppLayout/index.tsx
+++ b/frontend/src/container/AppLayout/index.tsx
@@ -16,7 +16,6 @@ import * as Sentry from '@sentry/react';
 import { Toaster } from '@signozhq/ui/sonner';
 import { TooltipProvider } from '@signozhq/ui/tooltip';
 import { Flex } from 'antd';
-import { Button } from '@signozhq/ui/button';
 import getLocalStorageApi from 'api/browser/localstorage/get';
 import setLocalStorageApi from 'api/browser/localstorage/set';
 import getChangelogByVersion from 'api/changelog/getChangelogByVersion';
@@ -820,14 +819,9 @@ function AppLayout(props: AppLayoutProps): JSX.Element {
 									{' '}
 									Please{' '}
 									<AuthZTooltip checks={SubscriptionManagePermissions}>
-										<Button
-											variant="link"
-											color="none"
-											className="upgrade-link"
-											onClick={handleFailedPayment}
-										>
+										<a className="upgrade-link" onClick={handleFailedPayment}>
 											pay the bill
-										</Button>
+										</a>
 									</AuthZTooltip>
 									to continue using SigNoz features.
 									<span className="refresh-payment-status">

--- a/frontend/src/container/BillingContainer/BillingContainer.module.scss
+++ b/frontend/src/container/BillingContainer/BillingContainer.module.scss
@@ -60,6 +60,10 @@
 		margin: var(--spacing-12) var(--spacing-4);
 	}
 
+	.usageDenied {
+		margin-bottom: var(--spacing-4);
+	}
+
 	.billingDetails {
 		margin: var(--spacing-4) 0;
 		border: 1px solid var(--l1-border);

--- a/frontend/src/container/BillingContainer/BillingContainer.tsx
+++ b/frontend/src/container/BillingContainer/BillingContainer.tsx
@@ -37,6 +37,7 @@ import { isEmpty, pick } from 'lodash-es';
 import AuthZButton from 'lib/authz/components/AuthZButton/AuthZButton';
 import AuthZTooltip from 'lib/authz/components/AuthZTooltip/AuthZTooltip';
 import { AuthZGuardContent } from 'lib/authz/components/AuthZGuard/AuthZGuardContent';
+import PermissionDeniedCallout from 'lib/authz/components/PermissionDeniedCallout/PermissionDeniedCallout';
 import {
 	SubscriptionCreatePermission,
 	SubscriptionManagePermissions,
@@ -509,7 +510,15 @@ export default function BillingContainer(): JSX.Element {
 					))}
 			</Card>
 
-			<AuthZGuardContent checks={[SubscriptionReadPermission]}>
+			<AuthZGuardContent
+				checks={[SubscriptionReadPermission]}
+				fallback={({ deniedPermissions }): JSX.Element => (
+					<PermissionDeniedCallout
+						deniedPermissions={deniedPermissions}
+						className={styles.usageDenied}
+					/>
+				)}
+			>
 				<>
 					<div className={styles.billingGraphSection}>
 						{!isLoading && !isFetchingBillingData ? (


### PR DESCRIPTION
#### Description

- The denied usage callout on the billing page keeps the same 8px gap to the blocks below it that the usage table has, so the layout reads the same with or without `subscription:read`.
- "pay the bill" in the failed-payment banner is an inline link again, with a visible disabled state when the user lacks permission.

#### Additional Information

Part of SigNoz/platform-pod#3091.
