### PR TITLE
fix(alertmanager): prevent concurrent snapshots from overwriting persisted state

### DIFF
--- a/pkg/alertmanager/alertmanagerserver/server.go
+++ b/pkg/alertmanager/alertmanagerserver/server.go
@@ -154,21 +154,13 @@ func New(
 				// Don't return here - we need to snapshot our state first.
 			}
 
-			storableSilences, err := server.stateStore.Get(ctx, server.orgID)
-			if err != nil && !errors.Ast(err, errors.TypeNotFound) {
-				return 0, err
-			}
-
-			if storableSilences == nil {
-				storableSilences = alertmanagertypes.NewStoreableState(server.orgID)
-			}
-
+			storableSilences := alertmanagertypes.NewStoreableState(server.orgID)
 			c, err := storableSilences.Set(alertmanagertypes.SilenceStateName, server.silences)
 			if err != nil {
 				return 0, err
 			}
 
-			return c, server.stateStore.Set(ctx, storableSilences)
+			return c, server.stateStore.Set(ctx, storableSilences, alertmanagertypes.SilenceStateName)
 		})
 	}()
 
@@ -182,21 +174,13 @@ func New(
 				// Don't return without saving the current state.
 			}
 
-			storableNFLog, err := server.stateStore.Get(ctx, server.orgID)
-			if err != nil && !errors.Ast(err, errors.TypeNotFound) {
-				return 0, err
-			}
-
-			if storableNFLog == nil {
-				storableNFLog = alertmanagertypes.NewStoreableState(server.orgID)
-			}
-
+			storableNFLog := alertmanagertypes.NewStoreableState(server.orgID)
 			c, err := storableNFLog.Set(alertmanagertypes.NFLogStateName, server.nflog)
 			if err != nil {
 				return 0, err
 			}
 
-			return c, server.stateStore.Set(ctx, storableNFLog)
+			return c, server.stateStore.Set(ctx, storableNFLog, alertmanagertypes.NFLogStateName)
 		})
 	}()
 

--- a/pkg/alertmanager/alertmanagerserver/server_snapshot_test.go
+++ b/pkg/alertmanager/alertmanagerserver/server_snapshot_test.go
@@ -1,0 +1,152 @@
+package alertmanagerserver
+
+import (
+	"context"
+	"log/slog"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/SigNoz/signoz/pkg/types/alertmanagertypes"
+	"github.com/SigNoz/signoz/pkg/types/alertmanagertypes/alertmanagertypestest"
+	"github.com/prometheus/alertmanager/nflog"
+	"github.com/prometheus/alertmanager/nflog/nflogpb"
+	"github.com/prometheus/alertmanager/notify"
+	"github.com/prometheus/alertmanager/types"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/common/model"
+	"github.com/stretchr/testify/require"
+)
+
+type snapshotResolvedSender struct{}
+
+func (snapshotResolvedSender) SendResolved() bool { return true }
+
+type snapshotWriteResult struct {
+	name alertmanagertypes.StateName
+	err  error
+}
+
+type snapshotBarrierStore struct {
+	alertmanagertypes.StateStore
+	first     alertmanagertypes.StateName
+	arrivals  atomic.Int32
+	gets      atomic.Int32
+	ready     chan struct{}
+	firstDone chan struct{}
+	completed chan snapshotWriteResult
+}
+
+func (s *snapshotBarrierStore) Get(ctx context.Context, orgID string) (*alertmanagertypes.StoreableState, error) {
+	s.gets.Add(1)
+	return s.StateStore.Get(ctx, orgID)
+}
+
+func (s *snapshotBarrierStore) Set(ctx context.Context, state *alertmanagertypes.StoreableState, name alertmanagertypes.StateName) error {
+	if s.arrivals.Add(1) == 2 {
+		close(s.ready)
+	}
+	select {
+	case <-s.ready:
+	case <-ctx.Done():
+		return ctx.Err()
+	}
+	if name != s.first {
+		select {
+		case <-s.firstDone:
+		case <-ctx.Done():
+			return ctx.Err()
+		}
+	}
+	err := s.StateStore.Set(ctx, state, name)
+	select {
+	case s.completed <- snapshotWriteResult{name: name, err: err}:
+	case <-ctx.Done():
+		return ctx.Err()
+	}
+	if name == s.first {
+		close(s.firstDone)
+	}
+	return err
+}
+
+func TestServerFinalSnapshotsPreserveNFLog(t *testing.T) {
+	for _, first := range []alertmanagertypes.StateName{alertmanagertypes.SilenceStateName, alertmanagertypes.NFLogStateName} {
+		t.Run(first.String()+"-first", func(t *testing.T) {
+			ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+			defer cancel()
+			store := &snapshotBarrierStore{
+				StateStore: alertmanagertypestest.NewStateStore(), first: first,
+				ready: make(chan struct{}), firstDone: make(chan struct{}),
+				completed: make(chan snapshotWriteResult, 2),
+			}
+			cfg := NewConfig()
+			cfg.Silences.MaintenanceInterval, cfg.NFLog.MaintenanceInterval = time.Hour, time.Hour
+			server, err := New(ctx, slog.New(slog.DiscardHandler), prometheus.NewRegistry(), cfg, "org", store, nil, nil)
+			require.NoError(t, err)
+			stopped := make(chan struct{})
+			var stopErr error
+			stop := sync.OnceFunc(func() {
+				go func() {
+					stopErr = server.Stop(context.Background())
+					close(stopped)
+				}()
+			})
+			t.Cleanup(func() {
+				cancel()
+				stop()
+				select {
+				case <-stopped:
+					require.NoError(t, stopErr)
+				case <-time.After(5 * time.Second):
+					t.Error("server cleanup timed out")
+				}
+			})
+			receiver := &nflogpb.Receiver{GroupName: "receiver", Integration: "webhook", Idx: 0}
+			logger := slog.New(slog.DiscardHandler)
+			alert := &types.Alert{Alert: model.Alert{Labels: model.LabelSet{"alertname": "snapshot-regression"}, StartsAt: time.Now()}}
+			notifyCtx := notify.WithGroupKey(ctx, "group")
+			notifyCtx = notify.WithRepeatInterval(notifyCtx, time.Hour)
+			dedup := notify.NewDedupStage(snapshotResolvedSender{}, server.nflog, receiver)
+			notifyCtx, pending, err := dedup.Exec(notifyCtx, logger, alert)
+			require.NoError(t, err)
+			require.Len(t, pending, 1)
+			_, _, err = notify.NewSetNotifiesStage(server.nflog, receiver).Exec(notifyCtx, logger, pending...)
+			require.NoError(t, err)
+			expectedEntries, err := server.nflog.Query(nflog.QReceiver(receiver), nflog.QGroupKey("group"))
+			require.NoError(t, err)
+			require.Len(t, expectedEntries, 1)
+			stop()
+			select {
+			case <-stopped:
+			case <-ctx.Done():
+				t.Fatal("final snapshots timed out")
+			}
+			require.Equal(t, int32(2), store.arrivals.Load())
+			require.Equal(t, int32(1), store.gets.Load())
+			require.Len(t, store.completed, 2)
+			firstResult, secondResult := <-store.completed, <-store.completed
+			require.Equal(t, first, firstResult.name)
+			require.NotEqual(t, first, secondResult.name)
+			require.NoError(t, firstResult.err)
+			require.NoError(t, secondResult.err)
+			state, err := store.StateStore.Get(ctx, "org")
+			require.NoError(t, err)
+			require.Empty(t, state.Silences)
+			snapshot, err := state.Get(alertmanagertypes.NFLogStateName)
+			require.NoError(t, err)
+			restored, err := nflog.New(nflog.Options{SnapshotReader: strings.NewReader(snapshot), Retention: cfg.NFLog.Retention, Metrics: prometheus.NewRegistry()})
+			require.NoError(t, err)
+			entries, err := restored.Query(nflog.QReceiver(receiver), nflog.QGroupKey("group"))
+			require.NoError(t, err)
+			require.Len(t, entries, 1)
+			require.Equal(t, expectedEntries[0].FiringAlerts, entries[0].FiringAlerts)
+			require.Empty(t, entries[0].ResolvedAlerts)
+			_, pending, err = notify.NewDedupStage(snapshotResolvedSender{}, restored, receiver).Exec(notifyCtx, logger, alert)
+			require.NoError(t, err)
+			require.Empty(t, pending)
+		})
+	}
+}

--- a/pkg/alertmanager/alertmanagerstore/sqlalertmanagerstore/state.go
+++ b/pkg/alertmanager/alertmanagerstore/sqlalertmanagerstore/state.go
@@ -7,6 +7,7 @@ import (
 	"github.com/SigNoz/signoz/pkg/errors"
 	"github.com/SigNoz/signoz/pkg/sqlstore"
 	"github.com/SigNoz/signoz/pkg/types/alertmanagertypes"
+	"github.com/uptrace/bun"
 )
 
 type state struct {
@@ -40,7 +41,17 @@ func (store *state) Get(ctx context.Context, orgID string) (*alertmanagertypes.S
 }
 
 // Set implements alertmanagertypes.StateStore.
-func (store *state) Set(ctx context.Context, storeableState *alertmanagertypes.StoreableState) error {
+func (store *state) Set(ctx context.Context, storeableState *alertmanagertypes.StoreableState, stateName alertmanagertypes.StateName) error {
+	var column string
+	switch stateName {
+	case alertmanagertypes.SilenceStateName:
+		column = "silences"
+	case alertmanagertypes.NFLogStateName:
+		column = "nflog"
+	default:
+		return errors.NewInvalidInputf(errors.CodeInvalidInput, "unknown alertmanager state %q", stateName.String())
+	}
+
 	tx, err := store.sqlstore.BunDB().BeginTx(ctx, nil)
 	if err != nil {
 		return err
@@ -51,9 +62,9 @@ func (store *state) Set(ctx context.Context, storeableState *alertmanagertypes.S
 	_, err = tx.
 		NewInsert().
 		Model(storeableState).
+		Column("id", "created_at", "updated_at", "org_id", column).
 		On("CONFLICT (org_id) DO UPDATE").
-		Set("silences = EXCLUDED.silences").
-		Set("nflog = EXCLUDED.nflog").
+		Set("? = EXCLUDED.?", bun.Ident(column), bun.Ident(column)).
 		Set("updated_at = EXCLUDED.updated_at").
 		Exec(ctx)
 	if err != nil {

--- a/pkg/alertmanager/alertmanagerstore/sqlalertmanagerstore/state_sql_test.go
+++ b/pkg/alertmanager/alertmanagerstore/sqlalertmanagerstore/state_sql_test.go
@@ -1,0 +1,61 @@
+package sqlalertmanagerstore
+
+import (
+	"errors"
+	"regexp"
+	"testing"
+
+	"github.com/DATA-DOG/go-sqlmock"
+	"github.com/SigNoz/signoz/pkg/sqlstore"
+	"github.com/SigNoz/signoz/pkg/sqlstore/sqlstoretest"
+	"github.com/SigNoz/signoz/pkg/types/alertmanagertypes"
+	"github.com/stretchr/testify/require"
+)
+
+func TestStateSnapshotSQL(t *testing.T) {
+	for _, provider := range []string{"sqlite", "postgres"} {
+		for _, column := range []string{"silences", "nflog"} {
+			for _, failure := range []string{"none", "begin", "write", "commit"} {
+				t.Run(provider+"/"+column+"/"+failure, func(t *testing.T) {
+					db := sqlstoretest.New(sqlstore.Config{Provider: provider}, sqlmock.QueryMatcherRegexp)
+					t.Cleanup(func() { _ = db.SQLDB().Close() })
+					mock := db.Mock()
+					store := NewStateStore(db)
+					input := alertmanagertypes.NewStoreableState("org")
+					input.Silences = "c2lsZW5jZQ=="
+					input.NFLog = "bmZsb2c="
+					component := alertmanagertypes.SilenceStateName
+					if column == "nflog" {
+						component = alertmanagertypes.NFLogStateName
+					}
+					sentinel := errors.New("database failure")
+					begin := mock.ExpectBegin()
+					if failure == "begin" {
+						begin.WillReturnError(sentinel)
+					} else {
+						prefix := `INSERT INTO "alertmanager_state" AS "storeable_state" ("id", "created_at", "updated_at", "org_id", "` + column + `") VALUES (`
+						suffix := `) ON CONFLICT (org_id) DO UPDATE SET "` + column + `" = EXCLUDED."` + column + `", updated_at = EXCLUDED.updated_at`
+						write := mock.ExpectExec("^" + regexp.QuoteMeta(prefix) + ".*" + regexp.QuoteMeta(suffix) + "$")
+						if failure == "write" {
+							write.WillReturnError(sentinel)
+							mock.ExpectRollback()
+						} else {
+							write.WillReturnResult(sqlmock.NewResult(0, 1))
+							commit := mock.ExpectCommit()
+							if failure == "commit" {
+								commit.WillReturnError(sentinel)
+							}
+						}
+					}
+					err := store.Set(t.Context(), input, component)
+					if failure == "none" {
+						require.NoError(t, err)
+					} else {
+						require.ErrorIs(t, err, sentinel)
+					}
+					require.NoError(t, mock.ExpectationsWereMet())
+				})
+			}
+		}
+	}
+}

--- a/pkg/alertmanager/alertmanagerstore/sqlalertmanagerstore/state_test.go
+++ b/pkg/alertmanager/alertmanagerstore/sqlalertmanagerstore/state_test.go
@@ -1,0 +1,264 @@
+package sqlalertmanagerstore
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/SigNoz/signoz/pkg/errors"
+	"github.com/SigNoz/signoz/pkg/factory/factorytest"
+	"github.com/SigNoz/signoz/pkg/sqlstore"
+	"github.com/SigNoz/signoz/pkg/sqlstore/sqlitesqlstore"
+	"github.com/SigNoz/signoz/pkg/types/alertmanagertypes"
+	"github.com/SigNoz/signoz/pkg/valuer"
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/stdlib"
+	"github.com/stretchr/testify/require"
+	"github.com/uptrace/bun"
+	"github.com/uptrace/bun/dialect/pgdialect"
+)
+
+type snapshotBytes string
+
+func (s snapshotBytes) MarshalBinary() ([]byte, error) { return []byte(s), nil }
+func (s snapshotBytes) Merge([]byte) error             { return nil }
+
+type snapshotSQLStore struct {
+	sqlstore.SQLStore
+	db *bun.DB
+}
+
+func (s *snapshotSQLStore) BunDB() *bun.DB { return s.db }
+
+func newSnapshotStore(t *testing.T, provider string) alertmanagertypes.StateStore {
+	t.Helper()
+	ctx, cancel := context.WithTimeout(t.Context(), 10*time.Second)
+	defer cancel()
+	var db sqlstore.SQLStore
+	if provider == "postgres" {
+		db = newPostgresSnapshotStore(t)
+	} else {
+		var err error
+		db, err = sqlitesqlstore.New(ctx, factorytest.NewSettings(), sqlstore.Config{
+			Provider:   "sqlite",
+			Connection: sqlstore.ConnectionConfig{MaxOpenConns: 2},
+			Sqlite: sqlstore.SqliteConfig{
+				Path:            filepath.Join(t.TempDir(), "state.db"),
+				Mode:            "wal",
+				BusyTimeout:     5 * time.Second,
+				TransactionMode: "immediate",
+			},
+		})
+		require.NoError(t, err)
+		t.Cleanup(func() { require.NoError(t, db.SQLDB().Close()) })
+	}
+	_, err := db.BunDB().NewCreateTable().Model((*alertmanagertypes.StoreableState)(nil)).Exec(ctx)
+	require.NoError(t, err)
+	_, err = db.BunDB().NewCreateIndex().Model((*alertmanagertypes.StoreableState)(nil)).
+		Index("alertmanager_state_org_id_idx").Column("org_id").Unique().Exec(ctx)
+	require.NoError(t, err)
+	return NewStateStore(db)
+}
+
+func newPostgresSnapshotStore(t *testing.T) sqlstore.SQLStore {
+	t.Helper()
+	dsn := os.Getenv("SIGNOZ_TEST_POSTGRES_DSN")
+	if dsn == "" {
+		t.Skip("SIGNOZ_TEST_POSTGRES_DSN not set")
+	}
+	config, err := pgx.ParseConfig(dsn)
+	require.NoError(t, err)
+	config.ConnectTimeout = 5 * time.Second
+	admin := stdlib.OpenDB(*config)
+	t.Cleanup(func() { require.NoError(t, admin.Close()) })
+	schema := "snapshot_" + fmt.Sprintf("%x", time.Now().UnixNano())
+	identifier := pgx.Identifier{schema}.Sanitize()
+	ctx, cancel := context.WithTimeout(t.Context(), 10*time.Second)
+	defer cancel()
+	_, err = admin.ExecContext(ctx, "CREATE SCHEMA "+identifier)
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+		_, err := admin.ExecContext(ctx, "DROP SCHEMA "+identifier+" CASCADE")
+		require.NoError(t, err)
+	})
+	config.RuntimeParams["search_path"] = schema
+	config.RuntimeParams["statement_timeout"] = "10000"
+	connection := stdlib.OpenDB(*config)
+	connection.SetMaxOpenConns(2)
+	db := bun.NewDB(connection, pgdialect.New())
+	t.Cleanup(func() { require.NoError(t, db.Close()) })
+	return &snapshotSQLStore{db: db}
+}
+
+func TestStateSnapshots(t *testing.T) {
+	for _, provider := range []string{"sqlite", "postgres"} {
+		t.Run(provider, func(t *testing.T) {
+			store := newSnapshotStore(t, provider)
+			t.Run("stale-write-order", func(t *testing.T) { testStateSnapshotOrdering(t, store) })
+			t.Run("concurrent-first-writes", func(t *testing.T) { testStateSnapshotFirstWrites(t, store) })
+			t.Run("empty-and-isolated", func(t *testing.T) { testStateSnapshotEmptyAndIsolated(t, store) })
+			t.Run("invalid-component", func(t *testing.T) {
+				ctx, cancel := context.WithTimeout(t.Context(), 10*time.Second)
+				defer cancel()
+				input := alertmanagertypes.NewStoreableState(valuer.GenerateUUID().StringValue())
+				err := store.Set(ctx, input, alertmanagertypes.StateName{})
+				require.True(t, errors.Ast(err, errors.TypeInvalidInput))
+				_, err = store.Get(ctx, input.OrgID)
+				require.True(t, errors.Ast(err, errors.TypeNotFound))
+			})
+		})
+	}
+}
+
+func testStateSnapshotOrdering(t *testing.T, store alertmanagertypes.StateStore) {
+	for _, first := range []alertmanagertypes.StateName{alertmanagertypes.SilenceStateName, alertmanagertypes.NFLogStateName} {
+		t.Run(first.String(), func(t *testing.T) {
+			ctx, cancel := context.WithTimeout(t.Context(), 10*time.Second)
+			defer cancel()
+			orgID := valuer.GenerateUUID().StringValue()
+			initial := alertmanagertypes.NewStoreableState(orgID)
+			_, err := initial.Set(alertmanagertypes.SilenceStateName, snapshotBytes("old silence"))
+			require.NoError(t, err)
+			_, err = initial.Set(alertmanagertypes.NFLogStateName, snapshotBytes("old nflog"))
+			require.NoError(t, err)
+			require.NoError(t, store.Set(ctx, initial, alertmanagertypes.SilenceStateName))
+			require.NoError(t, store.Set(ctx, initial, alertmanagertypes.NFLogStateName))
+
+			silences, err := store.Get(ctx, orgID)
+			require.NoError(t, err)
+			nflog, err := store.Get(ctx, orgID)
+			require.NoError(t, err)
+			_, err = silences.Set(alertmanagertypes.SilenceStateName, snapshotBytes("new silence"))
+			require.NoError(t, err)
+			_, err = nflog.Set(alertmanagertypes.NFLogStateName, snapshotBytes("new nflog"))
+			require.NoError(t, err)
+
+			if first == alertmanagertypes.SilenceStateName {
+				require.NoError(t, store.Set(ctx, silences, alertmanagertypes.SilenceStateName))
+				require.NoError(t, store.Set(ctx, nflog, alertmanagertypes.NFLogStateName))
+			} else {
+				require.NoError(t, store.Set(ctx, nflog, alertmanagertypes.NFLogStateName))
+				require.NoError(t, store.Set(ctx, silences, alertmanagertypes.SilenceStateName))
+			}
+			stored, err := store.Get(ctx, orgID)
+			require.NoError(t, err)
+			silenceData, err := stored.Get(alertmanagertypes.SilenceStateName)
+			require.NoError(t, err)
+			nflogData, err := stored.Get(alertmanagertypes.NFLogStateName)
+			require.NoError(t, err)
+			require.Equal(t, "new silence", silenceData)
+			require.Equal(t, "new nflog", nflogData)
+			require.Equal(t, initial.ID, stored.ID)
+			require.WithinDuration(t, initial.CreatedAt, stored.CreatedAt, time.Microsecond)
+		})
+	}
+}
+
+func testStateSnapshotFirstWrites(t *testing.T, store alertmanagertypes.StateStore) {
+	ctx, cancel := context.WithTimeout(t.Context(), 30*time.Second)
+	defer cancel()
+	for range 10 {
+		orgID := valuer.GenerateUUID().StringValue()
+		start := make(chan struct{})
+		results := make(chan error, 2)
+		var wg sync.WaitGroup
+		for _, component := range []alertmanagertypes.StateName{alertmanagertypes.SilenceStateName, alertmanagertypes.NFLogStateName} {
+			input := alertmanagertypes.NewStoreableState(orgID)
+			_, err := input.Set(component, snapshotBytes(component.String()))
+			require.NoError(t, err)
+			wg.Add(1)
+			go func() {
+				defer wg.Done()
+				<-start
+				results <- store.Set(ctx, input, component)
+			}()
+		}
+		close(start)
+		completed := make(chan struct{})
+		go func() {
+			wg.Wait()
+			close(completed)
+		}()
+		select {
+		case <-completed:
+		case <-ctx.Done():
+			t.Fatal("concurrent snapshot writes timed out")
+		}
+		close(results)
+		for err := range results {
+			require.NoError(t, err)
+		}
+		stored, err := store.Get(ctx, orgID)
+		require.NoError(t, err)
+		for _, component := range []alertmanagertypes.StateName{alertmanagertypes.SilenceStateName, alertmanagertypes.NFLogStateName} {
+			data, err := stored.Get(component)
+			require.NoError(t, err)
+			require.Equal(t, component.String(), data)
+		}
+	}
+}
+
+func testStateSnapshotEmptyAndIsolated(t *testing.T, store alertmanagertypes.StateStore) {
+	for _, component := range []alertmanagertypes.StateName{alertmanagertypes.SilenceStateName, alertmanagertypes.NFLogStateName} {
+		t.Run(component.String(), func(t *testing.T) {
+			ctx, cancel := context.WithTimeout(t.Context(), 10*time.Second)
+			defer cancel()
+			other := alertmanagertypes.NFLogStateName
+			if component == other {
+				other = alertmanagertypes.SilenceStateName
+			}
+			input := alertmanagertypes.NewStoreableState(valuer.GenerateUUID().StringValue())
+			_, err := input.Set(other, snapshotBytes("must not be inserted"))
+			require.NoError(t, err)
+			require.NoError(t, store.Set(ctx, input, component))
+			stored, err := store.Get(ctx, input.OrgID)
+			require.NoError(t, err)
+			require.Empty(t, stored.Silences)
+			require.Empty(t, stored.NFLog)
+
+			_, err = input.Set(component, snapshotBytes("to clear"))
+			require.NoError(t, err)
+			require.NoError(t, store.Set(ctx, input, component))
+			sibling := alertmanagertypes.NewStoreableState(input.OrgID)
+			_, err = sibling.Set(other, snapshotBytes("keep sibling"))
+			require.NoError(t, err)
+			require.NoError(t, store.Set(ctx, sibling, other))
+			isolated := alertmanagertypes.NewStoreableState(valuer.GenerateUUID().StringValue())
+			_, err = isolated.Set(component, snapshotBytes("keep other org"))
+			require.NoError(t, err)
+			require.NoError(t, store.Set(ctx, isolated, component))
+
+			_, err = input.Set(component, snapshotBytes(""))
+			require.NoError(t, err)
+			require.NoError(t, store.Set(ctx, input, component))
+			stored, err = store.Get(ctx, input.OrgID)
+			require.NoError(t, err)
+			_, err = stored.Get(component)
+			require.True(t, errors.Ast(err, errors.TypeNotFound))
+			data, err := stored.Get(other)
+			require.NoError(t, err)
+			require.Equal(t, "keep sibling", data)
+			var cleared sql.NullString
+			column := "silences"
+			if component == alertmanagertypes.NFLogStateName {
+				column = "nflog"
+			}
+			err = store.(*state).sqlstore.BunDB().NewSelect().Model((*alertmanagertypes.StoreableState)(nil)).
+				Column(column).Where("org_id = ?", input.OrgID).Scan(ctx, &cleared)
+			require.NoError(t, err)
+			require.False(t, cleared.Valid)
+			stored, err = store.Get(ctx, isolated.OrgID)
+			require.NoError(t, err)
+			data, err = stored.Get(component)
+			require.NoError(t, err)
+			require.Equal(t, "keep other org", data)
+		})
+	}
+}

--- a/pkg/types/alertmanagertypes/alertmanagertypestest/state.go
+++ b/pkg/types/alertmanagertypes/alertmanagertypestest/state.go
@@ -21,10 +21,27 @@ func NewStateStore() *StateStore {
 	}
 }
 
-func (s *StateStore) Set(ctx context.Context, storeableState *alertmanagertypes.StoreableState) error {
+func (s *StateStore) Set(ctx context.Context, storeableState *alertmanagertypes.StoreableState, stateName alertmanagertypes.StateName) error {
 	s.mtx.Lock()
-	s.states[storeableState.OrgID] = storeableState
-	s.mtx.Unlock()
+	defer s.mtx.Unlock()
+
+	stored, ok := s.states[storeableState.OrgID]
+	if !ok {
+		copy := *storeableState
+		copy.Silences = ""
+		copy.NFLog = ""
+		stored = &copy
+	}
+	switch stateName {
+	case alertmanagertypes.SilenceStateName:
+		stored.Silences = storeableState.Silences
+	case alertmanagertypes.NFLogStateName:
+		stored.NFLog = storeableState.NFLog
+	default:
+		return errors.NewInvalidInputf(errors.CodeInvalidInput, "unknown alertmanager state %q", stateName.String())
+	}
+	stored.UpdatedAt = storeableState.UpdatedAt
+	s.states[storeableState.OrgID] = stored
 	return nil
 }
 
@@ -35,5 +52,6 @@ func (s *StateStore) Get(ctx context.Context, orgID string) (*alertmanagertypes.
 		return nil, errors.Newf(errors.TypeNotFound, alertmanagertypes.ErrCodeAlertmanagerStateNotFound, "state for orgID %q not found", orgID)
 	}
 
-	return s.states[orgID], nil
+	copy := *s.states[orgID]
+	return &copy, nil
 }

--- a/pkg/types/alertmanagertypes/alertmanagertypestest/state_test.go
+++ b/pkg/types/alertmanagertypes/alertmanagertypestest/state_test.go
@@ -1,0 +1,78 @@
+package alertmanagertypestest
+
+import (
+	"context"
+	"testing"
+
+	"github.com/SigNoz/signoz/pkg/types/alertmanagertypes"
+	"github.com/stretchr/testify/require"
+)
+
+func TestStateStoreComponentSnapshots(t *testing.T) {
+	for _, first := range []alertmanagertypes.StateName{alertmanagertypes.SilenceStateName, alertmanagertypes.NFLogStateName} {
+		t.Run(first.String(), func(t *testing.T) {
+			ctx := context.Background()
+			store := NewStateStore()
+			input := alertmanagertypes.NewStoreableState("org")
+			input.Silences, input.NFLog = "silences", "nflog"
+			expected := *input
+			second := alertmanagertypes.SilenceStateName
+			if first == alertmanagertypes.SilenceStateName {
+				expected.NFLog = ""
+				second = alertmanagertypes.NFLogStateName
+			} else {
+				expected.Silences = ""
+			}
+			require.NoError(t, store.Set(ctx, input, first))
+			*input = *alertmanagertypes.NewStoreableState("mutated")
+			stored, err := store.Get(ctx, "org")
+			require.NoError(t, err)
+			require.Equal(t, expected, *stored)
+			fresh, err := store.Get(ctx, "org")
+			require.NoError(t, err)
+			require.NotSame(t, stored, fresh)
+			*stored = *input
+			require.Equal(t, expected, *fresh)
+			stored, err = store.Get(ctx, "org")
+			require.NoError(t, err)
+			require.Equal(t, expected, *stored)
+			update := alertmanagertypes.NewStoreableState("org")
+			update.Silences, update.NFLog = "updated-silences", "updated-nflog"
+			require.NoError(t, store.Set(ctx, update, second))
+			if second == alertmanagertypes.SilenceStateName {
+				expected.Silences = update.Silences
+			} else {
+				expected.NFLog = update.NFLog
+			}
+			expected.UpdatedAt = update.UpdatedAt
+			*update = *input
+			stored, err = store.Get(ctx, "org")
+			require.NoError(t, err)
+			require.Equal(t, expected, *stored)
+
+			clear := alertmanagertypes.NewStoreableState("org")
+			require.NoError(t, store.Set(ctx, clear, first))
+			if first == alertmanagertypes.SilenceStateName {
+				expected.Silences = ""
+			} else {
+				expected.NFLog = ""
+			}
+			expected.UpdatedAt = clear.UpdatedAt
+			stored, err = store.Get(ctx, "org")
+			require.NoError(t, err)
+			require.Equal(t, expected, *stored)
+
+			invalid := alertmanagertypes.NewStoreableState("org")
+			invalid.Silences, invalid.NFLog = "invalid", "invalid"
+			require.Error(t, store.Set(ctx, invalid, alertmanagertypes.StateName{}))
+			stored, err = store.Get(ctx, "org")
+			require.NoError(t, err)
+			require.Equal(t, expected, *stored)
+			invalid.OrgID = "missing"
+			require.Error(t, store.Set(ctx, invalid, alertmanagertypes.StateName{}))
+			stored, err = store.Get(ctx, "missing")
+			require.Error(t, err)
+			require.Nil(t, stored)
+		})
+	}
+}

--- a/pkg/types/alertmanagertypes/state.go
+++ b/pkg/types/alertmanagertypes/state.go
@@ -104,7 +104,8 @@ type StateStore interface {
 	// The return type matches the return of `silence.Maintenance` or `nflog.Maintenance`.
 	// See https://github.com/prometheus/alertmanager/blob/3b06b97af4d146e141af92885a185891eb79a5b0/silence/silence.go#L217
 	// and https://github.com/prometheus/alertmanager/blob/3b06b97af4d146e141af92885a185891eb79a5b0/nflog/nflog.go#L94
-	Set(context.Context, *StoreableState) error
+	// Only the named component is persisted; the other component is left untouched, even when this snapshot is empty.
+	Set(context.Context, *StoreableState, StateName) error
 
 	// Gets the silence state or the notification log state as a string from the store. This is used as a snapshot to load the
 	// initial state of silences or notification log when starting the alertmanager.


### PR DESCRIPTION
Description

- Persist silence and notification-log snapshots independently so concurrent maintenance workers cannot overwrite each other’s updates, including during shutdown.
- Remove the read-before-write step while preserving empty snapshots, the existing schema, and the snapshot encoding.
- Add regression coverage for both write orders, concurrent first inserts, empty snapshots, organization isolation, and notification deduplication after restoration.

Additional Information

- Validated with race-enabled tests against SQLite and PostgreSQL, plus the broader Alertmanager suites.
- Community and enterprise builds, go vet, and formatting checks pass.
- No database migration required.

Closes #12822