### PR TITLE
feat(apiserver): add tls support to http server

### DIFF
--- a/.claude/rules/go-test.md
+++ b/.claude/rules/go-test.md
@@ -1,0 +1,12 @@
+---
+paths:
+  - "**/*_test.go"
+---
+
+# Go tests
+
+- **testify + table-driven.** Use `assert` / `require`; prefer table-driven cases. Tests live next to the source file.
+- **`require` vs `assert`.** `require` for anything the rest of the test cannot proceed without — setup, `require.NoError(t, err)`, nil/length checks before indexing or dereferencing. `assert` for the actual expectations, so one failed check still reports the rest.
+- **Mock with mockery.** When an interface needs mocking, list it in `.mockery.yml` and run `mockery`; never hand-write mocks. Generated mocks live in the source package's `<pkg>test` sibling (e.g. `resourcestest.NewMockAdapter(t)`).
+- **Table format.** Declare cases as `testCases := []struct{ name string; ... }` and iterate with `for _, testCase := range testCases { t.Run(testCase.name, ...) }` — the variables are named `testCases` / `testCase`. Case names are PascalCase segments joined by `_`, one segment per aspect (scenario, condition, expectation): `TimestampNotNullNoDefault`, `DropPrimaryKeyConstraint_AlterColumnNullable`, `ForeignKeyConstraint_DoesNotExist_SCreateAndDropConstraintTrue`.
+- **No hoisted test constants.** When goconst flags a repeated literal in a test, vary the fixture strings across cases instead of hoisting a constant — never introduce a shared const for test data. 

--- a/conf/example.yaml
+++ b/conf/example.yaml
@@ -150,8 +150,6 @@ apiserver:
   #   key_file: /path/to/server.key
   #   # Minimum TLS version: "1.2" or "1.3". Defaults to "1.2".
   #   min_version: "1.2"
-  #   # Maximum TLS version: "1.2" or "1.3". Defaults to the highest supported.
-  #   max_version: "1.3"
   timeout:
     # Default request timeout.
     default: 60s

--- a/conf/example.yaml
+++ b/conf/example.yaml
@@ -144,6 +144,14 @@ apiserver:
   read_timeout: 60s
   # Keep at 0; any value cuts off streaming endpoints (livetail, SSE, export_raw_data).
   write_timeout: 0
+  # tls:
+  #   enabled: true
+  #   cert_file: /path/to/server.crt
+  #   key_file: /path/to/server.key
+  #   # Minimum TLS version: "1.2" or "1.3". Defaults to "1.2".
+  #   min_version: "1.2"
+  #   # Maximum TLS version: "1.2" or "1.3". Defaults to the highest supported.
+  #   max_version: "1.3"
   timeout:
     # Default request timeout.
     default: 60s

--- a/docs/contributing/go/service.md
+++ b/docs/contributing/go/service.md
@@ -191,7 +191,7 @@ A standalone service only has the `factory.Service` lifecycle i.e it does not se
         // ... dependencies ...
     ) user.Service {
         return &service{
-            settings: factory.NewScopedProviderSettings(providerSettings, "go.signoz.io/pkg/modules/user"),
+            settings: factory.NewScopedProviderSettings(providerSettings, "github.com/SigNoz/signoz/pkg/modules/user"),
             // ... dependencies ...
             stopC:    make(chan struct{}),
         }

--- a/pkg/apiserver/config.go
+++ b/pkg/apiserver/config.go
@@ -59,6 +59,10 @@ func newConfig() factory.Config {
 }
 
 func (c Config) Validate() error {
+	if err := c.Config.Validate(); err != nil {
+		return err
+	}
+
 	if c.Address == "" {
 		return errors.NewInvalidInputf(errors.CodeInvalidInput, "apiserver.address is required")
 	}

--- a/pkg/apiserver/config_test.go
+++ b/pkg/apiserver/config_test.go
@@ -16,6 +16,10 @@ import (
 func TestNewWithEnvProvider(t *testing.T) {
 	t.Setenv("SIGNOZ_APISERVER_ADDRESS", "0.0.0.0:9090")
 	t.Setenv("SIGNOZ_APISERVER_READ__TIMEOUT", "80s")
+	t.Setenv("SIGNOZ_APISERVER_TLS_ENABLED", "true")
+	t.Setenv("SIGNOZ_APISERVER_TLS_CERT__FILE", "/etc/signoz/server.crt")
+	t.Setenv("SIGNOZ_APISERVER_TLS_KEY__FILE", "/etc/signoz/server.key")
+	t.Setenv("SIGNOZ_APISERVER_TLS_MIN__VERSION", "1.3")
 	t.Setenv("SIGNOZ_APISERVER_TIMEOUT_DEFAULT", "70s")
 	t.Setenv("SIGNOZ_APISERVER_TIMEOUT_MAX", "700s")
 	t.Setenv("SIGNOZ_APISERVER_TIMEOUT_EXCLUDED__ROUTES", "/excluded1,/excluded2")
@@ -44,6 +48,12 @@ func TestNewWithEnvProvider(t *testing.T) {
 		Config: httpserver.Config{
 			Address:     "0.0.0.0:9090",
 			ReadTimeout: 80 * time.Second,
+			TLS: httpserver.TLS{
+				Enabled:    true,
+				CertFile:   "/etc/signoz/server.crt",
+				KeyFile:    "/etc/signoz/server.key",
+				MinVersion: "1.3",
+			},
 		},
 		Timeout: Timeout{
 			Default: 70 * time.Second,

--- a/pkg/http/server/config.go
+++ b/pkg/http/server/config.go
@@ -12,9 +12,8 @@ var tlsVersions = map[string]uint16{
 	"1.3": tls.VersionTLS13,
 }
 
-// Config holds the configuration for http.
 type Config struct {
-	//Address specifies the TCP address for the server to listen on, in the form "host:port".
+	// Address specifies the TCP address for the server to listen on, in the form "host:port".
 	// If empty, ":http" (port 80) is used. The service names are defined in RFC 6335 and assigned by IANA.
 	// See net.Dial for details of the address format.
 	Address string `mapstructure:"address"`
@@ -30,15 +29,16 @@ type Config struct {
 }
 
 type TLS struct {
-	Enabled  bool   `mapstructure:"enabled"`
+	Enabled bool `mapstructure:"enabled"`
+
+	// The full path to the certificate file.
 	CertFile string `mapstructure:"cert_file"`
-	KeyFile  string `mapstructure:"key_file"`
+
+	// The full path to the key file.
+	KeyFile string `mapstructure:"key_file"`
 
 	// MinVersion is the minimum acceptable TLS version, "1.2" or "1.3". Empty uses the Go default.
 	MinVersion string `mapstructure:"min_version"`
-
-	// MaxVersion is the maximum acceptable TLS version, "1.2" or "1.3". Empty uses the Go default.
-	MaxVersion string `mapstructure:"max_version"`
 }
 
 func (c Config) Validate() error {
@@ -47,21 +47,12 @@ func (c Config) Validate() error {
 	}
 
 	if c.TLS.CertFile == "" || c.TLS.KeyFile == "" {
-		return errors.NewInvalidInputf(errors.CodeInvalidInput, "tls.cert_file and tls.key_file are required when tls is enabled")
+		return errors.NewInvalidInputf(errors.CodeInvalidInput, "tls::cert_file and tls::key_file are required when tls is enabled")
 	}
 
-	minVersion, err := tlsVersion(c.TLS.MinVersion)
+	_, err := tlsVersion(c.TLS.MinVersion)
 	if err != nil {
 		return err
-	}
-
-	maxVersion, err := tlsVersion(c.TLS.MaxVersion)
-	if err != nil {
-		return err
-	}
-
-	if minVersion != 0 && maxVersion != 0 && minVersion > maxVersion {
-		return errors.NewInvalidInputf(errors.CodeInvalidInput, "tls.min_version cannot be greater than tls.max_version")
 	}
 
 	return nil
@@ -70,7 +61,7 @@ func (c Config) Validate() error {
 func (tlsConfig TLS) Config() (*tls.Config, error) {
 	cert, err := tls.LoadX509KeyPair(tlsConfig.CertFile, tlsConfig.KeyFile)
 	if err != nil {
-		return nil, errors.NewInvalidInputf(errors.CodeInvalidInput, "cannot load tls cert_file and key_file: %v", err)
+		return nil, errors.NewInvalidInputf(errors.CodeInvalidInput, "cannot load tls::cert_file and tls::key_file: %v", err)
 	}
 
 	minVersion, err := tlsVersion(tlsConfig.MinVersion)
@@ -78,15 +69,9 @@ func (tlsConfig TLS) Config() (*tls.Config, error) {
 		return nil, err
 	}
 
-	maxVersion, err := tlsVersion(tlsConfig.MaxVersion)
-	if err != nil {
-		return nil, err
-	}
-
 	return &tls.Config{
 		Certificates: []tls.Certificate{cert},
 		MinVersion:   minVersion,
-		MaxVersion:   maxVersion,
 	}, nil
 }
 

--- a/pkg/http/server/config.go
+++ b/pkg/http/server/config.go
@@ -1,6 +1,16 @@
 package server
 
-import "time"
+import (
+	"crypto/tls"
+	"time"
+
+	"github.com/SigNoz/signoz/pkg/errors"
+)
+
+var tlsVersions = map[string]uint16{
+	"1.2": tls.VersionTLS12,
+	"1.3": tls.VersionTLS13,
+}
 
 // Config holds the configuration for http.
 type Config struct {
@@ -15,4 +25,80 @@ type Config struct {
 	// WriteTimeout bounds writing the response. Zero means no timeout, required for
 	// streaming endpoints that hold the connection open.
 	WriteTimeout time.Duration `mapstructure:"write_timeout"`
+
+	TLS TLS `mapstructure:"tls"`
+}
+
+type TLS struct {
+	Enabled  bool   `mapstructure:"enabled"`
+	CertFile string `mapstructure:"cert_file"`
+	KeyFile  string `mapstructure:"key_file"`
+
+	// MinVersion is the minimum acceptable TLS version, "1.2" or "1.3". Empty uses the Go default.
+	MinVersion string `mapstructure:"min_version"`
+
+	// MaxVersion is the maximum acceptable TLS version, "1.2" or "1.3". Empty uses the Go default.
+	MaxVersion string `mapstructure:"max_version"`
+}
+
+func (c Config) Validate() error {
+	if !c.TLS.Enabled {
+		return nil
+	}
+
+	if c.TLS.CertFile == "" || c.TLS.KeyFile == "" {
+		return errors.NewInvalidInputf(errors.CodeInvalidInput, "tls.cert_file and tls.key_file are required when tls is enabled")
+	}
+
+	minVersion, err := tlsVersion(c.TLS.MinVersion)
+	if err != nil {
+		return err
+	}
+
+	maxVersion, err := tlsVersion(c.TLS.MaxVersion)
+	if err != nil {
+		return err
+	}
+
+	if minVersion != 0 && maxVersion != 0 && minVersion > maxVersion {
+		return errors.NewInvalidInputf(errors.CodeInvalidInput, "tls.min_version cannot be greater than tls.max_version")
+	}
+
+	return nil
+}
+
+func (tlsConfig TLS) Config() (*tls.Config, error) {
+	cert, err := tls.LoadX509KeyPair(tlsConfig.CertFile, tlsConfig.KeyFile)
+	if err != nil {
+		return nil, errors.NewInvalidInputf(errors.CodeInvalidInput, "cannot load tls cert_file and key_file: %v", err)
+	}
+
+	minVersion, err := tlsVersion(tlsConfig.MinVersion)
+	if err != nil {
+		return nil, err
+	}
+
+	maxVersion, err := tlsVersion(tlsConfig.MaxVersion)
+	if err != nil {
+		return nil, err
+	}
+
+	return &tls.Config{
+		Certificates: []tls.Certificate{cert},
+		MinVersion:   minVersion,
+		MaxVersion:   maxVersion,
+	}, nil
+}
+
+func tlsVersion(name string) (uint16, error) {
+	if name == "" {
+		return 0, nil
+	}
+
+	version, ok := tlsVersions[name]
+	if !ok {
+		return 0, errors.NewInvalidInputf(errors.CodeInvalidInput, "invalid tls version %q, must be \"1.2\" or \"1.3\"", name)
+	}
+
+	return version, nil
 }

--- a/pkg/http/server/server.go
+++ b/pkg/http/server/server.go
@@ -51,7 +51,7 @@ func New(logger *slog.Logger, cfg Config, handler http.Handler) (*Server, error)
 
 	return &Server{
 		srv:     srv,
-		logger:  logger.With(slog.String("pkg", "go.signoz.io/pkg/http/server")),
+		logger:  logger.With(slog.String("pkg", "github.com/SigNoz/signoz/pkg/http/server")),
 		handler: handler,
 		cfg:     cfg,
 	}, nil
@@ -62,6 +62,7 @@ func (server *Server) Start(ctx context.Context) error {
 
 	var err error
 	if server.cfg.TLS.Enabled {
+		// The certificate is already loaded in TLSConfig, so ListenAndServeTLS needs no file paths.
 		err = server.srv.ListenAndServeTLS("", "")
 	} else {
 		err = server.srv.ListenAndServe()

--- a/pkg/http/server/server.go
+++ b/pkg/http/server/server.go
@@ -28,12 +28,25 @@ func New(logger *slog.Logger, cfg Config, handler http.Handler) (*Server, error)
 		return nil, errors.NewInvalidInputf(errors.CodeInvalidInput, "cannot build http server, logger is required")
 	}
 
+	if err := cfg.Validate(); err != nil {
+		return nil, err
+	}
+
 	srv := &http.Server{
 		Addr:           cfg.Address,
 		Handler:        handler,
 		ReadTimeout:    cfg.ReadTimeout,
 		WriteTimeout:   cfg.WriteTimeout,
 		MaxHeaderBytes: 1 << 20,
+	}
+
+	if cfg.TLS.Enabled {
+		tlsConfig, err := cfg.TLS.Config()
+		if err != nil {
+			return nil, err
+		}
+
+		srv.TLSConfig = tlsConfig
 	}
 
 	return &Server{
@@ -46,11 +59,17 @@ func New(logger *slog.Logger, cfg Config, handler http.Handler) (*Server, error)
 
 func (server *Server) Start(ctx context.Context) error {
 	server.logger.InfoContext(ctx, "starting http server", slog.String("address", server.srv.Addr))
-	if err := server.srv.ListenAndServe(); err != nil {
-		if err != http.ErrServerClosed {
-			server.logger.ErrorContext(ctx, "failed to start server", errors.Attr(err))
-			return err
-		}
+
+	var err error
+	if server.cfg.TLS.Enabled {
+		err = server.srv.ListenAndServeTLS("", "")
+	} else {
+		err = server.srv.ListenAndServe()
+	}
+
+	if err != nil && err != http.ErrServerClosed {
+		server.logger.ErrorContext(ctx, "failed to start server", errors.Attr(err))
+		return err
 	}
 	return nil
 }

--- a/pkg/http/server/server_test.go
+++ b/pkg/http/server/server_test.go
@@ -24,7 +24,7 @@ import (
 )
 
 func TestNew(t *testing.T) {
-	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	logger := slog.New(slog.DiscardHandler)
 	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {})
 	certFile, keyFile := writeSelfSignedCert(t)
 
@@ -112,7 +112,7 @@ func TestStartWithTLS(t *testing.T) {
 	addr := freeAddr(t)
 
 	server, err := New(
-		slog.New(slog.NewTextHandler(io.Discard, nil)),
+		slog.New(slog.DiscardHandler),
 		Config{Address: addr, TLS: TLS{Enabled: true, CertFile: certFile, KeyFile: keyFile}},
 		http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) { _, _ = w.Write([]byte("ok")) }),
 	)
@@ -127,19 +127,33 @@ func TestStartWithTLS(t *testing.T) {
 	require.True(t, pool.AppendCertsFromPEM(certPEM))
 	client := &http.Client{Transport: &http.Transport{TLSClientConfig: &tls.Config{RootCAs: pool}}}
 
-	var resp *http.Response
+	var (
+		statusCode int
+		body       []byte
+		tlsVersion uint16
+	)
 	require.Eventually(t, func() bool {
-		resp, err = client.Get("https://" + addr)
-		return err == nil
-	}, 5*time.Second, 25*time.Millisecond)
-	defer func() { _ = resp.Body.Close() }()
+		resp, err := client.Get("https://" + addr)
+		if err != nil {
+			return false
+		}
+		defer func() { _ = resp.Body.Close() }()
 
-	body, err := io.ReadAll(resp.Body)
-	require.NoError(t, err)
-	assert.Equal(t, http.StatusOK, resp.StatusCode)
+		body, err = io.ReadAll(resp.Body)
+		if err != nil {
+			return false
+		}
+
+		statusCode = resp.StatusCode
+		if resp.TLS != nil {
+			tlsVersion = resp.TLS.Version
+		}
+		return true
+	}, 5*time.Second, 25*time.Millisecond)
+
+	assert.Equal(t, http.StatusOK, statusCode)
 	assert.Equal(t, "ok", string(body))
-	require.NotNil(t, resp.TLS)
-	assert.GreaterOrEqual(t, resp.TLS.Version, uint16(tls.VersionTLS12))
+	assert.GreaterOrEqual(t, tlsVersion, uint16(tls.VersionTLS12))
 
 	plainResp, err := http.Get("http://" + addr)
 	require.NoError(t, err)
@@ -154,7 +168,7 @@ func TestStartWithoutTLS(t *testing.T) {
 	addr := freeAddr(t)
 
 	server, err := New(
-		slog.New(slog.NewTextHandler(io.Discard, nil)),
+		slog.New(slog.DiscardHandler),
 		Config{Address: addr},
 		http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) { _, _ = w.Write([]byte("pong")) }),
 	)
@@ -163,16 +177,24 @@ func TestStartWithoutTLS(t *testing.T) {
 	errC := make(chan error, 1)
 	go func() { errC <- server.Start(context.Background()) }()
 
-	var resp *http.Response
+	var (
+		statusCode    int
+		tlsNegotiated bool
+	)
 	require.Eventually(t, func() bool {
-		var err error
-		resp, err = http.Get("http://" + addr)
-		return err == nil
-	}, 5*time.Second, 25*time.Millisecond)
-	defer func() { _ = resp.Body.Close() }()
+		resp, err := http.Get("http://" + addr)
+		if err != nil {
+			return false
+		}
+		defer func() { _ = resp.Body.Close() }()
 
-	assert.Equal(t, http.StatusOK, resp.StatusCode)
-	assert.Nil(t, resp.TLS)
+		statusCode = resp.StatusCode
+		tlsNegotiated = resp.TLS != nil
+		return true
+	}, 5*time.Second, 25*time.Millisecond)
+
+	assert.Equal(t, http.StatusOK, statusCode)
+	assert.False(t, tlsNegotiated)
 
 	require.NoError(t, server.Stop(context.Background()))
 	require.NoError(t, <-errC)

--- a/pkg/http/server/server_test.go
+++ b/pkg/http/server/server_test.go
@@ -36,7 +36,6 @@ func TestNew(t *testing.T) {
 		config     Config
 		err        bool
 		minVersion uint16
-		maxVersion uint16
 	}{
 		{
 			name:   "TLSDisabled",
@@ -67,16 +66,6 @@ func TestNew(t *testing.T) {
 			err:    true,
 		},
 		{
-			name:   "TLSEnabled_InvalidMaxVersion",
-			config: Config{TLS: TLS{Enabled: true, CertFile: "apiserver.crt", KeyFile: "apiserver.key", MaxVersion: "tls1.3"}},
-			err:    true,
-		},
-		{
-			name:   "TLSEnabled_MinGreaterThanMax",
-			config: Config{TLS: TLS{Enabled: true, CertFile: "http.crt", KeyFile: "http.key", MinVersion: "1.3", MaxVersion: "1.2"}},
-			err:    true,
-		},
-		{
 			name:   "TLSEnabled_MissingFiles",
 			config: Config{TLS: TLS{Enabled: true, CertFile: "missing.crt", KeyFile: "missing.key"}},
 			err:    true,
@@ -91,10 +80,9 @@ func TestNew(t *testing.T) {
 			config: Config{TLS: TLS{Enabled: true, CertFile: certFile, KeyFile: keyFile}},
 		},
 		{
-			name:       "TLSEnabled_WithMinAndMax",
-			config:     Config{TLS: TLS{Enabled: true, CertFile: certFile, KeyFile: keyFile, MinVersion: "1.2", MaxVersion: "1.3"}},
-			minVersion: tls.VersionTLS12,
-			maxVersion: tls.VersionTLS13,
+			name:       "TLSEnabled_WithMin",
+			config:     Config{TLS: TLS{Enabled: true, CertFile: certFile, KeyFile: keyFile, MinVersion: "1.3"}},
+			minVersion: tls.VersionTLS13,
 		},
 	}
 
@@ -115,7 +103,6 @@ func TestNew(t *testing.T) {
 			require.NotNil(t, server.srv.TLSConfig)
 			assert.Len(t, server.srv.TLSConfig.Certificates, 1)
 			assert.Equal(t, testCase.minVersion, server.srv.TLSConfig.MinVersion)
-			assert.Equal(t, testCase.maxVersion, server.srv.TLSConfig.MaxVersion)
 		})
 	}
 }

--- a/pkg/http/server/server_test.go
+++ b/pkg/http/server/server_test.go
@@ -23,90 +23,57 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestConfigValidate(t *testing.T) {
-	testCases := []struct {
-		name string
-		tls  TLS
-		err  bool
-	}{
-		{
-			name: "TLSDisabled",
-			tls:  TLS{},
-			err:  false,
-		},
-		{
-			name: "TLSEnabled_WithoutCertAndKey",
-			tls:  TLS{Enabled: true},
-			err:  true,
-		},
-		{
-			name: "TLSEnabled_WithoutKey",
-			tls:  TLS{Enabled: true, CertFile: "server.crt"},
-			err:  true,
-		},
-		{
-			name: "TLSEnabled_WithoutCert",
-			tls:  TLS{Enabled: true, KeyFile: "server.key"},
-			err:  true,
-		},
-		{
-			name: "TLSEnabled_WithCertAndKey",
-			tls:  TLS{Enabled: true, CertFile: "tls.crt", KeyFile: "tls.key"},
-			err:  false,
-		},
-		{
-			name: "TLSEnabled_InvalidMinVersion",
-			tls:  TLS{Enabled: true, CertFile: "apiserver.crt", KeyFile: "apiserver.key", MinVersion: "1.1"},
-			err:  true,
-		},
-		{
-			name: "TLSEnabled_InvalidMaxVersion",
-			tls:  TLS{Enabled: true, CertFile: "http.crt", KeyFile: "http.key", MaxVersion: "tls1.3"},
-			err:  true,
-		},
-		{
-			name: "TLSEnabled_MinGreaterThanMax",
-			tls:  TLS{Enabled: true, CertFile: "frontend.crt", KeyFile: "frontend.key", MinVersion: "1.3", MaxVersion: "1.2"},
-			err:  true,
-		},
-		{
-			name: "TLSEnabled_WithMinAndMax",
-			tls:  TLS{Enabled: true, CertFile: "backend.crt", KeyFile: "backend.key", MinVersion: "1.2", MaxVersion: "1.3"},
-			err:  false,
-		},
-	}
-
-	for _, testCase := range testCases {
-		t.Run(testCase.name, func(t *testing.T) {
-			err := Config{TLS: testCase.tls}.Validate()
-			if testCase.err {
-				assert.Error(t, err)
-			} else {
-				assert.NoError(t, err)
-			}
-		})
-	}
-}
-
 func TestNew(t *testing.T) {
 	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
 	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {})
 	certFile, keyFile := writeSelfSignedCert(t)
+
+	corruptFile := filepath.Join(t.TempDir(), "corrupt.crt")
+	require.NoError(t, os.WriteFile(corruptFile, []byte("not a pem"), 0o644))
 
 	testCases := []struct {
 		name       string
 		config     Config
 		err        bool
 		minVersion uint16
+		maxVersion uint16
 	}{
 		{
 			name:   "TLSDisabled",
 			config: Config{},
-			err:    false,
+		},
+		{
+			name:   "TLSDisabled_WithCertAndKey",
+			config: Config{TLS: TLS{CertFile: "ignored.crt", KeyFile: "ignored.key"}},
 		},
 		{
 			name:   "TLSEnabled_WithoutCertAndKey",
 			config: Config{TLS: TLS{Enabled: true}},
+			err:    true,
+		},
+		{
+			name:   "TLSEnabled_WithoutKey",
+			config: Config{TLS: TLS{Enabled: true, CertFile: "server.crt"}},
+			err:    true,
+		},
+		{
+			name:   "TLSEnabled_WithoutCert",
+			config: Config{TLS: TLS{Enabled: true, KeyFile: "server.key"}},
+			err:    true,
+		},
+		{
+			name:   "TLSEnabled_InvalidMinVersion",
+			config: Config{TLS: TLS{Enabled: true, CertFile: "tls.crt", KeyFile: "tls.key", MinVersion: "1.1"}},
+			err:    true,
+		},
+		{
+			name:   "TLSEnabled_InvalidMaxVersion",
+			config: Config{TLS: TLS{Enabled: true, CertFile: "apiserver.crt", KeyFile: "apiserver.key", MaxVersion: "tls1.3"}},
+			err:    true,
+		},
+		{
+			name:   "TLSEnabled_MinGreaterThanMax",
+			config: Config{TLS: TLS{Enabled: true, CertFile: "http.crt", KeyFile: "http.key", MinVersion: "1.3", MaxVersion: "1.2"}},
 			err:    true,
 		},
 		{
@@ -115,10 +82,19 @@ func TestNew(t *testing.T) {
 			err:    true,
 		},
 		{
-			name:       "TLSEnabled_ValidCertAndKey",
-			config:     Config{TLS: TLS{Enabled: true, CertFile: certFile, KeyFile: keyFile, MinVersion: "1.3"}},
-			err:        false,
-			minVersion: tls.VersionTLS13,
+			name:   "TLSEnabled_CorruptCertFile",
+			config: Config{TLS: TLS{Enabled: true, CertFile: corruptFile, KeyFile: keyFile}},
+			err:    true,
+		},
+		{
+			name:   "TLSEnabled_DefaultVersions",
+			config: Config{TLS: TLS{Enabled: true, CertFile: certFile, KeyFile: keyFile}},
+		},
+		{
+			name:       "TLSEnabled_WithMinAndMax",
+			config:     Config{TLS: TLS{Enabled: true, CertFile: certFile, KeyFile: keyFile, MinVersion: "1.2", MaxVersion: "1.3"}},
+			minVersion: tls.VersionTLS12,
+			maxVersion: tls.VersionTLS13,
 		},
 	}
 
@@ -131,13 +107,15 @@ func TestNew(t *testing.T) {
 			}
 
 			require.NoError(t, err)
-			if testCase.config.TLS.Enabled {
-				require.NotNil(t, server.srv.TLSConfig)
-				assert.Len(t, server.srv.TLSConfig.Certificates, 1)
-				assert.Equal(t, testCase.minVersion, server.srv.TLSConfig.MinVersion)
-			} else {
+			if !testCase.config.TLS.Enabled {
 				assert.Nil(t, server.srv.TLSConfig)
+				return
 			}
+
+			require.NotNil(t, server.srv.TLSConfig)
+			assert.Len(t, server.srv.TLSConfig.Certificates, 1)
+			assert.Equal(t, testCase.minVersion, server.srv.TLSConfig.MinVersion)
+			assert.Equal(t, testCase.maxVersion, server.srv.TLSConfig.MaxVersion)
 		})
 	}
 }

--- a/pkg/http/server/server_test.go
+++ b/pkg/http/server/server_test.go
@@ -1,0 +1,196 @@
+package server
+
+import (
+	"context"
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/tls"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
+	"io"
+	"log/slog"
+	"math/big"
+	"net"
+	"net/http"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestConfigValidate(t *testing.T) {
+	testCases := []struct {
+		name string
+		tls  TLS
+		err  bool
+	}{
+		{"disabled", TLS{}, false},
+		{"enabled without cert and key", TLS{Enabled: true}, true},
+		{"enabled without key", TLS{Enabled: true, CertFile: "server.crt"}, true},
+		{"enabled without cert", TLS{Enabled: true, KeyFile: "server.key"}, true},
+		{"enabled with cert and key", TLS{Enabled: true, CertFile: "server.crt", KeyFile: "server.key"}, false},
+		{"enabled with invalid min version", TLS{Enabled: true, CertFile: "server.crt", KeyFile: "server.key", MinVersion: "1.1"}, true},
+		{"enabled with invalid max version", TLS{Enabled: true, CertFile: "server.crt", KeyFile: "server.key", MaxVersion: "tls1.3"}, true},
+		{"enabled with min greater than max", TLS{Enabled: true, CertFile: "server.crt", KeyFile: "server.key", MinVersion: "1.3", MaxVersion: "1.2"}, true},
+		{"enabled with min and max", TLS{Enabled: true, CertFile: "server.crt", KeyFile: "server.key", MinVersion: "1.2", MaxVersion: "1.3"}, false},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := Config{TLS: tc.tls}.Validate()
+			if tc.err {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}
+
+func TestNew(t *testing.T) {
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {})
+
+	t.Run("tls disabled", func(t *testing.T) {
+		server, err := New(logger, Config{}, handler)
+		require.NoError(t, err)
+		assert.Nil(t, server.srv.TLSConfig)
+	})
+
+	t.Run("tls enabled without cert and key", func(t *testing.T) {
+		_, err := New(logger, Config{TLS: TLS{Enabled: true}}, handler)
+		assert.Error(t, err)
+	})
+
+	t.Run("tls enabled with missing files", func(t *testing.T) {
+		_, err := New(logger, Config{TLS: TLS{Enabled: true, CertFile: "missing.crt", KeyFile: "missing.key"}}, handler)
+		assert.Error(t, err)
+	})
+
+	t.Run("tls enabled with valid cert and key", func(t *testing.T) {
+		certFile, keyFile := writeSelfSignedCert(t)
+		server, err := New(logger, Config{TLS: TLS{Enabled: true, CertFile: certFile, KeyFile: keyFile, MinVersion: "1.3"}}, handler)
+		require.NoError(t, err)
+		require.NotNil(t, server.srv.TLSConfig)
+		assert.Len(t, server.srv.TLSConfig.Certificates, 1)
+		assert.Equal(t, uint16(tls.VersionTLS13), server.srv.TLSConfig.MinVersion)
+	})
+}
+
+func TestStartWithTLS(t *testing.T) {
+	certFile, keyFile := writeSelfSignedCert(t)
+	addr := freeAddr(t)
+
+	server, err := New(
+		slog.New(slog.NewTextHandler(io.Discard, nil)),
+		Config{Address: addr, TLS: TLS{Enabled: true, CertFile: certFile, KeyFile: keyFile}},
+		http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) { _, _ = w.Write([]byte("ok")) }),
+	)
+	require.NoError(t, err)
+
+	errC := make(chan error, 1)
+	go func() { errC <- server.Start(context.Background()) }()
+
+	certPEM, err := os.ReadFile(certFile)
+	require.NoError(t, err)
+	pool := x509.NewCertPool()
+	require.True(t, pool.AppendCertsFromPEM(certPEM))
+	client := &http.Client{Transport: &http.Transport{TLSClientConfig: &tls.Config{RootCAs: pool}}}
+
+	var resp *http.Response
+	require.Eventually(t, func() bool {
+		resp, err = client.Get("https://" + addr)
+		return err == nil
+	}, 5*time.Second, 25*time.Millisecond)
+	defer func() { _ = resp.Body.Close() }()
+
+	body, err := io.ReadAll(resp.Body)
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+	assert.Equal(t, "ok", string(body))
+	require.NotNil(t, resp.TLS)
+	assert.GreaterOrEqual(t, resp.TLS.Version, uint16(tls.VersionTLS12))
+
+	plainResp, err := http.Get("http://" + addr)
+	require.NoError(t, err)
+	_ = plainResp.Body.Close()
+	assert.Equal(t, http.StatusBadRequest, plainResp.StatusCode)
+
+	require.NoError(t, server.Stop(context.Background()))
+	require.NoError(t, <-errC)
+}
+
+func TestStartWithoutTLS(t *testing.T) {
+	addr := freeAddr(t)
+
+	server, err := New(
+		slog.New(slog.NewTextHandler(io.Discard, nil)),
+		Config{Address: addr},
+		http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) { _, _ = w.Write([]byte("ok")) }),
+	)
+	require.NoError(t, err)
+
+	errC := make(chan error, 1)
+	go func() { errC <- server.Start(context.Background()) }()
+
+	var resp *http.Response
+	require.Eventually(t, func() bool {
+		var err error
+		resp, err = http.Get("http://" + addr)
+		return err == nil
+	}, 5*time.Second, 25*time.Millisecond)
+	defer func() { _ = resp.Body.Close() }()
+
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+	assert.Nil(t, resp.TLS)
+
+	require.NoError(t, server.Stop(context.Background()))
+	require.NoError(t, <-errC)
+}
+
+func freeAddr(t *testing.T) string {
+	t.Helper()
+
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	defer func() { _ = listener.Close() }()
+
+	return listener.Addr().String()
+}
+
+func writeSelfSignedCert(t *testing.T) (string, string) {
+	t.Helper()
+
+	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	require.NoError(t, err)
+
+	template := &x509.Certificate{
+		SerialNumber: big.NewInt(1),
+		Subject:      pkix.Name{CommonName: "localhost"},
+		NotBefore:    time.Now().Add(-time.Hour),
+		NotAfter:     time.Now().Add(time.Hour),
+		KeyUsage:     x509.KeyUsageDigitalSignature,
+		ExtKeyUsage:  []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
+		IPAddresses:  []net.IP{net.ParseIP("127.0.0.1")},
+	}
+
+	der, err := x509.CreateCertificate(rand.Reader, template, template, &key.PublicKey, key)
+	require.NoError(t, err)
+
+	keyDER, err := x509.MarshalECPrivateKey(key)
+	require.NoError(t, err)
+
+	dir := t.TempDir()
+	certFile := filepath.Join(dir, "server.crt")
+	keyFile := filepath.Join(dir, "server.key")
+
+	require.NoError(t, os.WriteFile(certFile, pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: der}), 0o644))
+	require.NoError(t, os.WriteFile(keyFile, pem.EncodeToMemory(&pem.Block{Type: "EC PRIVATE KEY", Bytes: keyDER}), 0o600))
+
+	return certFile, keyFile
+}

--- a/pkg/http/server/server_test.go
+++ b/pkg/http/server/server_test.go
@@ -29,21 +29,57 @@ func TestConfigValidate(t *testing.T) {
 		tls  TLS
 		err  bool
 	}{
-		{"disabled", TLS{}, false},
-		{"enabled without cert and key", TLS{Enabled: true}, true},
-		{"enabled without key", TLS{Enabled: true, CertFile: "server.crt"}, true},
-		{"enabled without cert", TLS{Enabled: true, KeyFile: "server.key"}, true},
-		{"enabled with cert and key", TLS{Enabled: true, CertFile: "server.crt", KeyFile: "server.key"}, false},
-		{"enabled with invalid min version", TLS{Enabled: true, CertFile: "server.crt", KeyFile: "server.key", MinVersion: "1.1"}, true},
-		{"enabled with invalid max version", TLS{Enabled: true, CertFile: "server.crt", KeyFile: "server.key", MaxVersion: "tls1.3"}, true},
-		{"enabled with min greater than max", TLS{Enabled: true, CertFile: "server.crt", KeyFile: "server.key", MinVersion: "1.3", MaxVersion: "1.2"}, true},
-		{"enabled with min and max", TLS{Enabled: true, CertFile: "server.crt", KeyFile: "server.key", MinVersion: "1.2", MaxVersion: "1.3"}, false},
+		{
+			name: "TLSDisabled",
+			tls:  TLS{},
+			err:  false,
+		},
+		{
+			name: "TLSEnabled_WithoutCertAndKey",
+			tls:  TLS{Enabled: true},
+			err:  true,
+		},
+		{
+			name: "TLSEnabled_WithoutKey",
+			tls:  TLS{Enabled: true, CertFile: "server.crt"},
+			err:  true,
+		},
+		{
+			name: "TLSEnabled_WithoutCert",
+			tls:  TLS{Enabled: true, KeyFile: "server.key"},
+			err:  true,
+		},
+		{
+			name: "TLSEnabled_WithCertAndKey",
+			tls:  TLS{Enabled: true, CertFile: "tls.crt", KeyFile: "tls.key"},
+			err:  false,
+		},
+		{
+			name: "TLSEnabled_InvalidMinVersion",
+			tls:  TLS{Enabled: true, CertFile: "apiserver.crt", KeyFile: "apiserver.key", MinVersion: "1.1"},
+			err:  true,
+		},
+		{
+			name: "TLSEnabled_InvalidMaxVersion",
+			tls:  TLS{Enabled: true, CertFile: "http.crt", KeyFile: "http.key", MaxVersion: "tls1.3"},
+			err:  true,
+		},
+		{
+			name: "TLSEnabled_MinGreaterThanMax",
+			tls:  TLS{Enabled: true, CertFile: "frontend.crt", KeyFile: "frontend.key", MinVersion: "1.3", MaxVersion: "1.2"},
+			err:  true,
+		},
+		{
+			name: "TLSEnabled_WithMinAndMax",
+			tls:  TLS{Enabled: true, CertFile: "backend.crt", KeyFile: "backend.key", MinVersion: "1.2", MaxVersion: "1.3"},
+			err:  false,
+		},
 	}
 
-	for _, tc := range testCases {
-		t.Run(tc.name, func(t *testing.T) {
-			err := Config{TLS: tc.tls}.Validate()
-			if tc.err {
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			err := Config{TLS: testCase.tls}.Validate()
+			if testCase.err {
 				assert.Error(t, err)
 			} else {
 				assert.NoError(t, err)
@@ -55,31 +91,55 @@ func TestConfigValidate(t *testing.T) {
 func TestNew(t *testing.T) {
 	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
 	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {})
+	certFile, keyFile := writeSelfSignedCert(t)
 
-	t.Run("tls disabled", func(t *testing.T) {
-		server, err := New(logger, Config{}, handler)
-		require.NoError(t, err)
-		assert.Nil(t, server.srv.TLSConfig)
-	})
+	testCases := []struct {
+		name       string
+		config     Config
+		err        bool
+		minVersion uint16
+	}{
+		{
+			name:   "TLSDisabled",
+			config: Config{},
+			err:    false,
+		},
+		{
+			name:   "TLSEnabled_WithoutCertAndKey",
+			config: Config{TLS: TLS{Enabled: true}},
+			err:    true,
+		},
+		{
+			name:   "TLSEnabled_MissingFiles",
+			config: Config{TLS: TLS{Enabled: true, CertFile: "missing.crt", KeyFile: "missing.key"}},
+			err:    true,
+		},
+		{
+			name:       "TLSEnabled_ValidCertAndKey",
+			config:     Config{TLS: TLS{Enabled: true, CertFile: certFile, KeyFile: keyFile, MinVersion: "1.3"}},
+			err:        false,
+			minVersion: tls.VersionTLS13,
+		},
+	}
 
-	t.Run("tls enabled without cert and key", func(t *testing.T) {
-		_, err := New(logger, Config{TLS: TLS{Enabled: true}}, handler)
-		assert.Error(t, err)
-	})
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			server, err := New(logger, testCase.config, handler)
+			if testCase.err {
+				assert.Error(t, err)
+				return
+			}
 
-	t.Run("tls enabled with missing files", func(t *testing.T) {
-		_, err := New(logger, Config{TLS: TLS{Enabled: true, CertFile: "missing.crt", KeyFile: "missing.key"}}, handler)
-		assert.Error(t, err)
-	})
-
-	t.Run("tls enabled with valid cert and key", func(t *testing.T) {
-		certFile, keyFile := writeSelfSignedCert(t)
-		server, err := New(logger, Config{TLS: TLS{Enabled: true, CertFile: certFile, KeyFile: keyFile, MinVersion: "1.3"}}, handler)
-		require.NoError(t, err)
-		require.NotNil(t, server.srv.TLSConfig)
-		assert.Len(t, server.srv.TLSConfig.Certificates, 1)
-		assert.Equal(t, uint16(tls.VersionTLS13), server.srv.TLSConfig.MinVersion)
-	})
+			require.NoError(t, err)
+			if testCase.config.TLS.Enabled {
+				require.NotNil(t, server.srv.TLSConfig)
+				assert.Len(t, server.srv.TLSConfig.Certificates, 1)
+				assert.Equal(t, testCase.minVersion, server.srv.TLSConfig.MinVersion)
+			} else {
+				assert.Nil(t, server.srv.TLSConfig)
+			}
+		})
+	}
 }
 
 func TestStartWithTLS(t *testing.T) {
@@ -131,7 +191,7 @@ func TestStartWithoutTLS(t *testing.T) {
 	server, err := New(
 		slog.New(slog.NewTextHandler(io.Discard, nil)),
 		Config{Address: addr},
-		http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) { _, _ = w.Write([]byte("ok")) }),
+		http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) { _, _ = w.Write([]byte("pong")) }),
 	)
 	require.NoError(t, err)
 


### PR DESCRIPTION
#### Description

- Adds optional TLS to `pkg/http/server`, exposed under `apiserver.tls`: `enabled`, `cert_file`, `key_file`, `min_version` ("1.2" or "1.3").
- When enabled, the apiserver loads the key pair at startup and serves HTTPS via `ListenAndServeTLS`; disabled by default, no behavior change otherwise.
- Env: `SIGNOZ_APISERVER_TLS_ENABLED`, `SIGNOZ_APISERVER_TLS_CERT__FILE`, `SIGNOZ_APISERVER_TLS_KEY__FILE`, `SIGNOZ_APISERVER_TLS_MIN__VERSION`.
- Adds `.claude/rules/go-test.md`; the new http server tests follow it.
- Part of SigNoz/platform-pod#2302 — covers the apiserver HTTP piece only.