### PR TITLE
fix(dashboards): honor context link tab preference

### DIFF
--- a/frontend/src/pages/DashboardPage/DashboardContainer/PanelEditor/ConfigPane/sections/ContextLinksSection/__tests__/ContextLinksSection.test.tsx
+++ b/frontend/src/pages/DashboardPage/DashboardContainer/PanelEditor/ConfigPane/sections/ContextLinksSection/__tests__/ContextLinksSection.test.tsx
@@ -97,6 +97,28 @@ describe('ContextLinksSection', () => {
 		expect(onChange).toHaveBeenCalledWith([]);
 	});
 
+	it('preserves the disabled new-tab preference when saved and reopened', async () => {
+		const onChange = jest.fn();
+		const view = render(
+			<ContextLinksSection value={LINKS} onChange={onChange} />,
+		);
+		fireEvent.click(screen.getByTestId('context-link-edit-0'));
+		const toggle = await screen.findByTestId('context-link-newtab');
+		fireEvent.click(toggle);
+		fireEvent.click(screen.getByTestId('context-link-save'));
+
+		const saved = lastCall(onChange);
+		expect(saved[0].targetBlank).toBe(false);
+		view.unmount();
+		render(<ContextLinksSection value={saved} onChange={onChange} />);
+		fireEvent.click(screen.getByTestId('context-link-edit-0'));
+		const savedToggle = await screen.findByTestId('context-link-newtab');
+		expect(savedToggle).toHaveAttribute('aria-checked', 'false');
+		fireEvent.click(screen.getByTestId('context-link-save'));
+		expect(onChange).toHaveBeenCalledTimes(2);
+		expect(lastCall(onChange)[0].targetBlank).toBe(false);
+	});
+
 	it('shows a validation error only for a malformed URL', async () => {
 		render(<ContextLinksSection value={[]} onChange={jest.fn()} />);
 		fireEvent.click(screen.getByTestId('panel-editor-v2-add-link'));

--- a/frontend/src/pages/DashboardPage/DashboardContainer/Panels/utils/drilldown/__tests__/drilldown.test.ts
+++ b/frontend/src/pages/DashboardPage/DashboardContainer/Panels/utils/drilldown/__tests__/drilldown.test.ts
@@ -391,6 +391,32 @@ describe('enrichPieClick', () => {
 });
 
 describe('resolvePanelContextLinks', () => {
+	it.each([true, false, undefined])(
+		'preserves targetBlank=%s across variable resolution modes',
+		(targetBlank) => {
+			for (const renderVariables of [true, false, undefined]) {
+				const [link] = resolvePanelContextLinks(
+					[
+						{
+							name: 'Runbook',
+							url: 'https://wiki/{{service}}',
+							targetBlank,
+							renderVariables,
+						},
+					],
+					{ service: 'frontend' },
+				);
+
+				expect(link.targetBlank).toBe(targetBlank ?? true);
+				expect(link.url).toBe(
+					renderVariables === false
+						? 'https://wiki/{{service}}'
+						: 'https://wiki/frontend',
+				);
+			}
+		},
+	);
+
 	it('substitutes the clicked field value (_-prefixed) into the label and URL', () => {
 		const resolved = resolvePanelContextLinks(
 			[

--- a/frontend/src/pages/DashboardPage/DashboardContainer/Panels/utils/drilldown/resolvePanelContextLinks.ts
+++ b/frontend/src/pages/DashboardPage/DashboardContainer/Panels/utils/drilldown/resolvePanelContextLinks.ts
@@ -8,6 +8,7 @@ export interface ResolvedDrilldownLink {
 	id: string;
 	label: string;
 	url: string;
+	targetBlank: boolean;
 }
 
 /**
@@ -26,14 +27,16 @@ export function resolvePanelContextLinks(
 	return usable.map((link, index) => {
 		const rawLabel = link.name || link.url || '';
 		const rawUrl = link.url ?? '';
+		const targetBlank = link.targetBlank ?? true;
 		// Only an explicit `false` opts out; undefined defaults to substitution on.
 		if (link.renderVariables === false) {
-			return { id: String(index), label: rawLabel, url: rawUrl };
+			return { id: String(index), label: rawLabel, url: rawUrl, targetBlank };
 		}
 		return {
 			id: String(index),
 			label: resolveTexts({ texts: [rawLabel], processedVariables }).fullTexts[0],
 			url: resolveContextLinkUrl(rawUrl, processedVariables),
+			targetBlank,
 		};
 	});
 }

--- a/frontend/src/pages/DashboardPage/DashboardContainer/PanelsAndSectionsLayout/Panel/DrilldownMenu/DrilldownAggregateMenu.tsx
+++ b/frontend/src/pages/DashboardPage/DashboardContainer/PanelsAndSectionsLayout/Panel/DrilldownMenu/DrilldownAggregateMenu.tsx
@@ -16,6 +16,7 @@ import { getDataLinks } from 'pages/DashboardPage/DashboardContainer/Panels/util
 import { resolvePanelContextLinks } from 'pages/DashboardPage/DashboardContainer/Panels/utils/drilldown/resolvePanelContextLinks';
 import { DashboardDetailEvents } from 'pages/DashboardPage/constants/events';
 import type { Query } from 'types/api/queryBuilder/queryBuilderData';
+import { withBasePath } from 'utils/basePath';
 import { openInNewTab } from 'utils/navigation';
 
 import { useDrilldownContextVariables } from '../hooks/useDrilldownContextVariables';
@@ -173,8 +174,22 @@ function DrilldownAggregateMenu({
 						void logEvent(DashboardDetailEvents.DrilldownAction, {
 							action: 'contextLink',
 						});
-						openInNewTab(link.url);
-						onClose();
+						try {
+							if (link.targetBlank === false) {
+								// Imported links and variable substitutions bypass editor URL validation.
+								const { protocol } = new URL(withBasePath(link.url), document.baseURI);
+								if (protocol !== 'http:' && protocol !== 'https:') {
+									return;
+								}
+								window.open(withBasePath(link.url), '_self');
+							} else {
+								openInNewTab(link.url);
+							}
+						} catch {
+							return;
+						} finally {
+							onClose();
+						}
 					}}
 				>
 					<span data-testid="drilldown-context-link">{link.label}</span>

--- a/frontend/src/pages/DashboardPage/DashboardContainer/PanelsAndSectionsLayout/Panel/__tests__/useDrilldown.test.tsx
+++ b/frontend/src/pages/DashboardPage/DashboardContainer/PanelsAndSectionsLayout/Panel/__tests__/useDrilldown.test.tsx
@@ -7,6 +7,7 @@ import {
 import { PANEL_TYPES } from 'constants/queryBuilder';
 import type { DrilldownContext } from 'pages/DashboardPage/DashboardContainer/Panels/types/drilldown';
 import { EQueryType } from 'types/common/dashboard';
+import * as basePath from 'utils/basePath';
 
 import { useDrilldown } from '../hooks/useDrilldown';
 
@@ -15,6 +16,7 @@ const mockNavigate = jest.fn();
 const mockGetBuilderQueries = jest.fn();
 const mockGetPanelQueryType = jest.fn();
 let mockResolved = { resolvedQuery: 'RESOLVED_QUERY', isResolving: false };
+let mockContextVariables: Record<string, string> = {};
 let mockDashboardVariables: {
 	hasFieldVariables: boolean;
 	actions: unknown[];
@@ -51,7 +53,7 @@ jest.mock('../DrilldownMenu/DrilldownDashboardVariablesMenu', () => ({
 }));
 // Context-link variable map (redux global time + store) — out of scope for this suite.
 jest.mock('../hooks/useDrilldownContextVariables', () => ({
-	useDrilldownContextVariables: (): unknown => ({}),
+	useDrilldownContextVariables: (): unknown => mockContextVariables,
 }));
 jest.mock('container/QueryTable/Drilldown/useBaseDrilldownNavigate', () => ({
 	__esModule: true,
@@ -144,6 +146,7 @@ describe('useDrilldown', () => {
 		mockGetBuilderQueries.mockReturnValue([{ name: 'A' }]);
 		mockGetPanelQueryType.mockReturnValue(EQueryType.QUERY_BUILDER);
 		mockResolved = { resolvedQuery: 'RESOLVED_QUERY', isResolving: false };
+		mockContextVariables = {};
 		mockDashboardVariables = {
 			hasFieldVariables: true,
 			actions: [],
@@ -180,6 +183,162 @@ describe('useDrilldown', () => {
 	});
 
 	describe('aggregate menu', () => {
+		afterEach(() => {
+			jest.restoreAllMocks();
+		});
+
+		it.each([true, false, undefined])(
+			'honors targetBlank=%s when clicking resolved panel context links',
+			async (targetBlank) => {
+				const user = userEvent.setup();
+				const open = jest.spyOn(window, 'open').mockReturnValue(null);
+				mockContextVariables = { service: 'frontend' };
+				const panel = {
+					...tsPanel,
+					spec: {
+						...tsPanel.spec,
+						links: [
+							{ name: 'External', url: 'https://wiki/{{service}}', targetBlank },
+							{ name: 'Internal', url: '/logs?service={{service}}', targetBlank },
+							{
+								name: 'Literal',
+								url: '/logs?service={{service}}',
+								targetBlank,
+								renderVariables: false,
+							},
+						],
+					},
+				};
+				const { result } = renderHook(() => useDrilldown(panel, 'p1'));
+				const view = render(<div />);
+				for (let index = 0; index < panel.spec.links.length; index++) {
+					act(() =>
+						result.current.onPanelClick({
+							coordinates: { x: 1, y: 1 },
+							context: aggregateContext,
+						}),
+					);
+					view.rerender(<div>{result.current.contextMenuProps.items}</div>);
+					await user.click(screen.getAllByTestId('drilldown-context-link')[index]);
+					expect(result.current.contextMenuProps.coordinates).toBeNull();
+				}
+
+				const target = targetBlank === false ? '_self' : '_blank';
+				expect(open.mock.calls).toStrictEqual([
+					['https://wiki/frontend', target],
+					['/logs?service=frontend', target],
+					['/logs?service={{service}}', target],
+				]);
+				expect(result.current.contextMenuProps.coordinates).toBeNull();
+			},
+		);
+
+		it.each([true, false])(
+			'preserves the deployment base path with targetBlank=%s',
+			async (targetBlank) => {
+				const user = userEvent.setup();
+				const open = jest.spyOn(window, 'open').mockReturnValue(null);
+				const base = document.createElement('base');
+				base.setAttribute('href', '/signoz/');
+				document.head.prepend(base);
+				try {
+					jest.isolateModules(() => {
+						const isolated = jest.requireActual<typeof basePath>('utils/basePath');
+						jest
+							.spyOn(basePath, 'withBasePath')
+							.mockImplementation(isolated.withBasePath);
+					});
+					const panel = {
+						...tsPanel,
+						spec: {
+							...tsPanel.spec,
+							links: [
+								{ url: '/logs', targetBlank },
+								{ url: '/signoz/logs', targetBlank },
+								{ url: 'https://wiki/runbook', targetBlank },
+							],
+						},
+					};
+					const { result } = renderHook(() => useDrilldown(panel, 'p1'));
+					const view = render(<div />);
+					for (let index = 0; index < panel.spec.links.length; index++) {
+						act(() =>
+							result.current.onPanelClick({
+								coordinates: { x: 1, y: 1 },
+								context: aggregateContext,
+							}),
+						);
+						view.rerender(<div>{result.current.contextMenuProps.items}</div>);
+						await user.click(screen.getAllByTestId('drilldown-context-link')[index]);
+					}
+					const target = targetBlank ? '_blank' : '_self';
+					expect(open.mock.calls).toStrictEqual([
+						['/signoz/logs', target],
+						['/signoz/logs', target],
+						['https://wiki/runbook', target],
+					]);
+				} finally {
+					base.remove();
+				}
+			},
+		);
+
+		it.each([
+			'javascript:alert(1)',
+			'java\nscript:alert(1)',
+			'data:text/html,example',
+			'https://[',
+		])(
+			'does not navigate the current page to an unsafe or malformed URL: %s',
+			async (destination) => {
+				const user = userEvent.setup();
+				const open = jest.spyOn(window, 'open').mockReturnValue(null);
+				mockContextVariables = { destination };
+				const panel = {
+					...tsPanel,
+					spec: {
+						...tsPanel.spec,
+						links: [
+							{ name: 'Imported link', url: '{{destination}}', targetBlank: false },
+						],
+					},
+				};
+				const { result } = renderHook(() => useDrilldown(panel, 'p1'));
+				act(() =>
+					result.current.onPanelClick({
+						coordinates: { x: 1, y: 1 },
+						context: aggregateContext,
+					}),
+				);
+				render(<div>{result.current.contextMenuProps.items}</div>);
+
+				await user.click(screen.getByTestId('drilldown-context-link'));
+				expect(open).not.toHaveBeenCalled();
+				expect(result.current.contextMenuProps.coordinates).toBeNull();
+			},
+		);
+
+		it('keeps automatic trace links opening in a new tab', async () => {
+			const user = userEvent.setup();
+			const open = jest.spyOn(window, 'open').mockReturnValue(null);
+			const { result } = renderHook(() => useDrilldown(tsPanel, 'p1'));
+			act(() =>
+				result.current.onPanelClick({
+					coordinates: { x: 1, y: 1 },
+					context: {
+						...aggregateContext,
+						filters: [
+							{ filterKey: 'trace_id', filterValue: 'abc123', operator: '=' },
+						],
+					},
+				}),
+			);
+			render(<div>{result.current.contextMenuProps.items}</div>);
+
+			await user.click(screen.getByTestId('drilldown-data-link'));
+			expect(open).toHaveBeenCalledWith('/trace/abc123', '_blank');
+		});
+
 		it('shows View in Logs/Traces + Breakout on an aggregate click', () => {
 			const { result } = renderHook(() => useDrilldown(tsPanel, 'p1'));
 			act(() =>


### PR DESCRIPTION
- Problem: Dashboard context links always opened in a new tab, ignoring the saved “Open in new tab” preference.
- Fix: Preserve targetBlank during link resolution and honor it when navigating. Keep existing defaults, base-path handling, and automatic trace links unchanged. Validate resolved destinations before same-tab navigation.
- Testing: Added regressions for saved preferences, both targets, variable resolution, subpath deployments, and unsafe URLs. All 140 dashboard/base-path suites passed (1,144 tests), along with type checking, lint, formatting, and the production build.

Issues closed by this PR
Closes #12810