### PR TITLE
feat(infra-monitoring): add cluster-wide Kubernetes events view

### DIFF
--- a/frontend/src/container/InfraMonitoringK8sV2/Base/K8sDynamicList.tsx
+++ b/frontend/src/container/InfraMonitoringK8sV2/Base/K8sDynamicList.tsx
@@ -1,5 +1,7 @@
 import { useMemo } from 'react';
 
+import { K8sCategories } from '../constants';
+import K8sEventsList from '../Events/K8sEventsList';
 import { useInfraMonitoringCategory } from '../hooks';
 import { getEntityConfig } from './entity.registry';
 import { K8sBaseList } from './K8sBaseList';
@@ -20,6 +22,12 @@ export function K8sDynamicList({
 		() => getEntityConfig(selectedCategory),
 		[selectedCategory],
 	);
+
+	// Events are logs rather than a metrics-backed entity, so they have no
+	// registry entry and render their own list instead of list + details.
+	if (selectedCategory === K8sCategories.EVENTS) {
+		return <K8sEventsList controlListPrefix={controlListPrefix} />;
+	}
 
 	if (!config) {
 		return null;

--- a/frontend/src/container/InfraMonitoringK8sV2/Events/EventDetailsRow.tsx
+++ b/frontend/src/container/InfraMonitoringK8sV2/Events/EventDetailsRow.tsx
@@ -1,0 +1,16 @@
+import { EventContents } from '../EntityDetailsUtils/EntityEvents/EventsContent';
+import { K8sEventRow } from './types';
+
+interface EventDetailsRowProps {
+	record: K8sEventRow;
+}
+
+function EventDetailsRow({ record }: EventDetailsRowProps): JSX.Element {
+	return (
+		<EventContents
+			data={{ ...record.attributes_string, ...record.resources_string }}
+		/>
+	);
+}
+
+export default EventDetailsRow;

--- a/frontend/src/container/InfraMonitoringK8sV2/Events/EventObjectCell.tsx
+++ b/frontend/src/container/InfraMonitoringK8sV2/Events/EventObjectCell.tsx
@@ -1,0 +1,35 @@
+import { K8sEventRow } from './types';
+import { getEventDrillDownTarget } from './utils';
+
+import styles from './K8sEventsList.module.scss';
+
+interface EventObjectCellProps {
+	record: K8sEventRow;
+	onDrillDown: (record: K8sEventRow) => void;
+}
+
+/**
+ * Kinds without a details drawer — and Pod events missing `k8s.object.uid` —
+ * render as plain text rather than a dead link.
+ */
+function EventObjectCell({
+	record,
+	onDrillDown,
+}: EventObjectCellProps): JSX.Element {
+	if (!getEventDrillDownTarget(record)) {
+		return <span>{record.objectName || '—'}</span>;
+	}
+
+	return (
+		<button
+			type="button"
+			className={styles.objectLink}
+			onClick={(): void => onDrillDown(record)}
+			data-testid={`k8s-events-object-${record.id}`}
+		>
+			{record.objectName}
+		</button>
+	);
+}
+
+export default EventObjectCell;

--- a/frontend/src/container/InfraMonitoringK8sV2/Events/EventsExpandIcon.tsx
+++ b/frontend/src/container/InfraMonitoringK8sV2/Events/EventsExpandIcon.tsx
@@ -1,0 +1,38 @@
+import React from 'react';
+import { ChevronDown, ChevronRight } from '@signozhq/icons';
+
+import { K8sEventRow } from './types';
+
+import styles from './K8sEventsList.module.scss';
+
+interface EventsExpandIconProps {
+	expanded: boolean;
+	record: K8sEventRow;
+	onExpand: (
+		record: K8sEventRow,
+		e: React.MouseEvent<HTMLElement, MouseEvent>,
+	) => void;
+}
+
+function EventsExpandIcon({
+	expanded,
+	record,
+	onExpand,
+}: EventsExpandIconProps): JSX.Element {
+	const handleClick = (e: React.MouseEvent<SVGSVGElement>): void => {
+		onExpand(record, e as unknown as React.MouseEvent<HTMLElement, MouseEvent>);
+	};
+
+	const Icon = expanded ? ChevronDown : ChevronRight;
+
+	return (
+		<Icon
+			className={styles.expandIcon}
+			size={14}
+			onClick={handleClick}
+			data-testid={`k8s-events-expand-${record.id}`}
+		/>
+	);
+}
+
+export default EventsExpandIcon;

--- a/frontend/src/container/InfraMonitoringK8sV2/Events/K8sEventsList.module.scss
+++ b/frontend/src/container/InfraMonitoringK8sV2/Events/K8sEventsList.module.scss
@@ -1,0 +1,131 @@
+.container {
+	display: flex;
+	flex-direction: column;
+	padding: var(--spacing-4);
+	gap: var(--spacing-4);
+	width: 100%;
+}
+
+.controlsRow {
+	display: flex;
+	gap: var(--spacing-4);
+	width: 100%;
+	align-items: center;
+	justify-content: flex-end;
+}
+
+.dateTimeSelection {
+	margin-left: auto;
+	display: flex;
+	justify-content: flex-end;
+
+	--date-time-selector-border-color: var(--l2-border);
+
+	:global(.timeSelection-input) {
+		height: 32px;
+	}
+
+	:global(.ant-input-affix-wrapper) {
+		border-color: var(--l2-border);
+
+		&:hover {
+			border-color: var(--l2-border) !important;
+		}
+	}
+
+	:global(.refresh-actions .ant-form-item-control-input) {
+		&,
+		:global(.ant-btn) {
+			height: 30px;
+			min-height: unset;
+		}
+	}
+}
+
+.querySearch {
+	width: 100%;
+}
+
+.controls {
+	width: 100%;
+	display: flex;
+	justify-content: flex-end;
+}
+
+.isWarning {
+	color: var(--callout-warning-title);
+	font-weight: 500;
+}
+
+.isNormal {
+	color: var(--l2-foreground);
+}
+
+.objectLink {
+	padding: 0;
+	border: none;
+	background: none;
+	cursor: pointer;
+	color: var(--primary);
+	font: inherit;
+	text-align: left;
+
+	&:hover {
+		text-decoration: underline;
+	}
+}
+
+.expandIcon {
+	cursor: pointer;
+}
+
+.eventsTable {
+	:global(.ant-table) {
+		:global(.ant-table-thead) > tr > th {
+			padding: 12px;
+			font-size: 11px;
+			line-height: 18px;
+			background: var(--card);
+			border-bottom: none;
+			color: var(--l2-foreground);
+			font-family: Inter;
+			font-style: normal;
+			font-weight: 600;
+			letter-spacing: 0.44px;
+			text-transform: uppercase;
+
+			&::before {
+				background-color: transparent;
+			}
+		}
+
+		:global(.ant-table-cell) {
+			padding: 12px;
+			font-size: 13px;
+			line-height: 20px;
+			color: var(--l1-foreground);
+			background: var(--card);
+			border-bottom: none;
+		}
+
+		:global(.ant-table-tbody) > tr:hover > td {
+			background: color-mix(in srgb, var(--l1-foreground) 4%, transparent);
+		}
+
+		:global(.ant-table-tbody) > tr > td {
+			border-bottom: none;
+		}
+
+		:global(.ant-table-thead)
+			> tr
+			> th:not(:last-child):not(:global(.ant-table-selection-column)):not(
+				:global(.ant-table-row-expand-icon-cell)
+			):not([colspan])::before {
+			background-color: transparent;
+		}
+
+		:global(.ant-empty-normal) {
+			visibility: hidden;
+		}
+	}
+}

--- a/frontend/src/container/InfraMonitoringK8sV2/Events/K8sEventsList.tsx
+++ b/frontend/src/container/InfraMonitoringK8sV2/Events/K8sEventsList.tsx
@@ -1,0 +1,205 @@
+import React, { useEffect } from 'react';
+import { Table } from 'antd';
+import {
+	QuerySearchV2Provider,
+	useExpression,
+	useQuerySearchInitialExpressionProp,
+	useQuerySearchOnChange,
+	useUserExpression,
+} from 'components/QueryBuilderV2';
+import QuerySearch from 'components/QueryBuilderV2/QueryV2/QuerySearch/QuerySearch';
+import Controls from 'container/Controls';
+import RunQueryBtn from 'container/QueryBuilder/components/RunQueryBtn/RunQueryBtn';
+import DateTimeSelectionV2 from 'container/TopNav/DateTimeSelectionV2';
+import { useQueryState } from 'nuqs';
+import { DataSource } from 'types/common/queryBuilder';
+import { parseAsJsonNoValidate } from 'utils/nuqsParsers';
+
+import EntityEmptyState from '../EntityDetailsUtils/EntityEmptyState/EntityEmptyState';
+import EntityError from '../EntityDetailsUtils/EntityError/EntityError';
+import EventsNotConfigured from '../EntityDetailsUtils/EntityEvents/EventsNotConfigured';
+import {
+	getEntityEventsQueryPayload,
+	isEventsKeyNotFoundError,
+} from '../EntityDetailsUtils/EntityEvents/utils';
+import LoadingContainer from '../LoadingContainer';
+import EventDetailsRow from './EventDetailsRow';
+import EventsExpandIcon from './EventsExpandIcon';
+import {
+	K8S_EVENTS_BASE_EXPRESSION,
+	K8S_EVENTS_EXPRESSION_KEY,
+	K8S_EVENTS_FILTER_PLACEHOLDER,
+	K8S_EVENTS_PAGE_SIZE_OPTIONS,
+	K8S_EVENTS_PAGINATION_KEY,
+} from './constants';
+import { K8sEventRow } from './types';
+import { useK8sEvents } from './useK8sEvents';
+import { useK8sEventsCallbacks } from './useK8sEventsCallbacks';
+import { useK8sEventsColumns } from './useK8sEventsColumns';
+import { useK8sEventsTimeRange } from './useK8sEventsTimeRange';
+
+import styles from './K8sEventsList.module.scss';
+
+interface K8sEventsListProps {
+	controlListPrefix?: React.ReactNode;
+}
+
+function K8sEventsListContent({
+	controlListPrefix,
+}: K8sEventsListProps): JSX.Element {
+	const timeRange = useK8sEventsTimeRange();
+	const expression = useExpression();
+	const userExpression = useUserExpression();
+	const querySearchOnChange = useQuerySearchOnChange();
+	const querySearchInitialExpressionProp = useQuerySearchInitialExpressionProp();
+
+	const [pagination, setPagination] = useQueryState(
+		K8S_EVENTS_PAGINATION_KEY,
+		parseAsJsonNoValidate<{ offset: number; limit: number }>(),
+	);
+
+	const pageSize = pagination?.limit || K8S_EVENTS_PAGE_SIZE_OPTIONS[0];
+	const offset = pagination?.offset || 0;
+
+	const {
+		events,
+		isLoading,
+		isFetching,
+		isError,
+		error,
+		currentCount,
+		hasMore,
+		refetch,
+		cancel,
+	} = useK8sEvents({ expression, offset, pageSize });
+
+	const { handleRunQuery, handleDrillDown } = useK8sEventsCallbacks({
+		pageSize,
+		refetch,
+		setPagination,
+	});
+
+	const columns = useK8sEventsColumns(handleDrillDown);
+
+	useEffect(
+		() => (): void => {
+			void setPagination(null);
+		},
+		[setPagination],
+	);
+
+	const isDataEmpty =
+		!isLoading && !isFetching && !isError && events.length === 0;
+	const isKeyNotFound = isEventsKeyNotFoundError(error);
+
+	return (
+		<div className={styles.container} data-testid="k8s-events-list">
+			<div className={styles.controlsRow}>
+				{controlListPrefix}
+
+				<div className={styles.dateTimeSelection}>
+					<DateTimeSelectionV2
+						showAutoRefresh
+						showRefreshText={false}
+						hideShareModal
+						defaultRelativeTime="30m"
+					/>
+				</div>
+
+				<RunQueryBtn
+					isLoadingQueries={isFetching}
+					onStageRunQuery={(): void => handleRunQuery()}
+					handleCancelQuery={cancel}
+				/>
+			</div>
+
+			<div className={styles.querySearch}>
+				<QuerySearch
+					onChange={querySearchOnChange}
+					queryData={
+						getEntityEventsQueryPayload({
+							start: timeRange.startTime,
+							end: timeRange.endTime,
+							expression: userExpression || '',
+						}).queryData
+					}
+					dataSource={DataSource.LOGS}
+					onRun={handleRunQuery}
+					initialExpression={querySearchInitialExpressionProp}
+					placeholder={K8S_EVENTS_FILTER_PLACEHOLDER}
+				/>
+			</div>
+
+			{isLoading && events.length === 0 && <LoadingContainer />}
+
+			{isDataEmpty && <EntityEmptyState hasFilters={!!userExpression?.trim()} />}
+
+			{isError && !isLoading && isKeyNotFound && <EventsNotConfigured />}
+
+			{isError && !isLoading && !isKeyNotFound && <EntityError />}
+
+			{!isLoading && !isError && events.length > 0 && (
+				<div className={styles.eventsTable}>
+					<div className={styles.controls}>
+						<Controls
+							totalCount={hasMore ? currentCount + 1 : currentCount}
+							countPerPage={pageSize}
+							offset={offset}
+							perPageOptions={K8S_EVENTS_PAGE_SIZE_OPTIONS}
+							isLoading={isFetching}
+							handleNavigatePrevious={(): void => {
+								void setPagination({
+									offset: Math.max(0, offset - pageSize),
+									limit: pageSize,
+								});
+							}}
+							handleNavigateNext={(): void => {
+								void setPagination({
+									offset: offset + pageSize,
+									limit: pageSize,
+								});
+							}}
+							handleCountItemsPerPageChange={(value): void => {
+								void setPagination({ offset: 0, limit: value });
+							}}
+						/>
+					</div>
+
+					<Table<K8sEventRow>
+						loading={isFetching && events.length === 0}
+						columns={columns}
+						expandable={{
+							expandedRowRender: (record): JSX.Element => (
+								<EventDetailsRow record={record} />
+							),
+							expandIcon: ({ expanded, onExpand, record }): JSX.Element => (
+								<EventsExpandIcon
+									expanded={expanded}
+									onExpand={onExpand}
+									record={record}
+								/>
+							),
+						}}
+						dataSource={events}
+						pagination={false}
+						rowKey={(record): string => record.id}
+					/>
+				</div>
+			)}
+		</div>
+	);
+}
+
+function K8sEventsList({ controlListPrefix }: K8sEventsListProps): JSX.Element {
+	return (
+		<QuerySearchV2Provider
+			queryParamKey={K8S_EVENTS_EXPRESSION_KEY}
+			initialExpression={K8S_EVENTS_BASE_EXPRESSION}
+			persistOnUnmount
+		>
+			<K8sEventsListContent controlListPrefix={controlListPrefix} />
+		</QuerySearchV2Provider>
+	);
+}
+
+export default K8sEventsList;

--- a/frontend/src/container/InfraMonitoringK8sV2/Events/__tests__/utils.test.ts
+++ b/frontend/src/container/InfraMonitoringK8sV2/Events/__tests__/utils.test.ts
@@ -1,0 +1,152 @@
+import { EventRow } from 'container/InfraMonitoringK8sV2/EntityDetailsUtils/EntityEvents/hooks';
+import {
+	getEventDrillDownTarget,
+	isWarningSeverity,
+	readEventField,
+	toK8sEventRow,
+} from 'container/InfraMonitoringK8sV2/Events/utils';
+import { K8sEventRow } from 'container/InfraMonitoringK8sV2/Events/types';
+
+function buildRow(overrides: Partial<K8sEventRow> = {}): K8sEventRow {
+	return {
+		key: 'evt-1',
+		id: 'evt-1',
+		timestamp: '2026-09-09T10:00:00Z',
+		body: 'Back-off restarting failed container',
+		severity: 'WARNING',
+		kind: 'Deployment',
+		objectName: 'checkout',
+		namespace: 'shop',
+		reason: 'BackOff',
+		attributes_string: {},
+		resources_string: {},
+		...overrides,
+	};
+}
+
+describe('readEventField', () => {
+	it('reads from attributes first', () => {
+		const source = {
+			attributes_string: { 'k8s.cluster.name': 'from-attrs' },
+			resources_string: { 'k8s.cluster.name': 'from-resources' },
+		};
+
+		expect(readEventField(source, 'k8s.cluster.name')).toBe('from-attrs');
+	});
+
+	it('falls back to resources when the attribute is absent', () => {
+		const source = {
+			attributes_string: {},
+			resources_string: { 'k8s.cluster.name': 'from-resources' },
+		};
+
+		expect(readEventField(source, 'k8s.cluster.name')).toBe('from-resources');
+	});
+
+	it('returns an empty string when neither carries the key', () => {
+		expect(readEventField({}, 'k8s.cluster.name')).toBe('');
+	});
+});
+
+describe('isWarningSeverity', () => {
+	it.each(['WARNING', 'warning', 'Warn', 'ERROR'])(
+		'treats %s as warning',
+		(severity) => {
+			expect(isWarningSeverity(severity)).toBe(true);
+		},
+	);
+
+	it.each(['NORMAL', 'INFO', ''])('treats %s as not a warning', (severity) => {
+		expect(isWarningSeverity(severity)).toBe(false);
+	});
+});
+
+describe('toK8sEventRow', () => {
+	it('lifts k8s event attributes into flat columns', () => {
+		const event: EventRow = {
+			timestamp: '2026-09-09T10:00:00Z',
+			data: {
+				id: 'evt-9',
+				body: 'Liveness probe failed',
+				severity_text: 'WARNING',
+				attributes_string: {
+					'k8s.object.kind': 'Pod',
+					'k8s.object.name': 'payments-abc',
+					'k8s.namespace.name': 'shop',
+					'k8s.event.reason': 'Unhealthy',
+				},
+				resources_string: { 'k8s.cluster.name': 'dev-cluster' },
+			},
+		};
+
+		expect(toK8sEventRow(event)).toMatchObject({
+			id: 'evt-9',
+			kind: 'Pod',
+			objectName: 'payments-abc',
+			namespace: 'shop',
+			reason: 'Unhealthy',
+			severity: 'WARNING',
+		});
+	});
+
+	it('leaves columns blank when the collector omitted the attributes', () => {
+		const event: EventRow = {
+			timestamp: '2026-09-09T10:00:00Z',
+			data: { id: 'evt-10', body: 'something', severity_text: 'NORMAL' },
+		};
+
+		expect(toK8sEventRow(event)).toMatchObject({
+			kind: '',
+			objectName: '',
+			namespace: '',
+			reason: '',
+		});
+	});
+});
+
+describe('getEventDrillDownTarget', () => {
+	it('targets name-keyed entities by object name', () => {
+		expect(getEventDrillDownTarget(buildRow())).toStrictEqual({
+			category: 'deployments',
+			params: {
+				selectedItem: 'checkout',
+				clusterName: null,
+				namespaceName: 'shop',
+			},
+		});
+	});
+
+	it('carries the cluster through when present', () => {
+		const row = buildRow({
+			resources_string: { 'k8s.cluster.name': 'dev-cluster' },
+		});
+
+		expect(getEventDrillDownTarget(row)?.params.clusterName).toBe('dev-cluster');
+	});
+
+	it('targets pods by uid, since the pod drawer is keyed on uid', () => {
+		const row = buildRow({
+			kind: 'Pod',
+			objectName: 'payments-abc',
+			attributes_string: { 'k8s.object.uid': 'uid-payments-abc' },
+		});
+
+		expect(getEventDrillDownTarget(row)?.params.selectedItem).toBe(
+			'uid-payments-abc',
+		);
+	});
+
+	it('refuses a pod target when the uid is missing', () => {
+		const row = buildRow({ kind: 'Pod', objectName: 'payments-abc' });
+
+		expect(getEventDrillDownTarget(row)).toBeNull();
+	});
+
+	it('returns null for kinds without a details drawer', () => {
+		expect(getEventDrillDownTarget(buildRow({ kind: 'ReplicaSet' }))).toBeNull();
+	});
+
+	it('returns null when the object name is missing', () => {
+		expect(getEventDrillDownTarget(buildRow({ objectName: '' }))).toBeNull();
+	});
+});

--- a/frontend/src/container/InfraMonitoringK8sV2/Events/constants.ts
+++ b/frontend/src/container/InfraMonitoringK8sV2/Events/constants.ts
@@ -1,0 +1,33 @@
+import { INFRA_MONITORING_ATTR_KEYS, K8sCategories } from '../constants';
+
+/**
+ * Kubernetes events reach SigNoz as logs, so an unfiltered cluster-wide view
+ * would return every log line. This narrows it to event-shaped records, and
+ * doubles as the non-empty expression `useEntityEvents` requires to fire.
+ */
+export const K8S_EVENTS_BASE_EXPRESSION = `${INFRA_MONITORING_ATTR_KEYS.K8S_OBJECT_KIND} EXISTS`;
+
+export const K8S_EVENTS_EXPRESSION_KEY = 'k8sEventsExpression';
+export const K8S_EVENTS_PAGINATION_KEY = 'k8sEventsPagination';
+
+export const K8S_EVENTS_PAGE_SIZE_OPTIONS = [10, 20, 50, 100];
+
+export const K8S_EVENTS_FILTER_PLACEHOLDER =
+	"Enter your filter query (e.g., severity_text = 'WARNING' AND k8s.object.kind = 'Pod')";
+
+/**
+ * `involvedObject.kind` values that map onto a category with a details drawer.
+ * Kinds absent here (ReplicaSet, Endpoints, HorizontalPodAutoscaler…) still
+ * list, they just aren't clickable.
+ */
+export const EVENT_KIND_TO_CATEGORY: Record<string, string> = {
+	Pod: K8sCategories.PODS,
+	Node: K8sCategories.NODES,
+	Namespace: K8sCategories.NAMESPACES,
+	Deployment: K8sCategories.DEPLOYMENTS,
+	StatefulSet: K8sCategories.STATEFULSETS,
+	DaemonSet: K8sCategories.DAEMONSETS,
+	Job: K8sCategories.JOBS,
+	CronJob: K8sCategories.JOBS,
+	PersistentVolumeClaim: K8sCategories.VOLUMES,
+};

--- a/frontend/src/container/InfraMonitoringK8sV2/Events/types.ts
+++ b/frontend/src/container/InfraMonitoringK8sV2/Events/types.ts
@@ -1,0 +1,29 @@
+export interface K8sEventRow {
+	key: string;
+	id: string;
+	timestamp: string;
+	body: string;
+	severity: string;
+	kind: string;
+	objectName: string;
+	namespace: string;
+	reason: string;
+	attributes_string?: Record<string, string>;
+	resources_string?: Record<string, string>;
+}
+
+export interface EventDrillDownTarget {
+	category: string;
+	params: {
+		selectedItem: string;
+		clusterName: string | null;
+		namespaceName: string | null;
+	};
+}
+
+export interface K8sEventsTimeRange {
+	/** Unix timestamp in seconds — the unit API payload builders expect. */
+	startTime: number;
+	/** Unix timestamp in seconds — the unit API payload builders expect. */
+	endTime: number;
+}

--- a/frontend/src/container/InfraMonitoringK8sV2/Events/useK8sEvents.ts
+++ b/frontend/src/container/InfraMonitoringK8sV2/Events/useK8sEvents.ts
@@ -1,0 +1,37 @@
+import { useMemo } from 'react';
+
+import { useEntityEvents } from '../EntityDetailsUtils/EntityEvents/hooks';
+import { K8sEventRow } from './types';
+import { useK8sEventsTimeRange } from './useK8sEventsTimeRange';
+import { toK8sEventRow } from './utils';
+
+type UseK8sEventsResult = Omit<ReturnType<typeof useEntityEvents>, 'events'> & {
+	events: K8sEventRow[];
+};
+
+export function useK8sEvents({
+	expression,
+	offset,
+	pageSize,
+}: {
+	expression: string;
+	offset: number;
+	pageSize: number;
+}): UseK8sEventsResult {
+	const timeRange = useK8sEventsTimeRange();
+
+	const result = useEntityEvents({
+		queryKey: 'k8sClusterEvents',
+		timeRange,
+		expression,
+		offset,
+		pageSize,
+	});
+
+	const events = useMemo(
+		() => result.events.map(toK8sEventRow),
+		[result.events],
+	);
+
+	return { ...result, events };
+}

--- a/frontend/src/container/InfraMonitoringK8sV2/Events/useK8sEventsCallbacks.ts
+++ b/frontend/src/container/InfraMonitoringK8sV2/Events/useK8sEventsCallbacks.ts
@@ -1,0 +1,99 @@
+import { useCallback } from 'react';
+import {
+	useInitialExpression,
+	useInputExpression,
+	useQuerySearchOnRun,
+} from 'components/QueryBuilderV2';
+import {
+	combineInitialAndUserExpression,
+	getUserExpressionFromCombined,
+} from 'components/QueryBuilderV2/QueryV2/QuerySearch/utils';
+import { saveRecentQueryByExpression } from 'lib/recentQueries/saveRecentQuery';
+import { DataSource } from 'types/common/queryBuilder';
+import { validateQuery } from 'utils/queryValidationUtils';
+
+import { logInfraFilterCustomizedEvent } from '../Base/events';
+import { InfraMonitoringEntity, K8sCategories } from '../constants';
+import {
+	useInfraMonitoringCategory,
+	useInfraMonitoringSelectedItemParams,
+} from '../hooks';
+import { K8sEventRow } from './types';
+import { getEventDrillDownTarget } from './utils';
+
+interface UseK8sEventsCallbacksArgs {
+	pageSize: number;
+	refetch: () => void;
+	setPagination: (value: { offset: number; limit: number } | null) => void;
+}
+
+interface UseK8sEventsCallbacksResult {
+	handleRunQuery: (updatedExpression?: string) => void;
+	handleDrillDown: (record: K8sEventRow) => void;
+}
+
+export function useK8sEventsCallbacks({
+	pageSize,
+	refetch,
+	setPagination,
+}: UseK8sEventsCallbacksArgs): UseK8sEventsCallbacksResult {
+	const inputExpression = useInputExpression();
+	const initialExpression = useInitialExpression();
+	const querySearchOnRun = useQuerySearchOnRun();
+
+	const [, setSelectedCategory] = useInfraMonitoringCategory();
+	const [, setSelectedItemParams] = useInfraMonitoringSelectedItemParams();
+
+	const handleRunQuery = useCallback(
+		(updatedExpression?: string): void => {
+			const newUserExpression = updatedExpression
+				? getUserExpressionFromCombined(initialExpression, updatedExpression)
+				: inputExpression;
+
+			const validation = validateQuery(
+				initialExpression
+					? combineInitialAndUserExpression(initialExpression, newUserExpression)
+					: newUserExpression || '',
+			);
+			if (!validation.isValid) {
+				return;
+			}
+
+			saveRecentQueryByExpression(DataSource.LOGS, newUserExpression);
+			querySearchOnRun(newUserExpression || '');
+			setPagination({ offset: 0, limit: pageSize });
+
+			// Events is a category without a metrics-backed entity, matching how
+			// the page already reports quick-filter changes for it.
+			logInfraFilterCustomizedEvent(
+				K8sCategories.EVENTS as InfraMonitoringEntity,
+				'search',
+				newUserExpression || '',
+			);
+
+			refetch();
+		},
+		[
+			inputExpression,
+			initialExpression,
+			querySearchOnRun,
+			setPagination,
+			pageSize,
+			refetch,
+		],
+	);
+
+	const handleDrillDown = useCallback(
+		(record: K8sEventRow): void => {
+			const target = getEventDrillDownTarget(record);
+			if (!target) {
+				return;
+			}
+			setSelectedItemParams(target.params);
+			void setSelectedCategory(target.category);
+		},
+		[setSelectedCategory, setSelectedItemParams],
+	);
+
+	return { handleRunQuery, handleDrillDown };
+}

--- a/frontend/src/container/InfraMonitoringK8sV2/Events/useK8sEventsColumns.tsx
+++ b/frontend/src/container/InfraMonitoringK8sV2/Events/useK8sEventsColumns.tsx
@@ -1,0 +1,81 @@
+import { useMemo } from 'react';
+import { TableColumnsType } from 'antd';
+import { useTimezone } from 'providers/Timezone';
+
+import EventObjectCell from './EventObjectCell';
+import { K8sEventRow } from './types';
+import { isWarningSeverity } from './utils';
+
+import styles from './K8sEventsList.module.scss';
+
+const EMPTY_CELL = '—';
+
+export function useK8sEventsColumns(
+	onDrillDown: (record: K8sEventRow) => void,
+): TableColumnsType<K8sEventRow> {
+	const { formatTimezoneAdjustedTimestamp } = useTimezone();
+
+	return useMemo(
+		() => [
+			{
+				title: 'Severity',
+				dataIndex: 'severity',
+				key: 'severity',
+				width: 100,
+				render: (value: string): JSX.Element => (
+					<span
+						className={isWarningSeverity(value) ? styles.isWarning : styles.isNormal}
+					>
+						{value || EMPTY_CELL}
+					</span>
+				),
+			},
+			{
+				title: 'Timestamp',
+				dataIndex: 'timestamp',
+				key: 'timestamp',
+				width: 190,
+				ellipsis: true,
+				render: (value: string | number): string =>
+					formatTimezoneAdjustedTimestamp(
+						typeof value === 'string' ? value : value / 1e6,
+					),
+			},
+			{
+				title: 'Kind',
+				dataIndex: 'kind',
+				key: 'kind',
+				width: 110,
+				render: (value: string): string => value || EMPTY_CELL,
+			},
+			{
+				title: 'Object',
+				dataIndex: 'objectName',
+				key: 'objectName',
+				width: 200,
+				ellipsis: true,
+				render: (_value: string, record: K8sEventRow): JSX.Element => (
+					<EventObjectCell record={record} onDrillDown={onDrillDown} />
+				),
+			},
+			{
+				title: 'Namespace',
+				dataIndex: 'namespace',
+				key: 'namespace',
+				width: 140,
+				ellipsis: true,
+				render: (value: string): string => value || EMPTY_CELL,
+			},
+			{
+				title: 'Reason',
+				dataIndex: 'reason',
+				key: 'reason',
+				width: 160,
+				ellipsis: true,
+				render: (value: string): string => value || EMPTY_CELL,
+			},
+			{ title: 'Message', dataIndex: 'body', key: 'body' },
+		],
+		[formatTimezoneAdjustedTimestamp, onDrillDown],
+	);
+}

--- a/frontend/src/container/InfraMonitoringK8sV2/Events/useK8sEventsTimeRange.ts
+++ b/frontend/src/container/InfraMonitoringK8sV2/Events/useK8sEventsTimeRange.ts
@@ -1,0 +1,24 @@
+import { useMemo } from 'react';
+import { NANO_SECOND_MULTIPLIER, useGlobalTime } from 'store/globalTime';
+
+import { K8sEventsTimeRange } from './types';
+
+/**
+ * The cluster-wide list follows the page-level time picker, unlike the entity
+ * drawer which keeps a time range of its own.
+ */
+export function useK8sEventsTimeRange(): K8sEventsTimeRange {
+	const lastComputedMinMax = useGlobalTime((s) => s.lastComputedMinMax);
+
+	return useMemo(
+		() => ({
+			startTime: Math.floor(
+				lastComputedMinMax.minTime / NANO_SECOND_MULTIPLIER / 1000,
+			),
+			endTime: Math.floor(
+				lastComputedMinMax.maxTime / NANO_SECOND_MULTIPLIER / 1000,
+			),
+		}),
+		[lastComputedMinMax],
+	);
+}

--- a/frontend/src/container/InfraMonitoringK8sV2/Events/utils.ts
+++ b/frontend/src/container/InfraMonitoringK8sV2/Events/utils.ts
@@ -1,0 +1,85 @@
+import { EventRow } from '../EntityDetailsUtils/EntityEvents/hooks';
+import { INFRA_MONITORING_ATTR_KEYS, K8sCategories } from '../constants';
+import { EVENT_KIND_TO_CATEGORY } from './constants';
+import { EventDrillDownTarget, K8sEventRow } from './types';
+
+type EventFieldSource = Pick<
+	K8sEventRow,
+	'attributes_string' | 'resources_string'
+>;
+
+/**
+ * Event fields land in attributes or resources depending on the collector
+ * pipeline — k8sattributes promotes some to resource level — so both are
+ * checked before giving up.
+ */
+export function readEventField(source: EventFieldSource, key: string): string {
+	return source.attributes_string?.[key] ?? source.resources_string?.[key] ?? '';
+}
+
+export function isWarningSeverity(severity: string): boolean {
+	const normalized = severity?.toUpperCase() ?? '';
+	return (
+		normalized === 'WARNING' || normalized === 'WARN' || normalized === 'ERROR'
+	);
+}
+
+export function toK8sEventRow(event: EventRow): K8sEventRow {
+	const source: EventFieldSource = {
+		attributes_string: event.data.attributes_string,
+		resources_string: event.data.resources_string,
+	};
+
+	return {
+		key: event.data.id,
+		id: event.data.id,
+		timestamp: event.timestamp,
+		body: event.data.body,
+		severity: event.data.severity_text,
+		kind: readEventField(source, INFRA_MONITORING_ATTR_KEYS.K8S_OBJECT_KIND),
+		objectName: readEventField(
+			source,
+			INFRA_MONITORING_ATTR_KEYS.K8S_OBJECT_NAME,
+		),
+		namespace: readEventField(
+			source,
+			INFRA_MONITORING_ATTR_KEYS.K8S_NAMESPACE_NAME,
+		),
+		reason: readEventField(source, INFRA_MONITORING_ATTR_KEYS.K8S_EVENT_REASON),
+		...source,
+	};
+}
+
+/**
+ * Pods are keyed by UID in the details drawer while every other entity is
+ * keyed by name, so a Pod event is only clickable when the collector supplied
+ * `k8s.object.uid`.
+ */
+export function getEventDrillDownTarget(
+	row: K8sEventRow,
+): EventDrillDownTarget | null {
+	const category = EVENT_KIND_TO_CATEGORY[row.kind];
+	if (!category || !row.objectName) {
+		return null;
+	}
+
+	const clusterName =
+		readEventField(row, INFRA_MONITORING_ATTR_KEYS.K8S_CLUSTER_NAME) || null;
+	const namespaceName = row.namespace || null;
+
+	if (category === K8sCategories.PODS) {
+		const uid = readEventField(row, INFRA_MONITORING_ATTR_KEYS.K8S_OBJECT_UID);
+		if (!uid) {
+			return null;
+		}
+		return {
+			category,
+			params: { selectedItem: uid, clusterName, namespaceName },
+		};
+	}
+
+	return {
+		category,
+		params: { selectedItem: row.objectName, clusterName, namespaceName },
+	};
+}

--- a/frontend/src/container/InfraMonitoringK8sV2/InfraMonitoringK8s.tsx
+++ b/frontend/src/container/InfraMonitoringK8sV2/InfraMonitoringK8s.tsx
@@ -24,6 +24,7 @@ import {
 	Filter,
 	Group,
 	HardDrive,
+	CalendarClock,
 	Workflow,
 } from '@signozhq/icons';
 import ErrorBoundaryFallback from 'pages/ErrorBoundaryFallback/ErrorBoundaryFallback';
@@ -35,6 +36,7 @@ import {
 	GetContainersQuickFiltersConfig,
 	GetDaemonsetsQuickFiltersConfig,
 	GetDeploymentsQuickFiltersConfig,
+	GetEventsQuickFiltersConfig,
 	GetJobsQuickFiltersConfig,
 	GetNamespaceQuickFiltersConfig,
 	GetNodesQuickFiltersConfig,
@@ -218,9 +220,24 @@ export default function InfraMonitoringK8s(): JSX.Element {
 		[],
 	);
 
+	const activityCategories = useMemo(
+		() => [
+			{
+				key: K8sCategories.EVENTS,
+				label: 'Events',
+				icon: <CalendarClock size={14} />,
+				config: GetEventsQuickFiltersConfig(),
+			},
+		],
+		[],
+	);
+
 	const selectedCategoryConfig = useMemo(
-		() => categories.find((cat) => cat.key === selectedCategory)?.config,
-		[categories, selectedCategory],
+		() =>
+			[...categories, ...activityCategories].find(
+				(cat) => cat.key === selectedCategory,
+			)?.config,
+		[categories, activityCategories, selectedCategory],
 	);
 
 	const handleCategorySelect = (key: string): void => {
@@ -291,6 +308,35 @@ export default function InfraMonitoringK8s(): JSX.Element {
 										<div className={styles.categoryCard}>
 											<div className={styles.categoryList}>
 												{categories.map((category) => (
+													<button
+														key={category.key}
+														type="button"
+														className={`${styles.categoryItem} ${
+															selectedCategory === category.key
+																? styles.categoryItemSelected
+																: ''
+														}`}
+														onClick={(): void => handleCategorySelect(category.key)}
+														data-testid={`category-${category.key}`}
+													>
+														{category.icon}
+														<Typography.Text>{category.label}</Typography.Text>
+													</button>
+												))}
+											</div>
+										</div>
+									</div>
+
+									<div className={styles.categorySelectorSection}>
+										<div className={styles.sectionHeader} data-type="activity">
+											<Typography.Text className={styles.sectionLabel}>
+												Viewing · Activity
+											</Typography.Text>
+											<div className={styles.sectionLine} />
+										</div>
+										<div className={styles.categoryCard}>
+											<div className={styles.categoryList}>
+												{activityCategories.map((category) => (
 													<button
 														key={category.key}
 														type="button"

--- a/frontend/src/container/InfraMonitoringK8sV2/__tests__/InfraMonitoringK8s.test.tsx
+++ b/frontend/src/container/InfraMonitoringK8sV2/__tests__/InfraMonitoringK8s.test.tsx
@@ -69,6 +69,36 @@ function renderPage(
 }
 
 describe('InfraMonitoringK8s', () => {
+	describe('category rail', () => {
+		const onUrlUpdateMock = jest.fn<void, [UrlUpdateEvent]>();
+
+		beforeEach(async () => {
+			onUrlUpdateMock.mockClear();
+			renderPage({ category: K8sCategories.PODS }, onUrlUpdateMock);
+			await screen.findByTestId(`category-${K8sCategories.PODS}`);
+		});
+
+		// Events lives in its own rail section; a category reachable only by URL
+		// is invisible to anyone who has not been handed the link.
+		it('should offer Events alongside the resource categories', () => {
+			expect(
+				screen.getByTestId(`category-${K8sCategories.EVENTS}`),
+			).toBeInTheDocument();
+		});
+
+		it('should select Events on click', async () => {
+			fireEvent.click(screen.getByTestId(`category-${K8sCategories.EVENTS}`));
+
+			await waitFor(() => {
+				const categorySwitch = onUrlUpdateMock.mock.calls.find(
+					(call) => call[0].searchParams.get('category') === K8sCategories.EVENTS,
+				);
+
+				expect(categorySwitch).toBeDefined();
+			});
+		});
+	});
+
 	describe('when the category changes from a page other than the first', () => {
 		const onUrlUpdateMock = jest.fn<void, [UrlUpdateEvent]>();
 

--- a/frontend/src/container/InfraMonitoringK8sV2/constants.ts
+++ b/frontend/src/container/InfraMonitoringK8sV2/constants.ts
@@ -126,6 +126,9 @@ export const INFRA_MONITORING_ATTR_KEYS = {
 	// K8s events
 	K8S_OBJECT_KIND: 'k8s.object.kind',
 	K8S_OBJECT_NAME: 'k8s.object.name',
+	K8S_OBJECT_UID: 'k8s.object.uid',
+	K8S_EVENT_REASON: 'k8s.event.reason',
+	SEVERITY_TEXT: 'severity_text',
 
 	// Environment
 	DEPLOYMENT_ENVIRONMENT: 'deployment.environment',
@@ -179,6 +182,7 @@ export const K8sCategories = {
 	CONTAINERS: 'containers',
 	JOBS: 'jobs',
 	VOLUMES: 'volumes',
+	EVENTS: 'events',
 };
 
 /** The section the Kubernetes view opens on when a link names none. */
@@ -606,6 +610,66 @@ export function GetClustersQuickFiltersConfig(): IQuickFiltersConfig[] {
 				type: 'resource',
 			},
 			defaultOpen: true,
+		},
+	];
+}
+
+export function GetEventsQuickFiltersConfig(): IQuickFiltersConfig[] {
+	return [
+		{
+			type: FiltersType.CHECKBOX,
+			title: 'Severity',
+			attributeKey: {
+				key: INFRA_MONITORING_ATTR_KEYS.SEVERITY_TEXT,
+				dataType: DataTypes.String,
+				type: '',
+			},
+			dataSource: DataSource.LOGS,
+			defaultOpen: true,
+		},
+		{
+			type: FiltersType.CHECKBOX,
+			title: 'Reason',
+			attributeKey: {
+				key: INFRA_MONITORING_ATTR_KEYS.K8S_EVENT_REASON,
+				dataType: DataTypes.String,
+				type: 'tag',
+			},
+			dataSource: DataSource.LOGS,
+			defaultOpen: true,
+		},
+		{
+			type: FiltersType.CHECKBOX,
+			title: 'Object kind',
+			attributeKey: {
+				key: INFRA_MONITORING_ATTR_KEYS.K8S_OBJECT_KIND,
+				dataType: DataTypes.String,
+				type: 'tag',
+			},
+			dataSource: DataSource.LOGS,
+			defaultOpen: true,
+		},
+		{
+			type: FiltersType.CHECKBOX,
+			title: 'Namespace',
+			attributeKey: {
+				key: INFRA_MONITORING_ATTR_KEYS.K8S_NAMESPACE_NAME,
+				dataType: DataTypes.String,
+				type: 'tag',
+			},
+			dataSource: DataSource.LOGS,
+			defaultOpen: false,
+		},
+		{
+			type: FiltersType.CHECKBOX,
+			title: 'Cluster',
+			attributeKey: {
+				key: INFRA_MONITORING_ATTR_KEYS.K8S_CLUSTER_NAME,
+				dataType: DataTypes.String,
+				type: 'resource',
+			},
+			dataSource: DataSource.LOGS,
+			defaultOpen: false,
 		},
 	];
 }


### PR DESCRIPTION
#### Description

- Kubernetes events were only reachable one entity at a time, from inside the details drawer. Scanning a cluster for what is currently failing meant opening a drawer per pod — the `kubectl get events -A --field-selector type=Warning` workflow had no equivalent in the UI.
- Adds an **Events** category to the Kubernetes page, in a new `Viewing · Activity` section of the rail, listing events across every object with severity, timestamp, kind, object, namespace, reason and message.
- Object names link into the affected entity's drawer, so a warning found in the list leads straight to the pod or node it came from.
- Quick filters (severity, reason, object kind, namespace, cluster) and the search bar run against logs, since that is how events are stored.

#### Additional Information

- Frontend only. Events already reach SigNoz as logs via the collector's `k8sobjects` receiver, and the v5 query API already serves them, so no backend or new endpoint was needed. The existing `getEntityEventsQueryPayload` is expression-driven and is reused as-is.
- Events are not a metrics-backed entity, so the category has no `entity.registry` entry; `K8sDynamicList` branches on it and renders its own list rather than the usual list + details pair. For the same reason `EVENTS` is deliberately kept out of `InfraMonitoringEntity`, whose exhaustive `METRIC_NAMESPACE_BY_ENTITY` map has no meaningful entry for a logs-backed view.
- A base expression of `k8s.object.kind EXISTS` narrows the logs query to event-shaped records and satisfies the non-empty expression the events hook requires.
- **Worth a reviewer's eye:** pod drill-down assumes `k8s.object.uid` carries the *involved object's* UID, since the pod drawer is keyed on UID while every other entity is keyed on name. This was developed against synthetic data and has not been confirmed against a real cluster. It fails safe — a pod event without that attribute renders as plain text rather than a broken link — but if the receiver emits the Event's own UID instead, pod links would resolve incorrectly and the mapping needs a name→UID lookup.

