### PR TITLE
fix(alertmanager): prevent lost configuration updates during concurrent channel mutations

### DIFF
--- a/pkg/alertmanager/alertmanagerstore/sqlalertmanagerstore/config.go
+++ b/pkg/alertmanager/alertmanagerstore/sqlalertmanagerstore/config.go
@@ -3,6 +3,7 @@ package sqlalertmanagerstore
 import (
 	"context"
 	"database/sql"
+	"time"
 
 	"github.com/SigNoz/signoz/pkg/errors"
 	"github.com/SigNoz/signoz/pkg/sqlstore"
@@ -26,7 +27,7 @@ func (store *config) Get(ctx context.Context, orgID string) (*alertmanagertypes.
 
 	err := store.
 		sqlstore.
-		BunDB().
+		BunDBCtx(ctx).
 		NewSelect().
 		Model(storeableConfig).
 		Where("org_id = ?", orgID).
@@ -50,19 +51,41 @@ func (store *config) Get(ctx context.Context, orgID string) (*alertmanagertypes.
 // Set implements alertmanagertypes.ConfigStore.
 func (store *config) Set(ctx context.Context, config *alertmanagertypes.Config, opts ...alertmanagertypes.StoreOption) error {
 	return store.wrap(ctx, func(ctx context.Context) error {
-		if _, err := store.
-			sqlstore.
-			BunDBCtx(ctx).
-			NewInsert().
-			Model(config.StoreableConfig()).
-			On("CONFLICT (org_id) DO UPDATE").
-			Set("config = ?", config.StoreableConfig().Config).
-			Set("hash = ?", config.StoreableConfig().Hash).
-			Set("updated_at = ?", config.StoreableConfig().UpdatedAt).
-			Exec(ctx); err != nil {
+		stored := *config.StoreableConfig()
+		stored.UpdatedAt = time.Now().UTC().Truncate(time.Microsecond)
+		var result sql.Result
+		var err error
+		if originalHash, persisted := config.OriginalHash(); persisted {
+			originalUpdatedAt := config.OriginalUpdatedAt()
+			// Both dialects persist microseconds. Advance even if content repeats or the clock moves back.
+			if !stored.UpdatedAt.After(originalUpdatedAt) {
+				stored.UpdatedAt = originalUpdatedAt.Truncate(time.Microsecond).Add(time.Microsecond)
+			}
+			result, err = store.sqlstore.BunDBCtx(ctx).NewUpdate().
+				Model(&stored).
+				Column("config", "hash", "updated_at").
+				Where("id = ?", stored.ID.StringValue()).
+				Where("org_id = ?", stored.OrgID).
+				Where("hash = ?", originalHash).
+				Where("updated_at = ?", originalUpdatedAt).
+				Exec(ctx)
+		} else {
+			result, err = store.sqlstore.BunDBCtx(ctx).NewInsert().
+				Model(&stored).
+				On("CONFLICT (org_id) DO NOTHING").
+				Exec(ctx)
+		}
+		if err != nil {
 			return err
 		}
-
+		rows, err := result.RowsAffected()
+		if err != nil {
+			return err
+		}
+		if rows == 0 {
+			return errors.New(errors.TypeAlreadyExists, alertmanagertypes.ErrCodeAlertmanagerConfigConflict,
+				"alertmanager configuration changed concurrently; reload and retry the operation")
+		}
 		return nil
 	}, opts...)
 }
@@ -87,7 +110,7 @@ func (store *config) GetChannelByID(ctx context.Context, orgID string, id valuer
 
 	err := store.
 		sqlstore.
-		BunDB().
+		BunDBCtx(ctx).
 		NewSelect().
 		Model(channel).
 		Where("org_id = ?", orgID).
@@ -105,16 +128,24 @@ func (store *config) GetChannelByID(ctx context.Context, orgID string, id valuer
 
 func (store *config) UpdateChannel(ctx context.Context, orgID string, channel *alertmanagertypes.Channel, opts ...alertmanagertypes.StoreOption) error {
 	return store.wrap(ctx, func(ctx context.Context) error {
-		if _, err := store.
+		result, err := store.
 			sqlstore.
 			BunDBCtx(ctx).
 			NewUpdate().
 			Model(channel).
 			WherePK().
-			Exec(ctx); err != nil {
+			Where("org_id = ?", orgID).
+			Exec(ctx)
+		if err != nil {
 			return err
 		}
-
+		rows, err := result.RowsAffected()
+		if err != nil {
+			return err
+		}
+		if rows == 0 {
+			return errors.New(errors.TypeNotFound, alertmanagertypes.ErrCodeAlertmanagerChannelNotFound, "notification channel no longer exists")
+		}
 		return nil
 	}, opts...)
 }
@@ -123,17 +154,24 @@ func (store *config) DeleteChannelByID(ctx context.Context, orgID string, id val
 	return store.wrap(ctx, func(ctx context.Context) error {
 		channel := new(alertmanagertypes.Channel)
 
-		if _, err := store.
+		result, err := store.
 			sqlstore.
 			BunDBCtx(ctx).
 			NewDelete().
 			Model(channel).
 			Where("org_id = ?", orgID).
 			Where("id = ?", id.StringValue()).
-			Exec(ctx); err != nil {
+			Exec(ctx)
+		if err != nil {
 			return err
 		}
-
+		rows, err := result.RowsAffected()
+		if err != nil {
+			return err
+		}
+		if rows == 0 {
+			return errors.New(errors.TypeNotFound, alertmanagertypes.ErrCodeAlertmanagerChannelNotFound, "notification channel no longer exists")
+		}
 		return nil
 	}, opts...)
 }
@@ -143,7 +181,7 @@ func (store *config) ListChannels(ctx context.Context, orgID string) ([]*alertma
 
 	err := store.
 		sqlstore.
-		BunDB().
+		BunDBCtx(ctx).
 		NewSelect().
 		Model(&channels).
 		Where("org_id = ?", orgID).
@@ -160,7 +198,7 @@ func (store *config) ListAllChannels(ctx context.Context) ([]*alertmanagertypes.
 
 	err := store.
 		sqlstore.
-		BunDB().
+		BunDBCtx(ctx).
 		NewSelect().
 		Model(&channels).
 		Scan(ctx)
@@ -182,7 +220,7 @@ func (store *config) GetMatchers(ctx context.Context, orgID string) (map[string]
 
 	err := store.
 		sqlstore.
-		BunDB().
+		BunDBCtx(ctx).
 		NewSelect().
 		Column("id", "data").
 		Model(&matchers).

--- a/pkg/alertmanager/service.go
+++ b/pkg/alertmanager/service.go
@@ -180,14 +180,6 @@ func (service *Service) newServer(ctx context.Context, orgID string) (*alertmana
 		return nil, err
 	}
 
-	server, err := alertmanagerserver.New(
-		ctx, service.settings.Logger(), service.settings.PrometheusRegisterer(), service.config, orgID,
-		service.stateStore, service.notificationManager, service.maintenanceStore,
-	)
-	if err != nil {
-		return nil, err
-	}
-
 	config, err = service.compareAndSelectConfig(ctx, config)
 	if err != nil {
 		return nil, err
@@ -199,15 +191,17 @@ func (service *Service) newServer(ctx context.Context, orgID string) (*alertmana
 	// so that other code paths reading directly from the store see the up-to-date config.
 	if storedHash == config.StoreableConfig().Hash {
 		service.settings.Logger().DebugContext(ctx, "skipping config store update for org", slog.String("org_id", orgID), slog.String("hash", config.StoreableConfig().Hash))
-		return server, nil
+	} else {
+		if err := service.configStore.Set(ctx, config); err != nil {
+			return nil, err
+		}
 	}
 
-	err = service.configStore.Set(ctx, config)
-	if err != nil {
-		return nil, err
-	}
-
-	return server, nil
+	// A rejected reconciliation must not leave the constructor's maintenance workers running.
+	return alertmanagerserver.New(
+		ctx, service.settings.Logger(), service.settings.PrometheusRegisterer(), service.config, orgID,
+		service.stateStore, service.notificationManager, service.maintenanceStore,
+	)
 }
 
 // getConfig returns the config for the given orgID with overlays applied, along
@@ -264,7 +258,7 @@ func (service *Service) compareAndSelectConfig(ctx context.Context, incomingConf
 
 	if incomingConfig.StoreableConfig().Hash != config.StoreableConfig().Hash {
 		service.settings.Logger().InfoContext(ctx, "mismatch found, updating config to match channels and matchers")
-		return config, nil
+		incomingConfig.ReplaceWith(config)
 	}
 
 	return incomingConfig, nil

--- a/pkg/alertmanager/service_config_test.go
+++ b/pkg/alertmanager/service_config_test.go
@@ -1,0 +1,172 @@
+package alertmanager
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/SigNoz/signoz/pkg/alertmanager/alertmanagerserver"
+	"github.com/SigNoz/signoz/pkg/errors"
+	"github.com/SigNoz/signoz/pkg/factory"
+	"github.com/SigNoz/signoz/pkg/factory/factorytest"
+	"github.com/SigNoz/signoz/pkg/types/alertmanagertypes"
+	"github.com/stretchr/testify/require"
+)
+
+type reconciliationConfigStore struct {
+	alertmanagertypes.ConfigStore
+	stored   alertmanagertypes.StoreableConfig
+	channels []*alertmanagertypes.Channel
+	matchers map[string][]string
+	saved    []*alertmanagertypes.Config
+	setErr   error
+	orgIDs   []string
+}
+
+func (s *reconciliationConfigStore) Get(_ context.Context, orgID string) (*alertmanagertypes.Config, error) {
+	s.orgIDs = append(s.orgIDs, orgID)
+	stored := s.stored
+	return alertmanagertypes.NewConfigFromStoreableConfig(&stored)
+}
+
+func (s *reconciliationConfigStore) Set(_ context.Context, config *alertmanagertypes.Config, _ ...alertmanagertypes.StoreOption) error {
+	s.saved = append(s.saved, config)
+	return s.setErr
+}
+
+func (s *reconciliationConfigStore) ListChannels(_ context.Context, orgID string) ([]*alertmanagertypes.Channel, error) {
+	s.orgIDs = append(s.orgIDs, orgID)
+	return s.channels, nil
+}
+
+func (s *reconciliationConfigStore) GetMatchers(_ context.Context, orgID string) (map[string][]string, error) {
+	s.orgIDs = append(s.orgIDs, orgID)
+	return s.matchers, nil
+}
+
+type reconciliationStateStore struct {
+	alertmanagertypes.StateStore
+	getCalls int
+	err      error
+}
+
+func (s *reconciliationStateStore) Get(context.Context, string) (*alertmanagertypes.StoreableState, error) {
+	s.getCalls++
+	return nil, s.err
+}
+
+func reconciliationChannels(orgID string) []*alertmanagertypes.Channel {
+	return []*alertmanagertypes.Channel{{
+		Name: "current", DisplayName: "Current", Type: "webhook", OrgID: orgID,
+		Data: `{"name":"Current","webhook_configs":[{"url":"https://example.com/alerts","send_resolved":true,"max_alerts":7}],"googlechat_configs":[{"webhook_url":"https://chat.googleapis.com/v1/spaces/test/messages?key=test&token=test","send_resolved":true,"title":"Channel title","text":"Channel text"}]}`,
+	}}
+}
+
+func TestCompareAndSelectConfigPreservesStoredIdentityAndReadHash(t *testing.T) {
+	config := alertmanagerserver.NewConfig()
+	initial, err := alertmanagertypes.NewDefaultConfig(config.Global, config.Route, "org-reconcile")
+	require.NoError(t, err)
+	initial.StoreableConfig().CreatedAt = time.Date(2024, 1, 2, 3, 4, 5, 0, time.UTC)
+	stored := *initial.StoreableConfig()
+	store := &reconciliationConfigStore{
+		stored: stored, channels: reconciliationChannels(stored.OrgID),
+		matchers: map[string][]string{"rule-1": {"Current"}},
+	}
+	config.Route.GroupWait += time.Second
+	settings := factory.NewScopedProviderSettings(factorytest.NewSettings(), "alertmanager-config-test")
+	service := New(settings, config, nil, store, nil, nil, nil)
+	incoming, storedHash, err := service.getConfig(t.Context(), stored.OrgID)
+	require.NoError(t, err)
+	require.Equal(t, stored.Hash, storedHash)
+	require.NotEqual(t, stored.Hash, incoming.StoreableConfig().Hash)
+
+	rebuilt, err := alertmanagertypes.NewConfigFromChannels(config.Global, config.Route, store.channels, stored.OrgID)
+	require.NoError(t, err)
+	require.NoError(t, rebuilt.CreateRuleIDMatcher("rule-1", []string{"Current"}))
+	selected, err := service.compareAndSelectConfig(t.Context(), incoming)
+	require.NoError(t, err)
+	require.Same(t, incoming, selected)
+	require.Equal(t, stored.ID, selected.StoreableConfig().ID)
+	require.Equal(t, stored.OrgID, selected.StoreableConfig().OrgID)
+	require.Equal(t, stored.CreatedAt, selected.StoreableConfig().CreatedAt)
+	originalHash, persisted := selected.OriginalHash()
+	require.True(t, persisted)
+	require.Equal(t, stored.Hash, originalHash)
+	require.Equal(t, stored.UpdatedAt, selected.OriginalUpdatedAt())
+	require.NotEqual(t, originalHash, selected.StoreableConfig().Hash)
+	require.Equal(t, rebuilt.StoreableConfig().Hash, selected.StoreableConfig().Hash)
+	require.JSONEq(t, rebuilt.StoreableConfig().Config, selected.StoreableConfig().Config)
+	require.Equal(t, []string{"Current"}, selected.ReceiverNamesFromRuleID("rule-1"))
+	require.Equal(t, []string{stored.OrgID, stored.OrgID, stored.OrgID}, store.orgIDs)
+	require.Empty(t, store.saved)
+
+	resolved, err := selected.Resolved()
+	require.NoError(t, err)
+	resolvedHash, persisted := resolved.OriginalHash()
+	require.True(t, persisted)
+	require.Equal(t, stored.Hash, resolvedHash)
+	require.Equal(t, stored.UpdatedAt, resolved.OriginalUpdatedAt())
+	for _, candidate := range []*alertmanagertypes.Config{selected, resolved} {
+		receiver, err := candidate.GetReceiver("Current")
+		require.NoError(t, err)
+		require.Len(t, receiver.WebhookConfigs, 1)
+		require.Equal(t, "https://example.com/alerts", string(receiver.WebhookConfigs[0].URL))
+		require.EqualValues(t, 7, receiver.WebhookConfigs[0].MaxAlerts)
+		require.True(t, receiver.WebhookConfigs[0].VSendResolved)
+		require.Len(t, receiver.GoogleChatConfigs, 1)
+		require.Equal(t, "https://chat.googleapis.com/v1/spaces/test/messages?key=test&token=test", receiver.GoogleChatConfigs[0].WebhookURL.String())
+		require.Equal(t, "Channel title", receiver.GoogleChatConfigs[0].Title)
+		require.Equal(t, "Channel text", receiver.GoogleChatConfigs[0].Text)
+		require.True(t, receiver.GoogleChatConfigs[0].VSendResolved)
+	}
+}
+
+func TestNewServerReconcilesBeforeConstruction(t *testing.T) {
+	conflict := errors.New(errors.TypeAlreadyExists, alertmanagertypes.ErrCodeAlertmanagerConfigConflict, "concurrent config update")
+	constructionErr := errors.New(errors.TypeInternal, errors.CodeInternal, "construction reached state store")
+	for _, tc := range []struct {
+		name         string
+		changed      bool
+		setErr       error
+		wantErr      error
+		wantSaves    int
+		wantStateGet int
+	}{
+		{"conflict prevents construction", true, conflict, conflict, 1, 0},
+		{"saved reconciliation reaches construction", true, nil, constructionErr, 1, 1},
+		{"unchanged config skips save", false, nil, constructionErr, 0, 1},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			config := alertmanagerserver.NewConfig()
+			initial, err := alertmanagertypes.NewDefaultConfig(config.Global, config.Route, "org-construction")
+			require.NoError(t, err)
+			stored := *initial.StoreableConfig()
+			store := &reconciliationConfigStore{stored: stored, setErr: tc.setErr}
+			if tc.changed {
+				store.channels = reconciliationChannels(stored.OrgID)
+			}
+			state := &reconciliationStateStore{err: constructionErr}
+			settings := factory.NewScopedProviderSettings(factorytest.NewSettings(), "alertmanager-config-test")
+			service := New(settings, config, state, store, nil, nil, nil)
+
+			server, err := service.newServer(t.Context(), stored.OrgID)
+			require.ErrorIs(t, err, tc.wantErr)
+			require.Nil(t, server)
+			require.Empty(t, service.servers)
+			require.Equal(t, tc.wantStateGet, state.getCalls)
+			require.Len(t, store.saved, tc.wantSaves)
+			require.Equal(t, []string{stored.OrgID, stored.OrgID, stored.OrgID}, store.orgIDs)
+			if tc.wantSaves != 0 {
+				saved := store.saved[0]
+				originalHash, persisted := saved.OriginalHash()
+				require.True(t, persisted)
+				require.Equal(t, stored.Hash, originalHash)
+				require.Equal(t, stored.UpdatedAt, saved.OriginalUpdatedAt())
+				require.NotEqual(t, stored.Hash, saved.StoreableConfig().Hash)
+				require.Equal(t, stored.ID, saved.StoreableConfig().ID)
+				require.Equal(t, stored.OrgID, saved.StoreableConfig().OrgID)
+				require.Equal(t, stored.CreatedAt, saved.StoreableConfig().CreatedAt)
+			}
+		})
+	}
+}

--- a/pkg/alertmanager/signozalertmanager/config_persistence_test.go
+++ b/pkg/alertmanager/signozalertmanager/config_persistence_test.go
@@ -1,0 +1,250 @@
+package signozalertmanager
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/SigNoz/signoz/pkg/alertmanager"
+	"github.com/SigNoz/signoz/pkg/alertmanager/alertmanagerstore/sqlalertmanagerstore"
+	"github.com/SigNoz/signoz/pkg/alertmanager/nfmanager/nfmanagertest"
+	"github.com/SigNoz/signoz/pkg/errors"
+	"github.com/SigNoz/signoz/pkg/factory/factorytest"
+	"github.com/SigNoz/signoz/pkg/types/alertmanagertypes"
+	"github.com/SigNoz/signoz/pkg/valuer"
+	amconfig "github.com/prometheus/alertmanager/config"
+	"github.com/stretchr/testify/require"
+)
+
+func TestConfigurationPersistence(t *testing.T) {
+	for _, database := range []string{"sqlite", "postgres"} {
+		t.Run(database, func(t *testing.T) {
+			db := newChannelTestStore(t, database)
+			db.SQLDB().SetMaxOpenConns(1)
+			store := sqlalertmanagerstore.NewConfigStore(db)
+			defaults := alertmanager.NewConfigFactory().New().(alertmanager.Config)
+			orgID := valuer.GenerateUUID().StringValue()
+			newConfig := func() *alertmanagertypes.Config {
+				config, err := alertmanagertypes.NewDefaultConfig(defaults.Signoz.Global, defaults.Signoz.Route, orgID)
+				require.NoError(t, err)
+				return config
+			}
+			ctx, cancel := context.WithTimeout(t.Context(), 10*time.Second)
+			defer cancel()
+			initial := newConfig()
+			require.NoError(t, store.Set(ctx, initial))
+			assertConflict := func(err error) {
+				t.Helper()
+				require.Error(t, err)
+				require.True(t, errors.Asc(err, alertmanagertypes.ErrCodeAlertmanagerConfigConflict))
+			}
+			// A second creator must not replace an existing row, even with identical content.
+			assertConflict(store.Set(ctx, newConfig()))
+			stale, err := store.Get(ctx, orgID)
+			require.NoError(t, err)
+			createdAt := stale.StoreableConfig().CreatedAt
+			current, err := store.Get(ctx, orgID)
+			require.NoError(t, err)
+			require.NoError(t, current.SetGlobalConfig(defaults.Signoz.Global))
+			require.NoError(t, current.CreateReceiver(channelReceiver(t, "saved", "saved")))
+			require.NoError(t, store.Set(ctx, current))
+			assertConflict(store.Set(ctx, stale))
+			stored, err := store.Get(ctx, orgID)
+			require.NoError(t, err)
+			require.Equal(t, initial.StoreableConfig().ID, stored.StoreableConfig().ID)
+			require.True(t, createdAt.Equal(stored.StoreableConfig().CreatedAt))
+			baseline := stored.StoreableConfig().Config
+			originalHash, persisted := stored.OriginalHash()
+			require.True(t, persisted)
+
+			rollback := errors.NewInternalf(errors.CodeInternal, "rollback outer transaction")
+			err = db.RunInTxCtx(ctx, nil, func(ctx context.Context) error {
+				config, err := store.Get(ctx, orgID)
+				if err != nil {
+					return err
+				}
+				if err := config.SetGlobalConfig(defaults.Signoz.Global); err != nil {
+					return err
+				}
+				receiver := channelReceiver(t, "uncommitted", "uncommitted")
+				if err := config.CreateReceiver(receiver); err != nil {
+					return err
+				}
+				channel, err := alertmanagertypes.NewChannelFromReceiver(receiver, orgID)
+				if err != nil {
+					return err
+				}
+				if err := store.CreateChannel(ctx, channel, alertmanagertypes.WithCb(func(ctx context.Context) error {
+					return store.Set(ctx, config)
+				})); err != nil {
+					return err
+				}
+				channels, err := store.ListChannels(ctx, orgID)
+				require.NoError(t, err)
+				require.Len(t, channels, 1)
+				_, err = store.GetChannelByID(ctx, orgID, channel.ID)
+				require.NoError(t, err)
+				again, err := store.Get(ctx, orgID)
+				if err != nil {
+					return err
+				}
+				_, err = again.GetReceiver("uncommitted")
+				require.NoError(t, err)
+				if err := again.AddInhibitRules([]amconfig.InhibitRule{{Equal: []string{"service.name"}}}); err != nil {
+					return err
+				}
+				if err := store.Set(ctx, again); err != nil {
+					return err
+				}
+				return rollback
+			})
+			require.ErrorIs(t, err, rollback)
+			stored, err = store.Get(ctx, orgID)
+			require.NoError(t, err)
+			require.Equal(t, baseline, stored.StoreableConfig().Config)
+			channels, err := store.ListChannels(ctx, orgID)
+			require.NoError(t, err)
+			require.Empty(t, channels)
+			gotHash, _ := stored.OriginalHash()
+			require.Equal(t, originalHash, gotHash)
+
+			// A previously read snapshot remains usable after an unrelated transaction rolls back.
+			require.NoError(t, stored.SetGlobalConfig(defaults.Signoz.Global))
+			require.NoError(t, stored.CreateReceiver(channelReceiver(t, "after-rollback", "after")))
+			require.NoError(t, store.Set(ctx, stored))
+			cancelled, stop := context.WithCancel(ctx)
+			stop()
+			err = store.Set(cancelled, newConfig())
+			require.Error(t, err)
+			require.False(t, errors.Asc(err, alertmanagertypes.ErrCodeAlertmanagerConfigConflict))
+		})
+	}
+}
+
+func TestDefaultConfigurationResetPreservesIdentity(t *testing.T) {
+	db := newChannelTestStore(t, "sqlite")
+	defaults := alertmanager.NewConfigFactory().New().(alertmanager.Config)
+	p, err := New(factorytest.NewSettings(), defaults, db, nil, nil, nil)
+	require.NoError(t, err)
+	orgID := valuer.GenerateUUID().StringValue()
+	require.NoError(t, p.SetDefaultConfig(t.Context(), orgID))
+	before, err := p.GetConfig(t.Context(), orgID)
+	require.NoError(t, err)
+	_, err = p.CreateChannel(t.Context(), orgID, channelReceiver(t, "channel", "channel"))
+	require.NoError(t, err)
+	require.NoError(t, p.SetDefaultConfig(t.Context(), orgID))
+	after, err := p.GetConfig(t.Context(), orgID)
+	require.NoError(t, err)
+	require.Equal(t, before.StoreableConfig().ID, after.StoreableConfig().ID)
+	require.Equal(t, before.StoreableConfig().Hash, after.StoreableConfig().Hash)
+}
+
+func TestRecreatedChannelCannotBeChangedThroughDeletedIdentity(t *testing.T) {
+	for _, database := range []string{"sqlite", "postgres"} {
+		for _, operation := range []string{"update", "delete"} {
+			t.Run(database+"/"+operation, func(t *testing.T) {
+				db := newChannelTestStore(t, database)
+				defaults := alertmanager.NewConfigFactory().New().(alertmanager.Config)
+				p, err := New(factorytest.NewSettings(), defaults, db, nil, nfmanagertest.NewMock(), nil)
+				require.NoError(t, err)
+				orgID := valuer.GenerateUUID().StringValue()
+				ctx := t.Context()
+				require.NoError(t, p.SetDefaultConfig(ctx, orgID))
+				receiver := channelReceiver(t, "channel", "old")
+				original, err := p.CreateChannel(ctx, orgID, receiver)
+				require.NoError(t, err)
+				staleConfig, err := p.GetConfig(ctx, orgID)
+				require.NoError(t, err)
+				require.NoError(t, staleConfig.SetGlobalConfig(defaults.Signoz.Global))
+				require.NoError(t, p.DeleteChannelByID(ctx, orgID, original.ID))
+				replacement, err := p.CreateChannel(ctx, orgID, receiver)
+				require.NoError(t, err)
+				current, err := p.GetConfig(ctx, orgID)
+				require.NoError(t, err)
+				expectedHash, _ := staleConfig.OriginalHash()
+				require.Equal(t, expectedHash, current.StoreableConfig().Hash)
+				cb := alertmanagertypes.WithCb(func(ctx context.Context) error { return p.SetConfig(ctx, staleConfig) })
+				if operation == "update" {
+					changed := channelReceiver(t, "channel", "changed")
+					require.NoError(t, original.Update(changed))
+					require.NoError(t, staleConfig.UpdateReceiver(changed))
+					err = p.configStore.UpdateChannel(ctx, orgID, original, cb)
+				} else {
+					require.NoError(t, staleConfig.DeleteReceiver("channel"))
+					err = p.configStore.DeleteChannelByID(ctx, orgID, original.ID, cb)
+				}
+				require.Error(t, err)
+				require.True(t, errors.Ast(err, errors.TypeNotFound))
+				stored, err := p.GetChannelByID(ctx, orgID, replacement.ID)
+				require.NoError(t, err)
+				require.Equal(t, replacement.Data, stored.Data)
+				unchanged, err := p.GetConfig(ctx, orgID)
+				require.NoError(t, err)
+				require.Equal(t, current.StoreableConfig().Config, unchanged.StoreableConfig().Config)
+			})
+		}
+	}
+}
+
+func TestReconciliationRejectsConfigurationABA(t *testing.T) {
+	for _, database := range []string{"sqlite", "postgres"} {
+		for _, futureRevision := range []bool{false, true} {
+			name := "normal-clock"
+			if futureRevision {
+				name = "clock-behind-revision"
+			}
+			t.Run(database+"/"+name, func(t *testing.T) {
+				db := newChannelTestStore(t, database)
+				defaults := alertmanager.NewConfigFactory().New().(alertmanager.Config)
+				p, err := New(factorytest.NewSettings(), defaults, db, nil, nil, nil)
+				require.NoError(t, err)
+				ctx, cancel := context.WithTimeout(t.Context(), 10*time.Second)
+				defer cancel()
+				orgID := valuer.GenerateUUID().StringValue()
+				require.NoError(t, p.SetDefaultConfig(ctx, orgID))
+				channel, err := p.CreateChannel(ctx, orgID, channelReceiver(t, "channel", "A"))
+				require.NoError(t, err)
+				if futureRevision {
+					_, err := db.BunDB().NewUpdate().Model((*alertmanagertypes.StoreableConfig)(nil)).
+						Set("updated_at = ?", time.Now().Add(time.Hour).UTC().Truncate(time.Microsecond)).
+						Where("org_id = ?", orgID).Exec(ctx)
+					require.NoError(t, err)
+				}
+				before, err := p.GetConfig(ctx, orgID)
+				require.NoError(t, err)
+				require.NoError(t, p.UpdateChannelByReceiverAndID(ctx, orgID, channelReceiver(t, "channel", "B"), channel.ID))
+				channels, err := p.ListChannels(ctx, orgID)
+				require.NoError(t, err)
+				rebuilt, err := alertmanagertypes.NewConfigFromChannels(defaults.Signoz.Global, defaults.Signoz.Route, channels, orgID)
+				require.NoError(t, err)
+				middle, err := p.GetConfig(ctx, orgID)
+				require.NoError(t, err)
+				require.True(t, middle.OriginalUpdatedAt().After(before.OriginalUpdatedAt()))
+				require.NoError(t, p.UpdateChannelByReceiverAndID(ctx, orgID, channelReceiver(t, "channel", "A"), channel.ID))
+				after, err := p.GetConfig(ctx, orgID)
+				require.NoError(t, err)
+				require.Equal(t, before.StoreableConfig().Hash, after.StoreableConfig().Hash)
+				require.True(t, after.OriginalUpdatedAt().After(middle.OriginalUpdatedAt()))
+
+				before.ReplaceWith(rebuilt)
+				err = p.SetConfig(ctx, before)
+				require.Error(t, err)
+				require.True(t, errors.Asc(err, alertmanagertypes.ErrCodeAlertmanagerConfigConflict))
+				unchanged, err := p.GetConfig(ctx, orgID)
+				require.NoError(t, err)
+				require.Equal(t, after.StoreableConfig().Config, unchanged.StoreableConfig().Config)
+				require.Equal(t, after.OriginalUpdatedAt(), unchanged.OriginalUpdatedAt())
+				stored, err := p.GetChannelByID(ctx, orgID, channel.ID)
+				require.NoError(t, err)
+				require.Equal(t, channels[0].ID, stored.ID)
+				require.Contains(t, stored.Data, "http://localhost/A")
+
+				// Even a no-content-change save consumes the read revision.
+				require.NoError(t, p.SetConfig(ctx, after))
+				err = p.SetConfig(ctx, after)
+				require.Error(t, err)
+				require.True(t, errors.Asc(err, alertmanagertypes.ErrCodeAlertmanagerConfigConflict))
+			})
+		}
+	}
+}

--- a/pkg/alertmanager/signozalertmanager/provider.go
+++ b/pkg/alertmanager/signozalertmanager/provider.go
@@ -153,17 +153,17 @@ func (provider *provider) GetChannelByID(ctx context.Context, orgID string, chan
 }
 
 func (provider *provider) UpdateChannelByReceiverAndID(ctx context.Context, orgID string, receiver *alertmanagertypes.Receiver, id valuer.UUID) error {
+	config, err := provider.configStore.Get(ctx, orgID)
+	if err != nil {
+		return err
+	}
+
 	channel, err := provider.configStore.GetChannelByID(ctx, orgID, id)
 	if err != nil {
 		return err
 	}
 
 	if err := channel.Update(receiver); err != nil {
-		return err
-	}
-
-	config, err := provider.configStore.Get(ctx, orgID)
-	if err != nil {
 		return err
 	}
 
@@ -181,6 +181,11 @@ func (provider *provider) UpdateChannelByReceiverAndID(ctx context.Context, orgI
 }
 
 func (provider *provider) DeleteChannelByID(ctx context.Context, orgID string, channelID valuer.UUID) error {
+	config, err := provider.configStore.Get(ctx, orgID)
+	if err != nil {
+		return err
+	}
+
 	channel, err := provider.configStore.GetChannelByID(ctx, orgID, channelID)
 	if err != nil {
 		return err
@@ -199,11 +204,6 @@ func (provider *provider) DeleteChannelByID(ctx context.Context, orgID string, c
 		return errors.NewInvalidInputf(errors.CodeInvalidInput,
 			"channel %q cannot be deleted because it is used by the following routing policies: %v",
 			channel.DisplayName, names)
-	}
-
-	config, err := provider.configStore.Get(ctx, orgID)
-	if err != nil {
-		return err
 	}
 
 	if err := config.DeleteReceiver(channel.DisplayName); err != nil {
@@ -291,9 +291,19 @@ func (provider *provider) GetConfig(ctx context.Context, orgID string) (*alertma
 }
 
 func (provider *provider) SetDefaultConfig(ctx context.Context, orgID string) error {
+	existing, err := provider.configStore.Get(ctx, orgID)
+	if err != nil && !errors.Ast(err, errors.TypeNotFound) {
+		return err
+	}
+
 	config, err := alertmanagertypes.NewDefaultConfig(provider.config.Signoz.Global, provider.config.Signoz.Route, orgID)
 	if err != nil {
 		return err
+	}
+
+	if existing != nil {
+		existing.ReplaceWith(config)
+		config = existing
 	}
 
 	return provider.configStore.Set(ctx, config)

--- a/pkg/alertmanager/signozalertmanager/provider_concurrency_test.go
+++ b/pkg/alertmanager/signozalertmanager/provider_concurrency_test.go
@@ -1,0 +1,278 @@
+package signozalertmanager
+
+import (
+	"context"
+	"database/sql"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/SigNoz/signoz/pkg/alertmanager"
+	"github.com/SigNoz/signoz/pkg/alertmanager/nfmanager/nfmanagertest"
+	"github.com/SigNoz/signoz/pkg/errors"
+	"github.com/SigNoz/signoz/pkg/factory"
+	"github.com/SigNoz/signoz/pkg/factory/factorytest"
+	"github.com/SigNoz/signoz/pkg/http/render"
+	"github.com/SigNoz/signoz/pkg/sqlstore"
+	"github.com/SigNoz/signoz/pkg/sqlstore/sqlitesqlstore"
+	"github.com/SigNoz/signoz/pkg/types/alertmanagertypes"
+	"github.com/SigNoz/signoz/pkg/valuer"
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgconn"
+	"github.com/jackc/pgx/v5/stdlib"
+	"github.com/stretchr/testify/require"
+	"github.com/uptrace/bun"
+	"github.com/uptrace/bun/dialect/pgdialect"
+)
+
+type postgresChannelStore struct {
+	sqlstore.SQLStore
+	db *sqlstore.BunDB
+}
+
+func (s *postgresChannelStore) SQLDB() *sql.DB { return s.db.DB.DB }
+func (s *postgresChannelStore) BunDB() *bun.DB { return s.db.DB }
+func (s *postgresChannelStore) BunDBCtx(ctx context.Context) bun.IDB {
+	return s.db.BunDBCtx(ctx)
+}
+func (s *postgresChannelStore) RunInTxCtx(ctx context.Context, opts *sql.TxOptions, cb func(context.Context) error) error {
+	return s.db.RunInTxCtx(ctx, opts, cb)
+}
+func (s *postgresChannelStore) WrapAlreadyExistsErrf(err error, code errors.Code, format string, args ...any) error {
+	var pgErr *pgconn.PgError
+	if errors.As(err, &pgErr) && pgErr.Code == "23505" {
+		return errors.Wrapf(err, errors.TypeAlreadyExists, code, format, args...)
+	}
+	return err
+}
+
+func newChannelTestStore(t *testing.T, database string) sqlstore.SQLStore {
+	t.Helper()
+	var store sqlstore.SQLStore
+	settings := factorytest.NewSettings()
+	if database == "postgres" {
+		dsn := os.Getenv("SIGNOZ_TEST_POSTGRES_DSN")
+		if dsn == "" {
+			t.Skip("SIGNOZ_TEST_POSTGRES_DSN not set")
+		}
+		config, err := pgx.ParseConfig(dsn)
+		require.NoError(t, err)
+		config.ConnectTimeout = 5 * time.Second
+		config.RuntimeParams["statement_timeout"] = "10000"
+		config.RuntimeParams["lock_timeout"] = "5000"
+		admin := stdlib.OpenDB(*config)
+		t.Cleanup(func() { require.NoError(t, admin.Close()) })
+		schema := pgx.Identifier{"channel_" + valuer.GenerateUUID().StringValue()}.Sanitize()
+		_, err = admin.ExecContext(t.Context(), "CREATE SCHEMA "+schema)
+		require.NoError(t, err)
+		t.Cleanup(func() {
+			ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+			defer cancel()
+			_, err := admin.ExecContext(ctx, "DROP SCHEMA "+schema+" CASCADE")
+			require.NoError(t, err)
+		})
+		config.RuntimeParams["search_path"] = schema
+		config.RuntimeParams["statement_timeout"] = "10000"
+		db := stdlib.OpenDB(*config)
+		wrapped := sqlstore.NewBunDB(factory.NewScopedProviderSettings(settings, "channel-test"), db, pgdialect.New(), nil)
+		store = &postgresChannelStore{db: wrapped}
+	} else {
+		var err error
+		store, err = sqlitesqlstore.New(t.Context(), settings, sqlstore.Config{
+			Provider:   "sqlite",
+			Connection: sqlstore.ConnectionConfig{MaxOpenConns: 4},
+			Sqlite: sqlstore.SqliteConfig{
+				Path: filepath.Join(t.TempDir(), "channels.db"), Mode: "wal",
+				BusyTimeout: 5 * time.Second, TransactionMode: "immediate",
+			},
+		})
+		require.NoError(t, err)
+	}
+	t.Cleanup(func() { require.NoError(t, store.SQLDB().Close()) })
+	for _, model := range []any{(*alertmanagertypes.Channel)(nil), (*alertmanagertypes.StoreableConfig)(nil)} {
+		_, err := store.BunDB().NewCreateTable().Model(model).Exec(t.Context())
+		require.NoError(t, err)
+	}
+	_, err := store.BunDB().NewCreateIndex().Model((*alertmanagertypes.StoreableConfig)(nil)).
+		Index("config_org").Column("org_id").Unique().Exec(t.Context())
+	require.NoError(t, err)
+	_, err = store.BunDB().NewCreateIndex().Model((*alertmanagertypes.Channel)(nil)).
+		Index("channel_org_name").Column("org_id", "name").Unique().Exec(t.Context())
+	require.NoError(t, err)
+	return store
+}
+
+type channelReadBarrier struct {
+	alertmanagertypes.ConfigStore
+	reads   atomic.Int32
+	ready   chan int
+	release [2]chan struct{}
+}
+
+func (s *channelReadBarrier) Get(ctx context.Context, orgID string) (*alertmanagertypes.Config, error) {
+	config, err := s.ConfigStore.Get(ctx, orgID)
+	if err != nil {
+		return nil, err
+	}
+	i := int(s.reads.Add(1)) - 1
+	if i < len(s.release) {
+		s.ready <- i
+		select {
+		case <-s.release[i]:
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		}
+	}
+	return config, nil
+}
+
+func channelReceiver(t *testing.T, name, path string) *alertmanagertypes.Receiver {
+	t.Helper()
+	receiver, err := alertmanagertypes.NewReceiver(`{"name":"` + name + `","webhook_configs":[{"url":"http://localhost/` + path + `"}]}`)
+	require.NoError(t, err)
+	return receiver
+}
+
+func channelV2(t *testing.T, name string) *alertmanagertypes.PostableNotificationChannel {
+	t.Helper()
+	// Construct through the wire format to exercise the same tagged-union decoding as the API.
+	var input alertmanagertypes.PostableNotificationChannel
+	require.NoError(t, input.UnmarshalJSON([]byte(`{"name":"`+strings.ToLower(name)+`","displayName":"`+name+`","config":{"kind":"webhook","spec":{"url":"http://localhost/new"}}}`)))
+	return &input
+}
+
+func TestChannelMutationsRejectStaleConfiguration(t *testing.T) {
+	for _, database := range []string{"sqlite", "postgres"} {
+		for _, operations := range [][2]string{
+			{"create", "create"}, {"create-v2", "create-v2"}, {"create", "create-v2"},
+			{"update", "update"}, {"delete", "delete"}, {"delete", "create"}, {"update", "delete"},
+		} {
+			for _, first := range []int{0, 1, -1} {
+				order := "overlapping-writes"
+				if first >= 0 {
+					order = "first-" + string(rune('A'+first))
+				}
+				t.Run(database+"/"+strings.Join(operations[:], "-")+"/"+order, func(t *testing.T) {
+					store := newChannelTestStore(t, database)
+					cfg := alertmanager.NewConfigFactory().New().(alertmanager.Config)
+					nf := nfmanagertest.NewMock()
+					p, err := New(factorytest.NewSettings(), cfg, store, nil, nf, nil)
+					require.NoError(t, err)
+					orgID := valuer.GenerateUUID().StringValue()
+					require.NoError(t, p.SetDefaultConfig(t.Context(), orgID))
+					var existing [2]*alertmanagertypes.Channel
+					initialCount := 0
+					for i, name := range []string{"A", "B"} {
+						if operations[i] == "update" || operations[i] == "delete" {
+							existing[i], err = p.CreateChannel(t.Context(), orgID, channelReceiver(t, name, "old"))
+							require.NoError(t, err)
+							initialCount++
+						}
+					}
+					barrier := &channelReadBarrier{
+						ConfigStore: p.configStore, ready: make(chan int, 2),
+						release: [2]chan struct{}{make(chan struct{}), make(chan struct{})},
+					}
+					other, err := New(factorytest.NewSettings(), cfg, store, nil, nf, nil)
+					require.NoError(t, err)
+					p.configStore, other.configStore = barrier, barrier
+					providers := [2]*provider{p, other}
+					ctx, cancel := context.WithTimeout(t.Context(), 10*time.Second)
+					var workers sync.WaitGroup
+					defer workers.Wait()
+					defer cancel()
+					results := [2]chan error{make(chan error, 1), make(chan error, 1)}
+					var mutations [2]func() error
+					for i, name := range []string{"A", "B"} {
+						receiver := channelReceiver(t, name, "new")
+						v2 := channelV2(t, name)
+						mutations[i] = func() error {
+							var err error
+							switch operations[i] {
+							case "create":
+								_, err = providers[i].CreateChannel(ctx, orgID, receiver)
+							case "create-v2":
+								_, err = providers[i].CreateNotificationChannel(ctx, orgID, v2)
+							case "update":
+								err = providers[i].UpdateChannelByReceiverAndID(ctx, orgID, receiver, existing[i].ID)
+							case "delete":
+								err = providers[i].DeleteChannelByID(ctx, orgID, existing[i].ID)
+							}
+							return err
+						}
+						workers.Add(1)
+						go func() {
+							defer workers.Done()
+							results[i] <- mutations[i]()
+						}()
+						select {
+						case <-barrier.ready:
+						case <-ctx.Done():
+							t.Fatal(ctx.Err())
+						}
+					}
+					winner := first
+					if first < 0 {
+						close(barrier.release[0])
+						close(barrier.release[1])
+						errs := [2]error{<-results[0], <-results[1]}
+						winner = 0
+						if errs[0] != nil {
+							winner = 1
+						}
+						require.NoError(t, errs[winner])
+						err = errs[1-winner]
+					} else {
+						close(barrier.release[first])
+						require.NoError(t, <-results[first])
+						close(barrier.release[1-first])
+						err = <-results[1-first]
+					}
+					require.Error(t, err)
+					require.True(t, errors.Ast(err, errors.TypeAlreadyExists))
+					require.True(t, errors.Asc(err, alertmanagertypes.ErrCodeAlertmanagerConfigConflict))
+					rw := httptest.NewRecorder()
+					render.Error(rw, err)
+					require.Equal(t, http.StatusConflict, rw.Code)
+					channels, err := p.ListChannels(ctx, orgID)
+					require.NoError(t, err)
+					persisted, err := p.GetConfig(ctx, orgID)
+					require.NoError(t, err)
+					delta := map[string]int{"create": 1, "create-v2": 1, "update": 0, "delete": -1}
+					expectedCount := initialCount + delta[operations[winner]]
+					require.Len(t, channels, expectedCount)
+					require.Len(t, persisted.AlertmanagerConfig().Receivers, expectedCount+1)
+					for _, channel := range channels {
+						receiver, err := persisted.GetReceiver(channel.DisplayName)
+						require.NoError(t, err)
+						storedReceiver, err := alertmanagertypes.NewReceiver(channel.Data)
+						require.NoError(t, err)
+						require.Equal(t, storedReceiver.WebhookConfigs, receiver.WebhookConfigs)
+						if operations[1-winner] == "update" && channel.ID == existing[1-winner].ID {
+							require.Equal(t, "http://localhost/old", string(receiver.WebhookConfigs[0].URL))
+						}
+					}
+					// Resubmission must read current state and preserve the previously committed mutation.
+					require.NoError(t, mutations[1-winner]())
+					channels, err = p.ListChannels(ctx, orgID)
+					require.NoError(t, err)
+					persisted, err = p.GetConfig(ctx, orgID)
+					require.NoError(t, err)
+					require.Len(t, channels, expectedCount+delta[operations[1-winner]])
+					require.Len(t, persisted.AlertmanagerConfig().Receivers, len(channels)+1)
+					for _, channel := range channels {
+						receiver, err := persisted.GetReceiver(channel.DisplayName)
+						require.NoError(t, err)
+						require.Equal(t, "http://localhost/new", string(receiver.WebhookConfigs[0].URL))
+					}
+				})
+			}
+		}
+	}
+}

--- a/pkg/query-service/rules/manager.go
+++ b/pkg/query-service/rules/manager.go
@@ -380,11 +380,6 @@ func (m *Manager) EditRule(ctx context.Context, ruleStr string, id valuer.UUID) 
 
 	return m.ruleStore.EditRule(ctx, existingRule, func(ctx context.Context) error {
 		if parsedRule.NotificationSettings != nil {
-			config := parsedRule.NotificationSettings.GetAlertManagerNotificationConfig()
-			err = m.alertmanager.SetNotificationConfig(ctx, orgID, id.StringValue(), &config)
-			if err != nil {
-				return err
-			}
 			if !parsedRule.NotificationSettings.UsePolicy {
 				request, err := parsedRule.GetRuleRouteRequest(id.StringValue())
 				if err != nil {
@@ -407,6 +402,11 @@ func (m *Manager) EditRule(ctx context.Context, ruleStr string, id valuer.UUID) 
 				if err != nil {
 					return err
 				}
+			}
+			// Configuration conflicts must not publish notification settings from a rejected edit.
+			config := parsedRule.NotificationSettings.GetAlertManagerNotificationConfig()
+			if err = m.alertmanager.SetNotificationConfig(ctx, orgID, id.StringValue(), &config); err != nil {
+				return err
 			}
 		}
 		err = m.syncRuleStateWithTask(ctx, orgID, prepareTaskName(existingRule.ID.StringValue()), &parsedRule)
@@ -505,17 +505,17 @@ func (m *Manager) DeleteRule(ctx context.Context, idStr string) error {
 			return err
 		}
 
-		err = m.alertmanager.DeleteNotificationConfig(ctx, orgID, id.String())
-		if err != nil {
-			return err
-		}
-
 		err = m.alertmanager.DeleteAllRoutePoliciesByRuleId(ctx, id.String())
 		if err != nil {
 			return err
 		}
 
 		err = m.alertmanager.DeleteAllInhibitRulesByRuleId(ctx, orgID, id.String())
+		if err != nil {
+			return err
+		}
+
+		err = m.alertmanager.DeleteNotificationConfig(ctx, orgID, id.String())
 		if err != nil {
 			return err
 		}
@@ -585,11 +585,6 @@ func (m *Manager) CreateRule(ctx context.Context, ruleStr string) (*ruletypes.Ge
 
 	id, err := m.ruleStore.CreateRule(ctx, storedRule, func(ctx context.Context, id valuer.UUID) error {
 		if parsedRule.NotificationSettings != nil {
-			config := parsedRule.NotificationSettings.GetAlertManagerNotificationConfig()
-			err = m.alertmanager.SetNotificationConfig(ctx, orgID, id.StringValue(), &config)
-			if err != nil {
-				return err
-			}
 			if !parsedRule.NotificationSettings.UsePolicy {
 				request, err := parsedRule.GetRuleRouteRequest(id.StringValue())
 				if err != nil {
@@ -607,6 +602,10 @@ func (m *Manager) CreateRule(ctx context.Context, ruleStr string) (*ruletypes.Ge
 				if err != nil {
 					return err
 				}
+			}
+			config := parsedRule.NotificationSettings.GetAlertManagerNotificationConfig()
+			if err = m.alertmanager.SetNotificationConfig(ctx, orgID, id.StringValue(), &config); err != nil {
+				return err
 			}
 		}
 

--- a/pkg/query-service/rules/manager_config_conflict_test.go
+++ b/pkg/query-service/rules/manager_config_conflict_test.go
@@ -1,0 +1,178 @@
+package rules
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/SigNoz/signoz/pkg/alertmanager/alertmanagertest"
+	"github.com/SigNoz/signoz/pkg/errors"
+	"github.com/SigNoz/signoz/pkg/types"
+	"github.com/SigNoz/signoz/pkg/types/alertmanagertypes"
+	"github.com/SigNoz/signoz/pkg/types/authtypes"
+	"github.com/SigNoz/signoz/pkg/types/ruletypes"
+	"github.com/SigNoz/signoz/pkg/valuer"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+)
+
+type configConflictRuleStore struct {
+	ruletypes.RuleStore
+	rule          ruletypes.StorableRule
+	callbackCalls int
+}
+
+func (s *configConflictRuleStore) GetStoredRule(context.Context, valuer.UUID, valuer.UUID) (*ruletypes.StorableRule, error) {
+	rule := s.rule
+	return &rule, nil
+}
+
+func (s *configConflictRuleStore) CreateRule(ctx context.Context, _ *ruletypes.StorableRule, cb func(context.Context, valuer.UUID) error) (valuer.UUID, error) {
+	s.callbackCalls++
+	return s.rule.ID, cb(ctx, s.rule.ID)
+}
+
+func (s *configConflictRuleStore) EditRule(ctx context.Context, _ *ruletypes.StorableRule, cb func(context.Context) error) error {
+	s.callbackCalls++
+	return cb(ctx)
+}
+
+func (s *configConflictRuleStore) DeleteRule(ctx context.Context, _, _ valuer.UUID, cb func(context.Context) error) error {
+	s.callbackCalls++
+	return cb(ctx)
+}
+
+type configConflictTask struct {
+	Task
+	stopped bool
+}
+
+func (t *configConflictTask) Stop() {
+	t.stopped = true
+}
+
+func TestManagerConfigConflictPreservesNotificationsAndTasks(t *testing.T) {
+	orgID := valuer.MustNewUUID("01900000-0000-7000-8000-000000000001")
+	ruleID := valuer.MustNewUUID("01900000-0000-7000-8000-000000000002")
+	ctx := authtypes.NewContextWithClaims(context.Background(), authtypes.Claims{
+		OrgID: orgID.StringValue(), Email: "test@example.com",
+	})
+	rule := ThresholdRuleAtLeastOnceValueAbove(10, nil)
+	rule.Disabled = true
+	raw, err := json.Marshal(rule)
+	require.NoError(t, err)
+	var parsed ruletypes.PostableRule
+	require.NoError(t, json.Unmarshal(raw, &parsed))
+	require.NoError(t, parsed.Validate())
+	require.True(t, parsed.Disabled)
+	require.NotNil(t, parsed.NotificationSettings)
+	require.False(t, parsed.NotificationSettings.UsePolicy)
+	requests, err := parsed.GetRuleRouteRequest(ruleID.StringValue())
+	require.NoError(t, err)
+	inhibitors, err := parsed.GetInhibitRules(ruleID.StringValue())
+	require.NoError(t, err)
+
+	for _, tc := range []struct {
+		name      string
+		operation string
+		failAt    string
+		wantCalls []string
+	}{
+		{
+			name: "create/inhibitors", operation: "create", failAt: "CreateInhibitRules",
+			wantCalls: []string{"CreateRoutePolicies", "CreateInhibitRules"},
+		},
+		{
+			name: "edit/delete_inhibitors", operation: "edit", failAt: "DeleteAllInhibitRulesByRuleId",
+			wantCalls: []string{"UpdateAllRoutePoliciesByRuleId", "DeleteAllInhibitRulesByRuleId"},
+		},
+		{
+			name: "edit/create_inhibitors_second_write", operation: "edit", failAt: "CreateInhibitRules",
+			wantCalls: []string{"UpdateAllRoutePoliciesByRuleId", "DeleteAllInhibitRulesByRuleId", "CreateInhibitRules"},
+		},
+		{
+			name: "delete/config", operation: "delete", failAt: "SetConfig",
+			wantCalls: []string{"GetConfig", "SetConfig"},
+		},
+		{
+			name: "delete/inhibitors", operation: "delete", failAt: "DeleteAllInhibitRulesByRuleId",
+			wantCalls: []string{"GetConfig", "SetConfig", "DeleteAllRoutePoliciesByRuleId", "DeleteAllInhibitRulesByRuleId"},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			conflict := errors.New(errors.TypeAlreadyExists, alertmanagertypes.ErrCodeAlertmanagerConfigConflict,
+				"alertmanager configuration changed concurrently")
+			am := alertmanagertest.NewMockAlertmanager(t)
+			am.On("SetNotificationConfig", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil).Maybe()
+			am.On("DeleteNotificationConfig", mock.Anything, mock.Anything, mock.Anything).Return(nil).Maybe()
+			switch tc.operation {
+			case "create":
+				am.On("CreateRoutePolicies", ctx, requests).Return(nil, nil).Once()
+				am.On("CreateInhibitRules", ctx, orgID, inhibitors).Return(conflict).Once()
+			case "edit":
+				am.On("UpdateAllRoutePoliciesByRuleId", ctx, ruleID.StringValue(), requests).Return(nil).Once()
+				if tc.failAt == "DeleteAllInhibitRulesByRuleId" {
+					am.On("DeleteAllInhibitRulesByRuleId", ctx, orgID, ruleID.StringValue()).Return(conflict).Once()
+				} else {
+					am.On("DeleteAllInhibitRulesByRuleId", ctx, orgID, ruleID.StringValue()).Return(nil).Once()
+					am.On("CreateInhibitRules", ctx, orgID, inhibitors).Return(conflict).Once()
+				}
+			case "delete":
+				cfg, err := alertmanagertypes.NewDefaultConfig(alertmanagertypes.GlobalConfig{}, alertmanagertypes.RouteConfig{
+					GroupInterval: time.Minute, GroupWait: time.Minute, RepeatInterval: time.Minute,
+				}, orgID.StringValue())
+				require.NoError(t, err)
+				am.On("GetConfig", ctx, orgID.StringValue()).Return(cfg, nil).Once()
+				if tc.failAt == "SetConfig" {
+					am.On("SetConfig", ctx, cfg).Return(conflict).Once()
+				} else {
+					am.On("SetConfig", ctx, cfg).Return(nil).Once()
+					am.On("DeleteAllRoutePoliciesByRuleId", ctx, ruleID.StringValue()).Return(nil).Once()
+					am.On("DeleteAllInhibitRulesByRuleId", ctx, orgID, ruleID.StringValue()).Return(conflict).Once()
+				}
+			}
+			store := &configConflictRuleStore{rule: ruletypes.StorableRule{
+				Identifiable: types.Identifiable{ID: ruleID}, OrgID: orgID.StringValue(), Data: string(raw),
+			}}
+			mgr, err := NewManager(&ManagerOptions{
+				RuleStore: store, Alertmanager: am,
+				PrepareTaskFunc: func(PrepareTaskOptions) (Task, error) {
+					panic("config conflict must not prepare a task")
+				},
+			})
+			require.NoError(t, err)
+			task := &configConflictTask{}
+			existingRule := &struct{ Rule }{}
+			taskName := prepareTaskName(ruleID.StringValue())
+			mgr.tasks[taskName] = task
+			mgr.rules[ruleID.StringValue()] = existingRule
+
+			switch tc.operation {
+			case "create":
+				var created *ruletypes.GettableRule
+				created, err = mgr.CreateRule(ctx, string(raw))
+				require.Nil(t, created)
+			case "edit":
+				err = mgr.EditRule(ctx, string(raw), ruleID)
+			case "delete":
+				err = mgr.DeleteRule(ctx, ruleID.StringValue())
+			}
+
+			require.ErrorIs(t, err, conflict)
+			require.Equal(t, 1, store.callbackCalls)
+			am.AssertNotCalled(t, "SetNotificationConfig", mock.Anything, mock.Anything, mock.Anything, mock.Anything)
+			am.AssertNotCalled(t, "DeleteNotificationConfig", mock.Anything, mock.Anything, mock.Anything)
+			var calls []string
+			for _, call := range am.Calls {
+				calls = append(calls, call.Method)
+			}
+			require.Equal(t, tc.wantCalls, calls)
+			require.False(t, task.stopped)
+			require.Len(t, mgr.tasks, 1)
+			require.Same(t, task, mgr.tasks[taskName])
+			require.Len(t, mgr.rules, 1)
+			require.Same(t, existingRule, mgr.rules[ruleID.StringValue()])
+		})
+	}
+}

--- a/pkg/types/alertmanagertypes/config.go
+++ b/pkg/types/alertmanagertypes/config.go
@@ -60,6 +60,11 @@ type Config struct {
 	// storeableConfig is the representation of the config in the store
 	storeableConfig *StoreableConfig
 
+	// Retain the persisted hash across normalization and mutations for conditional writes.
+	originalHash      string
+	originalUpdatedAt time.Time
+	persisted         bool
+
 	// customConfigs holds the custom notifier configs upstream's
 	// config.Receiver cannot carry, keyed by receiver name.
 	customConfigs map[string]customReceiverConfigs
@@ -132,6 +137,9 @@ func NewConfigFromStoreableConfig(sc *StoreableConfig) (*Config, error) {
 		alertmanagerConfig: alertmanagerConfig,
 		customConfigs:      customConfigs,
 		storeableConfig:    sc,
+		originalHash:       sc.Hash,
+		originalUpdatedAt:  sc.UpdatedAt,
+		persisted:          true,
 	}, nil
 }
 
@@ -247,6 +255,9 @@ func (c *Config) Resolved() (*Config, error) {
 		alertmanagerConfig: alertmanagerConfig,
 		customConfigs:      customConfigs,
 		storeableConfig:    &storeableConfig,
+		originalHash:       c.originalHash,
+		originalUpdatedAt:  c.originalUpdatedAt,
+		persisted:          c.persisted,
 	}
 	resolved.applyNativeDefaults()
 
@@ -321,6 +332,24 @@ func (c *Config) AlertmanagerConfig() *config.Config {
 
 func (c *Config) StoreableConfig() *StoreableConfig {
 	return c.storeableConfig
+}
+
+// OriginalHash identifies the snapshot read from storage, not the pending content.
+// Read a new snapshot before another write; the enclosing transaction may still roll back.
+func (c *Config) OriginalHash() (string, bool) {
+	return c.originalHash, c.persisted
+}
+
+// OriginalUpdatedAt distinguishes revisions whose content hashes are identical.
+func (c *Config) OriginalUpdatedAt() time.Time {
+	return c.originalUpdatedAt
+}
+
+// ReplaceWith retains identity and the read precondition when reconciling derived content.
+func (c *Config) ReplaceWith(replacement *Config) {
+	c.alertmanagerConfig = replacement.alertmanagerConfig
+	c.customConfigs = replacement.customConfigs
+	c.flush()
 }
 
 func cloneReceiver(receiver *Receiver) (*Receiver, error) {


### PR DESCRIPTION
Description

- Reject stale configuration writes with HTTP 409 and roll back the associated channel mutation, preventing concurrent requests from silently overwriting each other.
- Check configuration identity, hash, and a monotonically advancing update timestamp, including cases where content changes and later returns to its original value.
- Preserve transaction-aware reads, startup reconciliation, and default-reset behavior. Prevent rejected rule mutations from publishing notification settings in memory.
- Add regression tests for concurrent creates, updates, and deletes; mixed V1/V2 requests; rollback and resubmission; and deleted/recreated channels.

Issues closed by this PR
Closes #12825

Additional Information

- No schema migration or dependency changes. Clients encountering a configuration conflict must reload and retry.
- Validated against SQLite and PostgreSQL 18.4, including 20 repeated race-enabled regression runs.
- Affected test suites, formatting, lint, vet, and community/enterprise builds pass. Both commits were also validated in clean worktrees.
- Full deployment-stack HTTP/E2E tests were not run.