### PR TITLE
fix(dashboard): honour "open in new tab" on v2 context links

### DIFF
--- a/frontend/src/pages/DashboardPage/DashboardContainer/Panels/utils/drilldown/__tests__/drilldown.test.ts
+++ b/frontend/src/pages/DashboardPage/DashboardContainer/Panels/utils/drilldown/__tests__/drilldown.test.ts
@@ -426,6 +426,30 @@ describe('resolvePanelContextLinks', () => {
 
 		expect(resolved[0].url).toBe('https://wiki/{{_service.name}}');
 	});
+
+	it('carries targetBlank through, defaulting to true when unset', () => {
+		const resolved = resolvePanelContextLinks(
+			[
+				{ name: 'Same tab', url: 'https://wiki/a', targetBlank: false },
+				{ name: 'New tab', url: 'https://wiki/b', targetBlank: true },
+				{ name: 'Unset', url: 'https://wiki/c' },
+				{
+					name: 'Literal',
+					url: 'https://wiki/d',
+					targetBlank: false,
+					renderVariables: false,
+				},
+			],
+			{},
+		);
+
+		expect(resolved.map((link) => link.targetBlank)).toStrictEqual([
+			false,
+			true,
+			true,
+			false,
+		]);
+	});
 });
 
 describe('stepClickTimeRange', () => {

--- a/frontend/src/pages/DashboardPage/DashboardContainer/Panels/utils/drilldown/resolvePanelContextLinks.ts
+++ b/frontend/src/pages/DashboardPage/DashboardContainer/Panels/utils/drilldown/resolvePanelContextLinks.ts
@@ -8,6 +8,8 @@ export interface ResolvedDrilldownLink {
 	id: string;
 	label: string;
 	url: string;
+	/** Opens in a new tab; links saved before the toggle existed default to true. */
+	targetBlank: boolean;
 }
 
 /**
@@ -26,14 +28,16 @@ export function resolvePanelContextLinks(
 	return usable.map((link, index) => {
 		const rawLabel = link.name || link.url || '';
 		const rawUrl = link.url ?? '';
+		const targetBlank = link.targetBlank ?? true;
 		// Only an explicit `false` opts out; undefined defaults to substitution on.
 		if (link.renderVariables === false) {
-			return { id: String(index), label: rawLabel, url: rawUrl };
+			return { id: String(index), label: rawLabel, url: rawUrl, targetBlank };
 		}
 		return {
 			id: String(index),
 			label: resolveTexts({ texts: [rawLabel], processedVariables }).fullTexts[0],
 			url: resolveContextLinkUrl(rawUrl, processedVariables),
+			targetBlank,
 		};
 	});
 }

--- a/frontend/src/pages/DashboardPage/DashboardContainer/PanelsAndSectionsLayout/Panel/DrilldownMenu/DrilldownAggregateMenu.tsx
+++ b/frontend/src/pages/DashboardPage/DashboardContainer/PanelsAndSectionsLayout/Panel/DrilldownMenu/DrilldownAggregateMenu.tsx
@@ -173,7 +173,7 @@ function DrilldownAggregateMenu({
 						void logEvent(DashboardDetailEvents.DrilldownAction, {
 							action: 'contextLink',
 						});
-						openInNewTab(link.url);
+						openInNewTab(link.url, !!link.targetBlank);
 						onClose();
 					}}
 				>

--- a/frontend/src/utils/navigation.ts
+++ b/frontend/src/utils/navigation.ts
@@ -1,5 +1,9 @@
 import { withBasePath } from 'utils/basePath';
 
-export const openInNewTab = (path: string): void => {
-	window.open(withBasePath(path), '_blank');
+export const openInNewTab = (path: string, newTab = true): void => {
+	if (newTab) {
+		window.open(withBasePath(path), '_blank');
+	} else {
+		window.location.assign(withBasePath(path));
+	}
 };


### PR DESCRIPTION
#### Description

- The panel editor persisted the "Open in new tab" toggle as `targetBlank`, but the drilldown menu dropped the field while resolving links and always called `openInNewTab`.
- `resolvePanelContextLinks` now carries `targetBlank` through (defaulting to `true` when unset, matching the editor default), and the menu branches on it.
- Added `openInSameTab` to `utils/navigation` so internal paths still get the base-path prefix and external URLs pass through unchanged.
- Auto-generated data links ("View Trace Details") keep opening in a new tab — they have no toggle.


Closes https://github.com/SigNoz/signoz/issues/12810