### PR TITLE
docs(security): use GitHub private vulnerability reporting

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -15,6 +15,10 @@
 .github @therealpandey
 go.mod @therealpandey
 
+# Security
+
+/SECURITY.md @therealpandey
+
 # Scaffold Owners
 
 /pkg/config/ @therealpandey

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,17 +1,26 @@
 # Security Policy
 
-SigNoz is looking forward to working with security researchers across the world to keep SigNoz and our users safe. If you have found an issue in our systems/applications, please reach out to us.
+SigNoz is looking forward to working with security researchers across the world to keep SigNoz and our users safe. If you have found an issue in our systems/applications, please report it to us privately.
 
 ## Supported Versions
-We always recommend using the latest version of SigNoz to ensure you get all security updates
+
+We always recommend using the latest version of SigNoz to ensure you get all security updates.
 
 ## Reporting a Vulnerability
 
 If you believe you have found a security vulnerability within SigNoz, please let us know right away. We'll try and fix the problem as soon as possible.
 
-**Do not report vulnerabilities using public GitHub issues**. Instead, email <security@signoz.io> with a detailed account of the issue. Please submit one issue per email, this helps us triage vulnerabilities.
+**Do not report vulnerabilities using public GitHub issues, discussions, or pull requests.**
 
-Once we've received your email we'll keep you updated as we fix the vulnerability.
+Instead, report it privately through GitHub's private vulnerability reporting:
+
+1. Go to the [**Security** tab](https://github.com/SigNoz/signoz/security) of this repository.
+2. Click **Report a vulnerability**, or use [this link](https://github.com/SigNoz/signoz/security/advisories/new).
+3. Describe the issue with as much detail as you can — affected version, impact, and steps to reproduce help us triage faster. Please submit one report per vulnerability.
+
+This opens a private advisory visible only to you and the SigNoz maintainers. We'll respond there, keep you updated as we work on a fix, and coordinate disclosure. If the report is valid we'll credit you on the published advisory and request a CVE.
+
+If you're unable to use GitHub's private reporting, you can email <security@signoz.io> instead.
 
 ## Thanks
 


### PR DESCRIPTION
#### Description

- Switches the vulnerability reporting channel in `SECURITY.md` to GitHub's private vulnerability reporting (Security → Report a vulnerability), which is already enabled on this repo.
- Keeps `security@signoz.io` as a fallback for reporters who can't use GitHub.
- Adds a short how-to and sets expectations for what happens after a report (private advisory, coordinated fix, credit + CVE).
- Adds a `CODEOWNERS` entry so `SECURITY.md` is owned by @therealpandey.

#### Additional Information

- Docs / repo config only; no code changes.
