### PR TITLE
test(traces-qb): make the map/json backend factor explicit per test

### DIFF
--- a/tests/fixtures/traces.py
+++ b/tests/fixtures/traces.py
@@ -968,19 +968,22 @@ def seed_attribute_evolution(
 ATTRIBUTE_JSON_ROLLOUT_TIME = datetime.datetime(2020, 1, 1, tzinfo=datetime.UTC)
 
 
-@pytest.fixture(name="attribute_backend", params=["map", "json"])
-def attribute_backend(
-    request: pytest.FixtureRequest,
+@pytest.fixture(name="use_attribute_backend")
+def use_attribute_backend(
     seed_attribute_evolution: Callable[[str, datetime.datetime], None],
-) -> str:
-    """Runs a traces test against both physical attribute layouts. "map" leaves the querier on the
+) -> Callable[[str], None]:
+    """Applies the physical attribute layout a test runs under. "map" leaves the querier on the
     legacy attributes_{string,number,bool} maps; "json" seeds the column-evolution row so it reads
-    the native `attributes` JSON column instead. Relies on insert_traces dual-writing both, so the
-    same seeded spans back either read — a test that passes under both has strict Map/JSON parity."""
-    backend = request.param
-    if backend == "json":
-        seed_attribute_evolution("traces", ATTRIBUTE_JSON_ROLLOUT_TIME)
-    return backend
+    the native `attributes` JSON column instead. Pair with
+    @pytest.mark.parametrize("attribute_backend", ["map", "json"]) and call it once in the body;
+    insert_traces dual-writes both layouts, so a test that passes under both has strict Map/JSON
+    parity."""
+
+    def _apply(backend: str) -> None:
+        if backend == "json":
+            seed_attribute_evolution("traces", ATTRIBUTE_JSON_ROLLOUT_TIME)
+
+    return _apply
 
 
 @pytest.fixture(name="insert_top_level_operations", scope="function")

--- a/tests/integration/tests/queriertraces/02_aggregation.py
+++ b/tests/integration/tests/queriertraces/02_aggregation.py
@@ -33,8 +33,6 @@ from fixtures.traces import TraceIdGenerator, Traces, TracesKind, TracesStatusCo
 # the real intrinsic/calculated/resource columns even when same-named colliding
 # attributes are present, so the corrupt variant yields identical values.
 
-pytestmark = pytest.mark.usefixtures("attribute_backend")
-
 
 # ============================================================================
 # Order-by referencing an aggregation
@@ -66,11 +64,14 @@ pytestmark = pytest.mark.usefixtures("attribute_backend")
         pytest.param({"name": "span.count_", "fieldContext": "span"}, "span.count_", HTTPStatus.OK, id="span.count_span-ctx_alias_span.count_"),
     ],
 )
+@pytest.mark.parametrize("attribute_backend", ["map", "json"])
 def test_traces_aggregate_order_by_count(
     signoz: types.SigNoz,
     create_user_admin: None,  # pylint: disable=unused-argument
     get_token: Callable[[str, str], str],
     insert_traces: Callable[[list[Traces]], None],
+    use_attribute_backend: Callable[[str], None],
+    attribute_backend: str,
     order_by: dict[str, str],
     aggregation_alias: str,
     expected_status: HTTPStatus,
@@ -85,6 +86,8 @@ def test_traces_aggregate_order_by_count(
     fieldContext. Only the combinations that double-specify the context are a bad
     request; the rest resolve and return the span count.
     """
+    use_attribute_backend(attribute_backend)
+
     now = datetime.now(tz=UTC).replace(second=0, microsecond=0)
     trace_id = TraceIdGenerator.trace_id()
     spans = [
@@ -136,11 +139,14 @@ def test_traces_aggregate_order_by_count(
 
 
 @pytest.mark.parametrize("noise", ["clean", "corrupt"])
+@pytest.mark.parametrize("attribute_backend", ["map", "json"])
 def test_traces_aggregate_functions(
     signoz: types.SigNoz,
     create_user_admin: None,  # pylint: disable=unused-argument
     get_token: Callable[[str, str], str],
     insert_traces: Callable[[list[Traces]], None],
+    use_attribute_backend: Callable[[str], None],
+    attribute_backend: str,
     noise: str,
 ) -> None:
     """
@@ -157,6 +163,8 @@ def test_traces_aggregate_functions(
     the corrupt variant the same-named colliding attributes must not change any of
     these.
     """
+    use_attribute_backend(attribute_backend)
+
     extra_attrs, extra_resources = trace_noise(noise)
     now = datetime.now(tz=UTC).replace(second=0, microsecond=0)
     # A scalar rate divides by the whole query window, so both sides agree on it.
@@ -239,11 +247,14 @@ def test_traces_aggregate_functions(
     )
 
 
+@pytest.mark.parametrize("attribute_backend", ["map", "json"])
 def test_traces_aggregate_calculated_range_countif(
     signoz: types.SigNoz,
     create_user_admin: None,  # pylint: disable=unused-argument
     get_token: Callable[[str, str], str],
     insert_traces: Callable[[list[Traces]], None],
+    use_attribute_backend: Callable[[str], None],
+    attribute_backend: str,
 ) -> None:
     """
     Setup:
@@ -253,6 +264,8 @@ def test_traces_aggregate_calculated_range_countif(
     countIf(response_status_code >= 400 AND response_status_code < 500) counts the
     single 4XX span (404).
     """
+    use_attribute_backend(attribute_backend)
+
     now = datetime.now(tz=UTC).replace(second=0, microsecond=0)
     spans = [
         Traces(
@@ -288,11 +301,14 @@ def test_traces_aggregate_calculated_range_countif(
 
 
 @pytest.mark.parametrize("noise", ["clean", "corrupt"])
+@pytest.mark.parametrize("attribute_backend", ["map", "json"])
 def test_traces_aggregate_having(
     signoz: types.SigNoz,
     create_user_admin: None,  # pylint: disable=unused-argument
     get_token: Callable[[str, str], str],
     insert_traces: Callable[[list[Traces]], None],
+    use_attribute_backend: Callable[[str], None],
+    attribute_backend: str,
     noise: str,
 ) -> None:
     """
@@ -303,6 +319,8 @@ def test_traces_aggregate_having(
     A grouped scalar query with `having count() > 2` returns only the groups
     whose count qualifies (svc-a), derived from the inserted spans.
     """
+    use_attribute_backend(attribute_backend)
+
     extra_attrs, extra_resources = trace_noise(noise)
     now = datetime.now(tz=UTC).replace(second=0, microsecond=0)
     counts = {"svc-a": 3, "svc-b": 1}
@@ -355,11 +373,14 @@ def test_traces_aggregate_having(
     ],
 )
 @pytest.mark.parametrize("noise", ["clean", "corrupt"])
+@pytest.mark.parametrize("attribute_backend", ["map", "json"])
 def test_traces_aggregate_time_series_limit(
     signoz: types.SigNoz,
     create_user_admin: None,  # pylint: disable=unused-argument
     get_token: Callable[[str, str], str],
     insert_traces: Callable[[list[Traces]], None],
+    use_attribute_backend: Callable[[str], None],
+    attribute_backend: str,
     noise: str,
     limit: int,
     direction: str,
@@ -374,6 +395,8 @@ def test_traces_aggregate_time_series_limit(
     summing to that service's span count. Under the corrupt variant the grouping
     (resource.service.name) and count are unaffected by the colliding attributes.
     """
+    use_attribute_backend(attribute_backend)
+
     extra_attrs, extra_resources = trace_noise(noise)
     now = datetime.now(tz=UTC).replace(second=0, microsecond=0)
     counts = {"svc-a": 5, "svc-b": 3, "svc-c": 7, "svc-d": 1}
@@ -434,11 +457,14 @@ def test_traces_aggregate_time_series_limit(
         pytest.param("avg(does_not_exist)", None, id="avg_unknown_is_null"),
     ],
 )
+@pytest.mark.parametrize("attribute_backend", ["map", "json"])
 def test_traces_aggregate_unknown_key(
     signoz: types.SigNoz,
     create_user_admin: None,  # pylint: disable=unused-argument
     get_token: Callable[[str, str], str],
     insert_traces: Callable[[list[Traces]], None],
+    use_attribute_backend: Callable[[str], None],
+    attribute_backend: str,
     expression: str,
     expected_value: Any,
 ) -> None:
@@ -450,6 +476,8 @@ def test_traces_aggregate_unknown_key(
     Aggregating a bare unknown key synthesizes a null column: count() of it is 0
     (no non-null values) and sum()/avg() are null — the query never errors.
     """
+    use_attribute_backend(attribute_backend)
+
     now = datetime.now(tz=UTC).replace(second=0, microsecond=0)
     spans = [
         Traces(

--- a/tests/integration/tests/queriertraces/06_trace_operator.py
+++ b/tests/integration/tests/queriertraces/06_trace_operator.py
@@ -69,8 +69,6 @@ from fixtures.traces import (
 #   ob.select    A=>B order http.method DESC  → POST, POST, GET
 # ============================================================================
 
-pytestmark = pytest.mark.usefixtures("attribute_backend")
-
 
 @pytest.mark.parametrize(
     "case",
@@ -233,13 +231,18 @@ pytestmark = pytest.mark.usefixtures("attribute_backend")
         ),
     ],
 )
+@pytest.mark.parametrize("attribute_backend", ["map", "json"])
 def test_trace_operator(
     signoz: types.SigNoz,
     create_user_admin: None,  # pylint: disable=unused-argument
     get_token: Callable[[str, str], str],
     insert_traces: Callable[[list[Traces]], None],
+    use_attribute_backend: Callable[[str], None],
+    attribute_backend: str,
     case: dict,
 ) -> None:
+    use_attribute_backend(attribute_backend)
+
     t1_trace_id = TraceIdGenerator.trace_id()
     t1_checkout_span_id = TraceIdGenerator.span_id()  # POST /checkout — structural root of T1
     t1_child_span_id = TraceIdGenerator.span_id()  # lookup-cart
@@ -571,11 +574,14 @@ def test_trace_operator(
         ),
     ],
 )
+@pytest.mark.parametrize("attribute_backend", ["map", "json"])
 def test_trace_operator_with_adjusted_keys(
     signoz: types.SigNoz,
     create_user_admin: None,  # pylint: disable=unused-argument
     get_token: Callable[[str, str], str],
     insert_traces: Callable[[list[Traces]], None],
+    use_attribute_backend: Callable[[str], None],
+    attribute_backend: str,
     payload_factory: Callable[[list[Traces]], list[dict[str, Any]]],
     request_type: str,
     assert_result: Callable[[requests.Response, list[Traces]], None],
@@ -586,6 +592,8 @@ def test_trace_operator_with_adjusted_keys(
     queries, otherwise deprecated keys and context-prefixed aliases don't
     resolve.
     """
+    use_attribute_backend(attribute_backend)
+
     traces = generate_traces_with_corrupt_metadata()
     insert_traces(traces)
     payload = payload_factory(traces)
@@ -628,11 +636,14 @@ TRACE_OPERATOR_CORE_FIELDS = [
         ),
     ],
 )
+@pytest.mark.parametrize("attribute_backend", ["map", "json"])
 def test_trace_operator_select_fields(
     signoz: types.SigNoz,
     create_user_admin: None,  # pylint: disable=unused-argument
     get_token: Callable[[str, str], str],
     insert_traces: Callable[[list[Traces]], None],
+    use_attribute_backend: Callable[[str], None],
+    attribute_backend: str,
     select_fields: list[dict[str, Any]],
     expansion: str,
 ) -> None:
@@ -656,6 +667,8 @@ def test_trace_operator_select_fields(
     - pkg/telemetrytraces/trace_operator_cte_builder.go::buildListQuery for
       the per-row SELECT.
     """
+    use_attribute_backend(attribute_backend)
+
     now = datetime.now(tz=UTC).replace(second=0, microsecond=0)
 
     trace_id = TraceIdGenerator.trace_id()

--- a/tests/integration/tests/queriertraces/09_unknown_keys.py
+++ b/tests/integration/tests/queriertraces/09_unknown_keys.py
@@ -22,16 +22,19 @@ from fixtures.traces import TraceIdGenerator, Traces, TracesKind, TracesStatusCo
 # Existence is a property of the data, not of metadata, so the query runs against
 # synthesized type-variant columns (filter / group-by / select) instead of failing.
 
-pytestmark = pytest.mark.usefixtures("attribute_backend")
 
-
+@pytest.mark.parametrize("attribute_backend", ["map", "json"])
 def test_traces_filter_unknown_key_synthesizes(
     signoz: types.SigNoz,
     create_user_admin: None,  # pylint: disable=unused-argument
     get_token: Callable[[str, str], str],
+    use_attribute_backend: Callable[[str], None],
+    attribute_backend: str,
 ) -> None:
     """An unknown attribute key runs against synthesized columns and returns 200 with a
     "not found" warning so typos still surface."""
+    use_attribute_backend(attribute_backend)
+
     now = datetime.now(tz=UTC)
     token = get_token(USER_ADMIN_EMAIL, USER_ADMIN_PASSWORD)
     response = make_query_request(
@@ -54,15 +57,20 @@ def test_traces_filter_unknown_key_synthesizes(
     assert any("totally.unknown.key" in m and "not found" in m for m in messages), f"expected a key-not-found warning, got warnings={messages}"
 
 
+@pytest.mark.parametrize("attribute_backend", ["map", "json"])
 def test_traces_filter_unknown_resource_key_filters(
     signoz: types.SigNoz,
     create_user_admin: None,  # pylint: disable=unused-argument
     get_token: Callable[[str, str], str],
     insert_traces: Callable[[list[Traces]], None],
+    use_attribute_backend: Callable[[str], None],
+    attribute_backend: str,
 ) -> None:
     """A resource-qualified unknown key must FILTER (0 rows), not be dropped: the
     resource-fingerprint sub-query skips keys absent from metadata, so the synthesized
     condition stays in the main query. A regression here returns every span."""
+    use_attribute_backend(attribute_backend)
+
     now = datetime.now(tz=UTC)
     insert_traces(
         [
@@ -103,14 +111,19 @@ def test_traces_filter_unknown_resource_key_filters(
         assert len(get_rows(response)) == expected, f"{expression}: expected {expected} rows"
 
 
+@pytest.mark.parametrize("attribute_backend", ["map", "json"])
 def test_traces_group_by_unknown_key_null_bucket(
     signoz: types.SigNoz,
     create_user_admin: None,  # pylint: disable=unused-argument
     get_token: Callable[[str, str], str],
     insert_traces: Callable[[list[Traces]], None],
+    use_attribute_backend: Callable[[str], None],
+    attribute_backend: str,
 ) -> None:
     """Grouping by an unknown key runs against synthesized columns: every span lands in
     the NULL bucket instead of the query failing."""
+    use_attribute_backend(attribute_backend)
+
     now = datetime.now(tz=UTC)
     insert_traces(
         [

--- a/tests/integration/tests/queriertraces/10_filter_operators.py
+++ b/tests/integration/tests/queriertraces/10_filter_operators.py
@@ -27,8 +27,6 @@ from fixtures.traces import TraceIdGenerator, Traces, TracesKind, TracesStatusCo
 # single-typed here, so no collision-driven divergence arises and both physical layouts
 # must return identical spans — the parity contract for the JSON attribute rollout.
 
-pytestmark = pytest.mark.usefixtures("attribute_backend")
-
 
 @pytest.mark.parametrize(
     "expression,expected_names",
@@ -66,11 +64,14 @@ pytestmark = pytest.mark.usefixtures("attribute_backend")
         pytest.param("responseStatusCode >= 400", {"cart-handler", "payment-processor"}, id="deprecated_responseStatusCode"),
     ],
 )
+@pytest.mark.parametrize("attribute_backend", ["map", "json"])
 def test_traces_filter_operators(
     signoz: types.SigNoz,
     create_user_admin: None,  # pylint: disable=unused-argument
     get_token: Callable[[str, str], str],
     insert_traces: Callable[[list[Traces]], None],
+    use_attribute_backend: Callable[[str], None],
+    attribute_backend: str,
     expression: str,
     expected_names: set[str],
 ) -> None:
@@ -82,6 +83,8 @@ def test_traces_filter_operators(
     Tests:
     Each production-shaped filter operator selects exactly the expected spans.
     """
+    use_attribute_backend(attribute_backend)
+
     now = datetime.now(tz=UTC).replace(second=0, microsecond=0)
     # (name, service, deployment.environment, http.request.method, http.response.status_code, latency_ms, has_error_type)
     specs = [

--- a/tests/integration/tests/queriertraces/11_aggregation_depth.py
+++ b/tests/integration/tests/queriertraces/11_aggregation_depth.py
@@ -25,15 +25,16 @@ from fixtures.traces import TraceIdGenerator, Traces, TracesKind, TracesStatusCo
 # same-named colliding attribute must not divert grouping or aggregation off the real
 # intrinsic column.
 
-pytestmark = pytest.mark.usefixtures("attribute_backend")
-
 
 @pytest.mark.parametrize("noise", ["clean", "corrupt", "collision"])
+@pytest.mark.parametrize("attribute_backend", ["map", "json"])
 def test_traces_aggregate_percentiles(
     signoz: types.SigNoz,
     create_user_admin: None,  # pylint: disable=unused-argument
     get_token: Callable[[str, str], str],
     insert_traces: Callable[[list[Traces]], None],
+    use_attribute_backend: Callable[[str], None],
+    attribute_backend: str,
     noise: str,
 ) -> None:
     """
@@ -48,6 +49,8 @@ def test_traces_aggregate_percentiles(
     intrinsic column rather than error with ClickHouse NO_COMMON_TYPE (386) — the
     regression behind the span_percentile 500.
     """
+    use_attribute_backend(attribute_backend)
+
     extra_attrs, extra_resources = trace_noise(noise)
     now = datetime.now(tz=UTC).replace(second=0, microsecond=0)
     durations_s = [1, 2, 3, 4, 5]
@@ -92,11 +95,14 @@ def test_traces_aggregate_percentiles(
     ],
 )
 @pytest.mark.parametrize("noise", ["clean", "corrupt"])
+@pytest.mark.parametrize("attribute_backend", ["map", "json"])
 def test_traces_aggregate_group_by_non_resource(
     signoz: types.SigNoz,
     create_user_admin: None,  # pylint: disable=unused-argument
     get_token: Callable[[str, str], str],
     insert_traces: Callable[[list[Traces]], None],
+    use_attribute_backend: Callable[[str], None],
+    attribute_backend: str,
     noise: str,
     group_key: str,
     expected: dict[str, int],
@@ -110,6 +116,8 @@ def test_traces_aggregate_group_by_non_resource(
     not just a resource key — buckets by the real value; under the corrupt variant a
     same-named colliding attribute must not divert the grouping.
     """
+    use_attribute_backend(attribute_backend)
+
     extra_attrs, extra_resources = trace_noise(noise)
     now = datetime.now(tz=UTC).replace(second=0, microsecond=0)
     specs = [("op-a", "/a"), ("op-a", "/a"), ("op-b", "/b")]
@@ -143,11 +151,14 @@ def test_traces_aggregate_group_by_non_resource(
 
 
 @pytest.mark.parametrize("noise", ["clean", "corrupt"])
+@pytest.mark.parametrize("attribute_backend", ["map", "json"])
 def test_traces_aggregate_multi_group_by(
     signoz: types.SigNoz,
     create_user_admin: None,  # pylint: disable=unused-argument
     get_token: Callable[[str, str], str],
     insert_traces: Callable[[list[Traces]], None],
+    use_attribute_backend: Callable[[str], None],
+    attribute_backend: str,
     noise: str,
 ) -> None:
     """
@@ -159,6 +170,8 @@ def test_traces_aggregate_multi_group_by(
     Grouping by two keys (a resource key and an intrinsic column) returns one row per
     present pair with the correct per-pair count.
     """
+    use_attribute_backend(attribute_backend)
+
     extra_attrs, extra_resources = trace_noise(noise)
     now = datetime.now(tz=UTC).replace(second=0, microsecond=0)
     pair_counts = {("svc-1", "op-a"): 2, ("svc-1", "op-b"): 1, ("svc-2", "op-a"): 1}
@@ -205,11 +218,14 @@ def test_traces_aggregate_multi_group_by(
     ],
 )
 @pytest.mark.parametrize("noise", ["clean", "corrupt"])
+@pytest.mark.parametrize("attribute_backend", ["map", "json"])
 def test_traces_aggregate_having_breadth(
     signoz: types.SigNoz,
     create_user_admin: None,  # pylint: disable=unused-argument
     get_token: Callable[[str, str], str],
     insert_traces: Callable[[list[Traces]], None],
+    use_attribute_backend: Callable[[str], None],
+    attribute_backend: str,
     noise: str,
     having_expression: str,
     expected_services: set[str],
@@ -223,6 +239,8 @@ def test_traces_aggregate_having_breadth(
     each keep only the qualifying groups — extending the count()-only HAVING in
     02_aggregation.py.
     """
+    use_attribute_backend(attribute_backend)
+
     extra_attrs, extra_resources = trace_noise(noise)
     now = datetime.now(tz=UTC).replace(second=0, microsecond=0)
     specs = [("svc-a", 1), ("svc-a", 1), ("svc-a", 1), ("svc-b", 5)]
@@ -264,11 +282,14 @@ def test_traces_aggregate_having_breadth(
         pytest.param("duration_nano > 2000000000", id="raw_nanoseconds"),
     ],
 )
+@pytest.mark.parametrize("attribute_backend", ["map", "json"])
 def test_traces_duration_nano_qol_filter_with_collision(
     signoz: types.SigNoz,
     create_user_admin: None,  # pylint: disable=unused-argument
     get_token: Callable[[str, str], str],
     insert_traces: Callable[[list[Traces]], None],
+    use_attribute_backend: Callable[[str], None],
+    attribute_backend: str,
     duration_filter: str,
 ) -> None:
     """
@@ -282,6 +303,8 @@ def test_traces_duration_nano_qol_filter_with_collision(
     ClickHouse NO_COMMON_TYPE (386). The string attribute is cast; the intrinsic column
     stays a bare comparison.
     """
+    use_attribute_backend(attribute_backend)
+
     now = datetime.now(tz=UTC).replace(second=0, microsecond=0)
     durations_s = [1, 2, 3, 4, 5]
     spans = [


### PR DESCRIPTION
## Description

Alternative to the module-level `pytestmark = pytest.mark.usefixtures("attribute_backend")` mechanism, raised as its own PR against the feature branch so we can accept or reject it.

The current mechanism is magical in two ways the repo otherwise avoids: the `attribute_backend` fixture is a parametrized value-fixture (`request.param` — indirect parametrization) applied invisibly via a module-level `usefixtures`, so a test that runs under both backends never names the factor in its signature or body.

This makes the backend factor explicit per test:

- `attribute_backend` (the parametrized value-fixture) becomes `use_attribute_backend`, a fixture-factory that yields a callable — matching the repo's "fixture-factory over indirect parametrization" pytest convention.
- Each test in the five span-attribute suites (02/06/09/10/11) declares `@pytest.mark.parametrize("attribute_backend", ["map", "json"])` and calls `use_attribute_backend(attribute_backend)` once in its body.
- Teardown stays with `seed_attribute_evolution`; coverage is unchanged — both backends still cross the full noise factor (174 span-attribute cases, same as before).

Trade-off: a `@parametrize` decorator + one call line per test, and the noise-parametrized tests now stack two decorators. That repetition is the cost of removing the magic — the pytest rule accepts it ("repetition across tests is cheaper than indirection").

🤖 Generated with [Claude Code](https://claude.com/claude-code)
