### PR TITLE
fix(alertmanager): coordinate synchronization and shutdown

### DIFF
--- a/pkg/alertmanager/alertmanagerserver/dispatcher.go
+++ b/pkg/alertmanager/alertmanagerserver/dispatcher.go
@@ -37,6 +37,7 @@ type Dispatcher struct {
 	aggrGroupsPerRoute map[*dispatch.Route]map[model.Fingerprint]*aggrGroup
 	aggrGroupsNum      int
 
+	ready  chan struct{}
 	done   chan struct{}
 	ctx    context.Context
 	cancel func()
@@ -79,6 +80,7 @@ func NewDispatcher(
 		limits:              lim,
 		notificationManager: n,
 		orgID:               orgID,
+		ready:               make(chan struct{}),
 	}
 	return disp
 }
@@ -95,7 +97,9 @@ func (d *Dispatcher) Run() {
 	d.ctx, d.cancel = context.WithCancel(context.Background())
 	d.mtx.Unlock()
 
-	d.run(d.alerts.Subscribe(fmt.Sprintf("dispatcher-%s", d.orgID)))
+	it := d.alerts.Subscribe(fmt.Sprintf("dispatcher-%s", d.orgID))
+	close(d.ready)
+	d.run(it)
 	close(d.done)
 }
 

--- a/pkg/alertmanager/alertmanagerserver/server.go
+++ b/pkg/alertmanager/alertmanagerserver/server.go
@@ -59,6 +59,7 @@ type Server struct {
 	dispatcher          *Dispatcher
 	dispatcherMetrics   *DispatcherMetrics
 	inhibitor           *inhibit.Inhibitor
+	inhibitorDone       chan struct{}
 	silencer            *silence.Silencer
 	silences            *silence.Silences
 	timeIntervals       map[string][]timeinterval.TimeInterval
@@ -305,6 +306,7 @@ func (server *Server) SetConfig(ctx context.Context, alertmanagerConfig *alertma
 
 	if server.inhibitor != nil {
 		server.inhibitor.Stop()
+		<-server.inhibitorDone
 	}
 	if server.dispatcher != nil {
 		server.dispatcher.Stop()
@@ -351,7 +353,15 @@ func (server *Server) SetConfig(ctx context.Context, alertmanagerConfig *alertma
 	// we call Start() and Stop() in quick succession.
 	// Both these goroutines will run indefinitely.
 	go server.dispatcher.Run()
-	go server.inhibitor.Run()
+	server.inhibitorDone = make(chan struct{})
+	go func(inhibitor *inhibit.Inhibitor, done chan struct{}) {
+		defer close(done)
+		inhibitor.Run()
+	}(server.inhibitor, server.inhibitorDone)
+
+	// Stop must not run before the workers install their cancellation functions.
+	<-server.dispatcher.ready
+	server.inhibitor.WaitForLoading()
 
 	server.alertmanagerConfig = resolved
 	return nil
@@ -479,6 +489,7 @@ func (server *Server) Stop(ctx context.Context) error {
 
 	if server.inhibitor != nil {
 		server.inhibitor.Stop()
+		<-server.inhibitorDone
 	}
 
 	// Close the alert provider.

--- a/pkg/alertmanager/alertmanagerserver/server_lifecycle_test.go
+++ b/pkg/alertmanager/alertmanagerserver/server_lifecycle_test.go
@@ -1,0 +1,67 @@
+package alertmanagerserver
+
+import (
+	"context"
+	"log/slog"
+	"testing"
+
+	"github.com/SigNoz/signoz/pkg/alertmanager/nfmanager/nfmanagertest"
+	"github.com/SigNoz/signoz/pkg/types/alertmanagertypes"
+	"github.com/SigNoz/signoz/pkg/types/alertmanagertypes/alertmanagertypestest"
+	"github.com/prometheus/alertmanager/config"
+	"github.com/prometheus/alertmanager/pkg/labels"
+	"github.com/prometheus/alertmanager/types"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/common/model"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/goleak"
+)
+
+func TestServerWorkersStopAfterConfig(t *testing.T) {
+	for _, tc := range []struct {
+		name    string
+		reloads int
+	}{
+		{name: "immediate stop", reloads: 1},
+		{name: "rapid reloads", reloads: 3},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			defer goleak.VerifyNone(t, goleak.IgnoreCurrent())
+			ctx := context.Background()
+			srvConfig := NewConfig()
+			srvConfig.Templates = nil
+			server, err := New(ctx, slog.New(slog.DiscardHandler), prometheus.NewRegistry(), srvConfig,
+				"test-org", alertmanagertypestest.NewStateStore(), nfmanagertest.NewMock(), alertmanagertypestest.NewMockMaintenanceStore(t))
+			require.NoError(t, err)
+			defer func() { require.NoError(t, server.Stop(ctx)) }()
+			require.NoError(t, server.alerts.Put(ctx, &types.Alert{Alert: model.Alert{
+				Labels: model.LabelSet{"alertname": "test", "severity": "critical"},
+			}}))
+
+			for range tc.reloads {
+				previousDispatcher := server.dispatcher
+				previousInhibitorDone := server.inhibitorDone
+				amConfig, err := alertmanagertypes.NewDefaultConfig(srvConfig.Global, srvConfig.Route, "test-org")
+				require.NoError(t, err)
+				amConfig.AlertmanagerConfig().InhibitRules = []config.InhibitRule{{
+					SourceMatchers: config.Matchers{{Type: labels.MatchEqual, Name: "severity", Value: "critical"}},
+					TargetMatchers: config.Matchers{{Type: labels.MatchEqual, Name: "severity", Value: "warning"}},
+					Equal:          []string{"alertname"},
+				}}
+				require.NoError(t, server.SetConfig(ctx, amConfig))
+				if previousDispatcher != nil {
+					select {
+					case <-previousDispatcher.done:
+					default:
+						t.Fatal("reload returned before the old dispatcher stopped")
+					}
+					select {
+					case <-previousInhibitorDone:
+					default:
+						t.Fatal("reload returned before the old inhibitor stopped")
+					}
+				}
+			}
+		})
+	}
+}

--- a/pkg/alertmanager/service.go
+++ b/pkg/alertmanager/service.go
@@ -37,6 +37,7 @@ type Service struct {
 
 	// Mutex to protect the servers map
 	serversMtx sync.RWMutex
+	stopped    bool
 
 	notificationManager nfmanager.NotificationManager
 
@@ -68,13 +69,18 @@ func New(
 }
 
 func (service *Service) SyncServers(ctx context.Context) error {
+	service.serversMtx.Lock()
+	defer service.serversMtx.Unlock()
+	if service.stopped {
+		return nil
+	}
+
 	compat.InitFromFlags(service.settings.Logger(), featurecontrol.NoopFlags{})
 	orgs, err := service.orgGetter.ListByOwnedKeyRange(ctx)
 	if err != nil {
 		return err
 	}
 
-	service.serversMtx.Lock()
 	for _, org := range orgs {
 		config, _, err := service.getConfig(ctx, org.ID.StringValue())
 		if err != nil {
@@ -104,7 +110,6 @@ func (service *Service) SyncServers(ctx context.Context) error {
 			continue
 		}
 	}
-	service.serversMtx.Unlock()
 
 	return nil
 }
@@ -163,6 +168,14 @@ func (service *Service) TestAlert(ctx context.Context, orgID string, receiversMa
 }
 
 func (service *Service) Stop(ctx context.Context) error {
+	service.serversMtx.Lock()
+	defer service.serversMtx.Unlock()
+	if service.stopped {
+		return nil
+	}
+	// A queued sync must not publish or reconfigure servers after teardown.
+	service.stopped = true
+
 	var errs []error
 	for _, server := range service.servers {
 		if err := server.Stop(ctx); err != nil {
@@ -170,20 +183,13 @@ func (service *Service) Stop(ctx context.Context) error {
 			service.settings.Logger().ErrorContext(ctx, "failed to stop alertmanager server", errors.Attr(err))
 		}
 	}
+	clear(service.servers)
 
 	return errors.Join(errs...)
 }
 
 func (service *Service) newServer(ctx context.Context, orgID string) (*alertmanagerserver.Server, error) {
 	config, storedHash, err := service.getConfig(ctx, orgID)
-	if err != nil {
-		return nil, err
-	}
-
-	server, err := alertmanagerserver.New(
-		ctx, service.settings.Logger(), service.settings.PrometheusRegisterer(), service.config, orgID,
-		service.stateStore, service.notificationManager, service.maintenanceStore,
-	)
 	if err != nil {
 		return nil, err
 	}
@@ -199,15 +205,17 @@ func (service *Service) newServer(ctx context.Context, orgID string) (*alertmana
 	// so that other code paths reading directly from the store see the up-to-date config.
 	if storedHash == config.StoreableConfig().Hash {
 		service.settings.Logger().DebugContext(ctx, "skipping config store update for org", slog.String("org_id", orgID), slog.String("hash", config.StoreableConfig().Hash))
-		return server, nil
+	} else {
+		if err := service.configStore.Set(ctx, config); err != nil {
+			return nil, err
+		}
 	}
 
-	err = service.configStore.Set(ctx, config)
-	if err != nil {
-		return nil, err
-	}
-
-	return server, nil
+	// Construction starts workers, so finish fallible reconciliation before handing them to the service.
+	return alertmanagerserver.New(
+		ctx, service.settings.Logger(), service.settings.PrometheusRegisterer(), service.config, orgID,
+		service.stateStore, service.notificationManager, service.maintenanceStore,
+	)
 }
 
 // getConfig returns the config for the given orgID with overlays applied, along

--- a/pkg/alertmanager/service_test.go
+++ b/pkg/alertmanager/service_test.go
@@ -1,0 +1,358 @@
+package alertmanager
+
+import (
+	"context"
+	"log/slog"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/SigNoz/signoz/pkg/alertmanager/alertmanagerserver"
+	"github.com/SigNoz/signoz/pkg/alertmanager/nfmanager/nfmanagertest"
+	"github.com/SigNoz/signoz/pkg/errors"
+	"github.com/SigNoz/signoz/pkg/factory"
+	"github.com/SigNoz/signoz/pkg/factory/factorytest"
+	"github.com/SigNoz/signoz/pkg/modules/organization"
+	"github.com/SigNoz/signoz/pkg/types"
+	"github.com/SigNoz/signoz/pkg/types/alertmanagertypes"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/goleak"
+)
+
+type lifecycleOrgGetter struct {
+	organization.Getter
+	list func(context.Context) ([]*types.Organization, error)
+}
+
+func (g *lifecycleOrgGetter) ListByOwnedKeyRange(ctx context.Context) ([]*types.Organization, error) {
+	return g.list(ctx)
+}
+
+type lifecycleConfigStore struct {
+	alertmanagertypes.ConfigStore
+	config          alertmanagerserver.Config
+	beforeGet       func()
+	listChannelsErr error
+	setErr          error
+	stale           bool
+}
+
+func (s *lifecycleConfigStore) Get(_ context.Context, orgID string) (*alertmanagertypes.Config, error) {
+	if s.beforeGet != nil {
+		s.beforeGet()
+	}
+	config, err := alertmanagertypes.NewDefaultConfig(s.config.Global, s.config.Route, orgID)
+	if err != nil {
+		return nil, err
+	}
+	if s.stale {
+		config.StoreableConfig().Hash = "stale"
+	}
+	return alertmanagertypes.NewConfigFromStoreableConfig(config.StoreableConfig())
+}
+
+func (s *lifecycleConfigStore) Set(context.Context, *alertmanagertypes.Config, ...alertmanagertypes.StoreOption) error {
+	return s.setErr
+}
+
+func (s *lifecycleConfigStore) ListChannels(context.Context, string) ([]*alertmanagertypes.Channel, error) {
+	return []*alertmanagertypes.Channel{}, s.listChannelsErr
+}
+
+func (*lifecycleConfigStore) GetMatchers(context.Context, string) (map[string][]string, error) {
+	return map[string][]string{}, nil
+}
+
+type lifecycleStateStore struct {
+	writes    atomic.Int64
+	beforeSet func()
+}
+
+func (*lifecycleStateStore) Get(context.Context, string) (*alertmanagertypes.StoreableState, error) {
+	return nil, errors.New(errors.TypeNotFound, alertmanagertypes.ErrCodeAlertmanagerStateNotFound, "no snapshot")
+}
+
+func (s *lifecycleStateStore) Set(ctx context.Context, _ *alertmanagertypes.StoreableState) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	if s.beforeSet != nil {
+		s.beforeSet()
+	}
+	s.writes.Add(1)
+	return nil
+}
+
+func newLifecycleService(t *testing.T, getter organization.Getter) (*Service, *lifecycleStateStore) {
+	t.Helper()
+	config := alertmanagerserver.NewConfig()
+	config.Templates = nil
+	state := &lifecycleStateStore{}
+	settings := factorytest.NewSettings()
+	settings.Logger = slog.New(slog.NewTextHandler(t.Output(), nil))
+	return New(
+		factory.NewScopedProviderSettings(settings, "alertmanager-test"),
+		config, state, &lifecycleConfigStore{config: config}, getter, nfmanagertest.NewMock(), nil,
+	), state
+}
+
+func awaitLifecycleResult(t *testing.T, done <-chan error) {
+	t.Helper()
+	select {
+	case err := <-done:
+		require.NoError(t, err)
+	case <-time.After(5 * time.Second):
+		t.Fatal("lifecycle operation did not finish")
+	}
+}
+
+func TestServiceDoesNotSyncAfterStop(t *testing.T) {
+	var calls atomic.Int64
+	service, _ := newLifecycleService(t, &lifecycleOrgGetter{
+		list: func(context.Context) ([]*types.Organization, error) {
+			calls.Add(1)
+			return []*types.Organization{}, nil
+		},
+	})
+
+	require.NoError(t, service.Stop(context.Background()))
+	require.NoError(t, service.SyncServers(context.Background()))
+	assert.Zero(t, calls.Load(), "a stopped service must not start another synchronization")
+}
+
+func TestServiceStopWaitsForInitialSync(t *testing.T) {
+	baseline := goleak.IgnoreCurrent()
+	t.Cleanup(func() { goleak.VerifyNone(t, baseline) })
+	entered := make(chan struct{})
+	release := make(chan struct{})
+	var releaseOnce sync.Once
+	unblock := func() { releaseOnce.Do(func() { close(release) }) }
+	org := types.NewOrganization("test", "test")
+	service, state := newLifecycleService(t, &lifecycleOrgGetter{
+		list: func(context.Context) ([]*types.Organization, error) {
+			close(entered)
+			<-release
+			return []*types.Organization{org}, nil
+		},
+	})
+	t.Cleanup(func() {
+		unblock()
+		require.NoError(t, service.Stop(context.Background()))
+	})
+
+	synced := make(chan error, 1)
+	go func() { synced <- service.SyncServers(context.Background()) }()
+	select {
+	case <-entered:
+	case <-time.After(5 * time.Second):
+		t.Fatal("synchronization did not reach organization lookup")
+	}
+
+	stopped := make(chan error, 1)
+	go func() { stopped <- service.Stop(context.Background()) }()
+	earlyStop := false
+	select {
+	case err := <-stopped:
+		assert.NoError(t, err)
+		t.Error("Stop returned while initial synchronization was still in progress")
+		earlyStop = true
+	case <-time.After(20 * time.Millisecond):
+	}
+	unblock()
+	awaitLifecycleResult(t, synced)
+	if earlyStop {
+		// Clean up servers created after the broken shutdown returned.
+		for _, server := range service.servers {
+			require.NoError(t, server.Stop(context.Background()))
+		}
+		return
+	}
+	awaitLifecycleResult(t, stopped)
+	assert.Empty(t, service.servers)
+	assert.Equal(t, int64(2), state.writes.Load(), "both final snapshots must finish before Stop returns")
+}
+
+func TestServiceStopWaitsForRefresh(t *testing.T) {
+	for _, newOrg := range []bool{false, true} {
+		name := "config reload"
+		if newOrg {
+			name = "new organization"
+		}
+		t.Run(name, func(t *testing.T) {
+			baseline := goleak.IgnoreCurrent()
+			t.Cleanup(func() { goleak.VerifyNone(t, baseline) })
+			ctx := context.Background()
+			orgs := []*types.Organization{types.NewOrganization("first", "first")}
+			service, state := newLifecycleService(t, &lifecycleOrgGetter{
+				list: func(context.Context) ([]*types.Organization, error) { return orgs, nil },
+			})
+			require.NoError(t, service.SyncServers(ctx))
+			require.Len(t, service.servers, 1)
+			originalServer := service.servers[orgs[0].ID.StringValue()]
+			oldHash := originalServer.Hash()
+			if newOrg {
+				orgs = append(orgs, types.NewOrganization("second", "second"))
+			} else {
+				service.config.Route.GroupWait += time.Second
+			}
+
+			entered := make(chan struct{})
+			release := make(chan struct{})
+			var once sync.Once
+			unblock := func() { once.Do(func() { close(release) }) }
+			t.Cleanup(func() {
+				unblock()
+				require.NoError(t, service.Stop(ctx))
+			})
+			var readOnce sync.Once
+			service.configStore.(*lifecycleConfigStore).beforeGet = func() {
+				readOnce.Do(func() {
+					close(entered)
+					<-release
+				})
+			}
+			synced := make(chan error, 1)
+			go func() { synced <- service.SyncServers(ctx) }()
+			select {
+			case <-entered:
+			case <-time.After(5 * time.Second):
+				t.Fatal("refresh did not reach config loading")
+			}
+			stopped := make(chan error, 1)
+			go func() { stopped <- service.Stop(ctx) }()
+			select {
+			case err := <-stopped:
+				t.Fatalf("Stop returned during refresh: %v", err)
+			case <-time.After(20 * time.Millisecond):
+			}
+			unblock()
+			awaitLifecycleResult(t, synced)
+			awaitLifecycleResult(t, stopped)
+			assert.Empty(t, service.servers)
+			assert.Equal(t, int64(2*len(orgs)), state.writes.Load())
+			if newOrg {
+				assert.Equal(t, oldHash, originalServer.Hash())
+			} else {
+				expected, err := alertmanagertypes.NewDefaultConfig(service.config.Global, service.config.Route, orgs[0].ID.StringValue())
+				require.NoError(t, err)
+				assert.Equal(t, expected.StoreableConfig().Hash, originalServer.Hash())
+				assert.NotEqual(t, oldHash, originalServer.Hash(), "the admitted refresh must apply its configuration before teardown")
+			}
+			require.NoError(t, service.SyncServers(ctx))
+			assert.Empty(t, service.servers, "a queued refresh must not restart a stopped server")
+		})
+	}
+}
+
+func TestServiceStopWaitsForSnapshotsAndRejectsReaders(t *testing.T) {
+	baseline := goleak.IgnoreCurrent()
+	t.Cleanup(func() { goleak.VerifyNone(t, baseline) })
+	ctx := context.Background()
+	org := types.NewOrganization("test", "test")
+	service, state := newLifecycleService(t, &lifecycleOrgGetter{
+		list: func(context.Context) ([]*types.Organization, error) { return []*types.Organization{org}, nil },
+	})
+	require.NoError(t, service.SyncServers(ctx))
+	require.Len(t, service.servers, 1)
+	entered := make(chan struct{}, 2)
+	release := make(chan struct{})
+	var once sync.Once
+	unblock := func() { once.Do(func() { close(release) }) }
+	t.Cleanup(func() {
+		unblock()
+		require.NoError(t, service.Stop(ctx))
+	})
+	state.beforeSet = func() {
+		entered <- struct{}{}
+		<-release
+	}
+	stopped := make(chan error, 1)
+	go func() { stopped <- service.Stop(ctx) }()
+	for range 2 {
+		select {
+		case <-entered:
+		case <-time.After(5 * time.Second):
+			t.Fatal("shutdown did not reach both snapshots")
+		}
+	}
+	repeated := make(chan error, 1)
+	go func() { repeated <- service.Stop(ctx) }()
+	read := make(chan error, 1)
+	go func() { read <- service.PutAlerts(ctx, org.ID.StringValue(), nil) }()
+	select {
+	case err := <-stopped:
+		t.Fatalf("Stop returned before snapshots finished: %v", err)
+	case err := <-repeated:
+		t.Fatalf("concurrent Stop returned before teardown finished: %v", err)
+	case err := <-read:
+		t.Fatalf("reader reached a server during teardown: %v", err)
+	case <-time.After(20 * time.Millisecond):
+	}
+	unblock()
+	awaitLifecycleResult(t, stopped)
+	awaitLifecycleResult(t, repeated)
+	select {
+	case err := <-read:
+		assert.True(t, errors.Asc(err, ErrCodeAlertmanagerNotFound))
+	case <-time.After(5 * time.Second):
+		t.Fatal("reader did not return after shutdown")
+	}
+	assert.Equal(t, int64(2), state.writes.Load())
+	require.NoError(t, service.Stop(ctx))
+}
+
+func TestServiceFailedServerReconciliationDoesNotStartWorkers(t *testing.T) {
+	for _, failure := range []string{"channel lookup", "config persistence"} {
+		t.Run(failure, func(t *testing.T) {
+			defer goleak.VerifyNone(t, goleak.IgnoreCurrent())
+			org := types.NewOrganization("test", "test")
+			service, state := newLifecycleService(t, &lifecycleOrgGetter{
+				list: func(context.Context) ([]*types.Organization, error) { return []*types.Organization{org}, nil },
+			})
+			store := service.configStore.(*lifecycleConfigStore)
+			wantErr := errors.NewInternalf(errors.CodeInternal, "reconciliation failed")
+			if failure == "channel lookup" {
+				store.listChannelsErr = wantErr
+			} else {
+				store.stale = true
+				store.setErr = wantErr
+			}
+			_, err := service.newServer(context.Background(), org.ID.StringValue())
+			assert.ErrorIs(t, err, wantErr)
+			assert.Empty(t, service.servers)
+			require.NoError(t, service.Stop(context.Background()))
+			assert.Zero(t, state.writes.Load())
+		})
+	}
+}
+
+func TestServiceStopAfterCanceledSync(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	entered := make(chan struct{})
+	service, _ := newLifecycleService(t, &lifecycleOrgGetter{
+		list: func(ctx context.Context) ([]*types.Organization, error) {
+			close(entered)
+			<-ctx.Done()
+			return nil, ctx.Err()
+		},
+	})
+	defer cancel()
+	synced := make(chan error, 1)
+	go func() { synced <- service.SyncServers(ctx) }()
+	select {
+	case <-entered:
+	case <-time.After(5 * time.Second):
+		t.Fatal("synchronization did not begin")
+	}
+	cancel()
+	select {
+	case err := <-synced:
+		assert.ErrorIs(t, err, context.Canceled)
+	case <-time.After(5 * time.Second):
+		t.Fatal("canceled synchronization did not return")
+	}
+	require.NoError(t, service.Stop(context.Background()))
+	require.NoError(t, service.SyncServers(context.Background()))
+}

--- a/pkg/alertmanager/signozalertmanager/provider.go
+++ b/pkg/alertmanager/signozalertmanager/provider.go
@@ -2,6 +2,7 @@ package signozalertmanager
 
 import (
 	"context"
+	"sync"
 	"time"
 
 	amConfig "github.com/prometheus/alertmanager/config"
@@ -31,6 +32,7 @@ type provider struct {
 	notificationManager nfmanager.NotificationManager
 	maintenanceStore    alertmanagertypes.MaintenanceStore
 	stopC               chan struct{}
+	stopOnce            sync.Once
 }
 
 func NewFactory(
@@ -99,7 +101,7 @@ func (provider *provider) Start(ctx context.Context) error {
 }
 
 func (provider *provider) Stop(ctx context.Context) error {
-	close(provider.stopC)
+	provider.stopOnce.Do(func() { close(provider.stopC) })
 	return provider.service.Stop(ctx)
 }
 

--- a/pkg/alertmanager/signozalertmanager/provider_test.go
+++ b/pkg/alertmanager/signozalertmanager/provider_test.go
@@ -1,0 +1,130 @@
+package signozalertmanager
+
+import (
+	"context"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/DATA-DOG/go-sqlmock"
+	"github.com/SigNoz/signoz/pkg/alertmanager"
+	"github.com/SigNoz/signoz/pkg/alertmanager/alertmanagerserver"
+	"github.com/SigNoz/signoz/pkg/errors"
+	"github.com/SigNoz/signoz/pkg/factory"
+	"github.com/SigNoz/signoz/pkg/factory/factorytest"
+	"github.com/SigNoz/signoz/pkg/modules/organization"
+	"github.com/SigNoz/signoz/pkg/sqlstore"
+	"github.com/SigNoz/signoz/pkg/sqlstore/sqlstoretest"
+	"github.com/SigNoz/signoz/pkg/types"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/goleak"
+)
+
+type lifecycleGetter struct {
+	organization.Getter
+	list func(context.Context) ([]*types.Organization, error)
+}
+
+func (g *lifecycleGetter) ListByOwnedKeyRange(ctx context.Context) ([]*types.Organization, error) {
+	return g.list(ctx)
+}
+
+func newLifecycleProvider(t *testing.T, getter organization.Getter) *provider {
+	t.Helper()
+	store := sqlstoretest.New(sqlstore.Config{Provider: "sqlite"}, sqlmock.QueryMatcherEqual)
+	t.Cleanup(func() {
+		store.Mock().ExpectClose()
+		require.NoError(t, store.BunDB().Close())
+		require.NoError(t, store.Mock().ExpectationsWereMet())
+	})
+	config := alertmanager.Config{Signoz: alertmanager.Signoz{
+		PollInterval: time.Millisecond,
+		Config:       alertmanagerserver.NewConfig(),
+	}}
+	p, err := New(factorytest.NewSettings(), config, store, getter, nil, nil)
+	require.NoError(t, err)
+	return p
+}
+
+func TestProviderStopBeforeStart(t *testing.T) {
+	var calls atomic.Int64
+	p := newLifecycleProvider(t, &lifecycleGetter{
+		list: func(context.Context) ([]*types.Organization, error) {
+			calls.Add(1)
+			return []*types.Organization{}, nil
+		},
+	})
+	require.NoError(t, p.Stop(context.Background()))
+	done := make(chan error, 1)
+	go func() { done <- p.Start(context.Background()) }()
+	select {
+	case err := <-done:
+		require.NoError(t, err)
+	case <-time.After(5 * time.Second):
+		t.Fatal("late Start did not return")
+	}
+	assert.Zero(t, calls.Load())
+
+	var wg sync.WaitGroup
+	for range 10 {
+		wg.Go(func() { assert.NoError(t, p.Stop(context.Background())) })
+	}
+	wg.Wait()
+}
+
+func TestProviderStopAfterStartupFailure(t *testing.T) {
+	wantErr := errors.NewInternalf(errors.CodeInternal, "organization lookup failed")
+	p := newLifecycleProvider(t, &lifecycleGetter{
+		list: func(context.Context) ([]*types.Organization, error) { return nil, wantErr },
+	})
+	assert.ErrorIs(t, p.Start(context.Background()), wantErr)
+	require.NoError(t, p.Stop(context.Background()))
+	require.NoError(t, p.Start(context.Background()))
+	require.NoError(t, p.Stop(context.Background()))
+}
+
+func TestRegistryStopsProviderDuringSync(t *testing.T) {
+	entered := make(chan struct{})
+	release := make(chan struct{})
+	var once sync.Once
+	unblock := func() { once.Do(func() { close(release) }) }
+	p := newLifecycleProvider(t, &lifecycleGetter{
+		list: func(context.Context) ([]*types.Organization, error) {
+			close(entered)
+			<-release
+			return []*types.Organization{}, nil
+		},
+	})
+	// The SQL mock has its own lifetime; only check goroutines created after it.
+	defer goleak.VerifyNone(t, goleak.IgnoreCurrent())
+	defer func() {
+		unblock()
+		require.NoError(t, p.Stop(context.Background()))
+	}()
+	settings := factorytest.NewSettings()
+	registry, err := factory.NewRegistry(context.Background(), settings.Logger,
+		factory.NewNamedService(factory.MustNewName("alertmanager"), p))
+	require.NoError(t, err)
+	registry.Start(context.Background())
+	select {
+	case <-entered:
+	case <-time.After(5 * time.Second):
+		t.Fatal("registry did not start provider synchronization")
+	}
+	stopped := make(chan error, 1)
+	go func() { stopped <- registry.Stop(context.Background()) }()
+	select {
+	case err := <-stopped:
+		t.Fatalf("registry shutdown returned before synchronization: %v", err)
+	case <-time.After(20 * time.Millisecond):
+	}
+	unblock()
+	select {
+	case err := <-stopped:
+		require.NoError(t, err)
+	case <-time.After(5 * time.Second):
+		t.Fatal("registry shutdown did not finish")
+	}
+}


### PR DESCRIPTION
Description
- Serialize server synchronization with shutdown so in-flight refreshes finish before teardown and queued refreshes cannot restart stopped servers.
- Wait for dispatcher and inhibitor startup, and join the inhibitor during reload and shutdown to prevent leaked workers.
- Complete configuration reconciliation before starting workers, avoiding leaks when initialization fails. Make repeated provider stop calls safe.

Additional Information

- Added regression tests for shutdown during synchronization, immediate stop, rapid reloads, failed initialization, cancellation, and final snapshot completion.
- Race-enabled tests, formatting, lint, go vet, and both community and enterprise builds pass.

closes #12819