### PR TITLE
fix(alertmanager): prevent lost configuration updates during concurre…

### DIFF
--- a/pkg/alertmanager/alertmanagerstore/sqlalertmanagerstore/config.go
+++ b/pkg/alertmanager/alertmanagerstore/sqlalertmanagerstore/config.go
@@ -68,6 +68,43 @@ func (store *config) Set(ctx context.Context, config *alertmanagertypes.Config, 
 	}, opts...)
 }
 
+// SetIfHash implements optimistic concurrency control. It updates the config
+// only if the current hash in the database matches expectedHash. Returns
+// ErrCodeAlertmanagerConfigConflict if the hash does not match, indicating
+// a concurrent mutation has changed the config.
+func (store *config) SetIfHash(ctx context.Context, config *alertmanagertypes.Config, expectedHash string) error {
+	result, err := store.
+		sqlstore.
+		BunDBCtx(ctx).
+		NewUpdate().
+		Model(config.StoreableConfig()).
+		Where("org_id = ?", config.StoreableConfig().OrgID).
+		Where("hash = ?", expectedHash).
+		Set("config = ?", config.StoreableConfig().Config).
+		Set("hash = ?", config.StoreableConfig().Hash).
+		Set("updated_at = ?", config.StoreableConfig().UpdatedAt).
+		Exec(ctx)
+	if err != nil {
+		return err
+	}
+
+	rowsAffected, err := result.RowsAffected()
+	if err != nil {
+		return err
+	}
+
+	if rowsAffected == 0 {
+		return errors.Newf(
+			errors.TypeConflict,
+			alertmanagertypes.ErrCodeAlertmanagerConfigConflict,
+			"concurrent modification detected for org %s: config was changed by another request, please retry",
+			config.StoreableConfig().OrgID,
+		)
+	}
+
+	return nil
+}
+
 func (store *config) CreateChannel(ctx context.Context, channel *alertmanagertypes.Channel, opts ...alertmanagertypes.StoreOption) error {
 	return store.wrap(ctx, func(ctx context.Context) error {
 		if _, err := store.

--- a/pkg/alertmanager/signozalertmanager/provider.go
+++ b/pkg/alertmanager/signozalertmanager/provider.go
@@ -2,6 +2,7 @@ package signozalertmanager
 
 import (
 	"context"
+	"fmt"
 	"time"
 
 	amConfig "github.com/prometheus/alertmanager/config"
@@ -20,6 +21,12 @@ import (
 	"github.com/SigNoz/signoz/pkg/types/authtypes"
 	"github.com/SigNoz/signoz/pkg/types/ruletypes"
 	"github.com/SigNoz/signoz/pkg/valuer"
+)
+
+const (
+	// maxConfigRetries is the maximum number of retries for optimistic
+	// concurrency control when a concurrent modification is detected.
+	maxConfigRetries = 3
 )
 
 type provider struct {
@@ -178,22 +185,38 @@ func (provider *provider) UpdateChannelByReceiverAndID(ctx context.Context, orgI
 		return err
 	}
 
-	config, err := provider.configStore.Get(ctx, orgID)
-	if err != nil {
-		return err
+	var lastErr error
+
+	for attempt := 0; attempt < maxConfigRetries; attempt++ {
+		config, err := provider.configStore.Get(ctx, orgID)
+		if err != nil {
+			return err
+		}
+
+		expectedHash := config.StoreableConfig().Hash
+
+		if err := config.SetGlobalConfig(provider.config.Signoz.Global); err != nil {
+			return err
+		}
+
+		if err := config.UpdateReceiver(receiver); err != nil {
+			return err
+		}
+
+		if err := provider.configStore.UpdateChannel(ctx, orgID, channel, alertmanagertypes.WithCb(func(ctx context.Context) error {
+			return provider.configStore.SetIfHash(ctx, config, expectedHash)
+		})); err != nil {
+			if errors.Asc(err, alertmanagertypes.ErrCodeAlertmanagerConfigConflict) {
+				lastErr = err
+				continue
+			}
+			return err
+		}
+
+		return nil
 	}
 
-	if err := config.SetGlobalConfig(provider.config.Signoz.Global); err != nil {
-		return err
-	}
-
-	if err := config.UpdateReceiver(receiver); err != nil {
-		return err
-	}
-
-	return provider.configStore.UpdateChannel(ctx, orgID, channel, alertmanagertypes.WithCb(func(ctx context.Context) error {
-		return provider.configStore.Set(ctx, config)
-	}))
+	return fmt.Errorf("failed to update channel after %d attempts due to concurrent modifications: %w", maxConfigRetries, lastErr)
 }
 
 func (provider *provider) DeleteChannelByID(ctx context.Context, orgID string, channelID valuer.UUID) error {
@@ -217,47 +240,75 @@ func (provider *provider) DeleteChannelByID(ctx context.Context, orgID string, c
 			channel.DisplayName, names)
 	}
 
-	config, err := provider.configStore.Get(ctx, orgID)
-	if err != nil {
-		return err
+	var lastErr error
+
+	for attempt := 0; attempt < maxConfigRetries; attempt++ {
+		config, err := provider.configStore.Get(ctx, orgID)
+		if err != nil {
+			return err
+		}
+
+		expectedHash := config.StoreableConfig().Hash
+
+		if err := config.DeleteReceiver(channel.DisplayName); err != nil {
+			return err
+		}
+
+		if err := provider.configStore.DeleteChannelByID(ctx, orgID, channelID, alertmanagertypes.WithCb(func(ctx context.Context) error {
+			return provider.configStore.SetIfHash(ctx, config, expectedHash)
+		})); err != nil {
+			if errors.Asc(err, alertmanagertypes.ErrCodeAlertmanagerConfigConflict) {
+				lastErr = err
+				continue
+			}
+			return err
+		}
+
+		return nil
 	}
 
-	if err := config.DeleteReceiver(channel.DisplayName); err != nil {
-		return err
-	}
-
-	return provider.configStore.DeleteChannelByID(ctx, orgID, channelID, alertmanagertypes.WithCb(func(ctx context.Context) error {
-		return provider.configStore.Set(ctx, config)
-	}))
+	return fmt.Errorf("failed to delete channel after %d attempts due to concurrent modifications: %w", maxConfigRetries, lastErr)
 }
 
 func (provider *provider) CreateChannel(ctx context.Context, orgID string, receiver *alertmanagertypes.Receiver) (*alertmanagertypes.Channel, error) {
-	config, err := provider.configStore.Get(ctx, orgID)
-	if err != nil {
-		return nil, err
+	var lastErr error
+
+	for attempt := 0; attempt < maxConfigRetries; attempt++ {
+		config, err := provider.configStore.Get(ctx, orgID)
+		if err != nil {
+			return nil, err
+		}
+
+		expectedHash := config.StoreableConfig().Hash
+
+		if err := config.SetGlobalConfig(provider.config.Signoz.Global); err != nil {
+			return nil, err
+		}
+
+		if err := config.CreateReceiver(receiver); err != nil {
+			return nil, err
+		}
+
+		channel, err := alertmanagertypes.NewChannelFromReceiver(receiver, orgID)
+		if err != nil {
+			return nil, err
+		}
+
+		err = provider.configStore.CreateChannel(ctx, channel, alertmanagertypes.WithCb(func(ctx context.Context) error {
+			return provider.configStore.SetIfHash(ctx, config, expectedHash)
+		}))
+		if err != nil {
+			if errors.Asc(err, alertmanagertypes.ErrCodeAlertmanagerConfigConflict) {
+				lastErr = err
+				continue
+			}
+			return nil, err
+		}
+
+		return channel, nil
 	}
 
-	if err := config.SetGlobalConfig(provider.config.Signoz.Global); err != nil {
-		return nil, err
-	}
-
-	if err := config.CreateReceiver(receiver); err != nil {
-		return nil, err
-	}
-
-	channel, err := alertmanagertypes.NewChannelFromReceiver(receiver, orgID)
-	if err != nil {
-		return nil, err
-	}
-
-	err = provider.configStore.CreateChannel(ctx, channel, alertmanagertypes.WithCb(func(ctx context.Context) error {
-		return provider.configStore.Set(ctx, config)
-	}))
-	if err != nil {
-		return nil, err
-	}
-
-	return channel, nil
+	return nil, fmt.Errorf("failed to create channel after %d attempts due to concurrent modifications: %w", maxConfigRetries, lastErr)
 }
 
 func (provider *provider) CreateNotificationChannel(ctx context.Context, orgID string, postable alertmanagertypes.PostableNotificationChannel) (*alertmanagertypes.Channel, error) {
@@ -266,32 +317,44 @@ func (provider *provider) CreateNotificationChannel(ctx context.Context, orgID s
 		return nil, err
 	}
 
-	config, err := provider.configStore.Get(ctx, orgID)
-	if err != nil {
-		return nil, err
+	var lastErr error
+
+	for attempt := 0; attempt < maxConfigRetries; attempt++ {
+		config, err := provider.configStore.Get(ctx, orgID)
+		if err != nil {
+			return nil, err
+		}
+
+		expectedHash := config.StoreableConfig().Hash
+
+		if err := config.SetGlobalConfig(provider.config.Signoz.Global); err != nil {
+			return nil, err
+		}
+
+		if err := config.CreateReceiverV2(receiver); err != nil {
+			return nil, err
+		}
+
+		channel, err := alertmanagertypes.NewChannelFromReceiverWithName(receiver, postable.Name, orgID)
+		if err != nil {
+			return nil, err
+		}
+
+		err = provider.configStore.CreateChannel(ctx, channel, alertmanagertypes.WithCb(func(ctx context.Context) error {
+			return provider.configStore.SetIfHash(ctx, config, expectedHash)
+		}))
+		if err != nil {
+			if errors.Asc(err, alertmanagertypes.ErrCodeAlertmanagerConfigConflict) {
+				lastErr = err
+				continue
+			}
+			return nil, err
+		}
+
+		return channel, nil
 	}
 
-	if err := config.SetGlobalConfig(provider.config.Signoz.Global); err != nil {
-		return nil, err
-	}
-
-	if err := config.CreateReceiverV2(receiver); err != nil {
-		return nil, err
-	}
-
-	channel, err := alertmanagertypes.NewChannelFromReceiverWithName(receiver, postable.Name, orgID)
-	if err != nil {
-		return nil, err
-	}
-
-	err = provider.configStore.CreateChannel(ctx, channel, alertmanagertypes.WithCb(func(ctx context.Context) error {
-		return provider.configStore.Set(ctx, config)
-	}))
-	if err != nil {
-		return nil, err
-	}
-
-	return channel, nil
+	return nil, fmt.Errorf("failed to create notification channel after %d attempts due to concurrent modifications: %w", maxConfigRetries, lastErr)
 }
 
 // UpdateNotificationChannel replaces the channel's configuration. The display
@@ -312,26 +375,38 @@ func (provider *provider) UpdateNotificationChannel(ctx context.Context, orgID s
 		return nil, err
 	}
 
-	config, err := provider.configStore.Get(ctx, orgID)
-	if err != nil {
-		return nil, err
+	var lastErr error
+
+	for attempt := 0; attempt < maxConfigRetries; attempt++ {
+		config, err := provider.configStore.Get(ctx, orgID)
+		if err != nil {
+			return nil, err
+		}
+
+		expectedHash := config.StoreableConfig().Hash
+
+		if err := config.SetGlobalConfig(provider.config.Signoz.Global); err != nil {
+			return nil, err
+		}
+
+		if err := config.UpdateReceiver(receiver); err != nil {
+			return nil, err
+		}
+
+		if err := provider.configStore.UpdateChannel(ctx, orgID, channel, alertmanagertypes.WithCb(func(ctx context.Context) error {
+			return provider.configStore.SetIfHash(ctx, config, expectedHash)
+		})); err != nil {
+			if errors.Asc(err, alertmanagertypes.ErrCodeAlertmanagerConfigConflict) {
+				lastErr = err
+				continue
+			}
+			return nil, err
+		}
+
+		return channel, nil
 	}
 
-	if err := config.SetGlobalConfig(provider.config.Signoz.Global); err != nil {
-		return nil, err
-	}
-
-	if err := config.UpdateReceiver(receiver); err != nil {
-		return nil, err
-	}
-
-	if err := provider.configStore.UpdateChannel(ctx, orgID, channel, alertmanagertypes.WithCb(func(ctx context.Context) error {
-		return provider.configStore.Set(ctx, config)
-	})); err != nil {
-		return nil, err
-	}
-
-	return channel, nil
+	return nil, fmt.Errorf("failed to update notification channel after %d attempts due to concurrent modifications: %w", maxConfigRetries, lastErr)
 }
 
 func (provider *provider) TestNotificationChannel(ctx context.Context, orgID string, testable alertmanagertypes.TestableNotificationChannel) error {

--- a/pkg/types/alertmanagertypes/config.go
+++ b/pkg/types/alertmanagertypes/config.go
@@ -589,6 +589,11 @@ type ConfigStore interface {
 	// Set creates or updates a config.
 	Set(context.Context, *Config, ...StoreOption) error
 
+	// SetIfHash updates the config only if the current hash in the database
+	// matches expectedHash. Returns ErrCodeAlertmanagerConfigConflict if the
+	// hash does not match, indicating a concurrent mutation.
+	SetIfHash(context.Context, *Config, string) error
+
 	// Get returns the config for the given orgID
 	Get(context.Context, string) (*Config, error)
 


### PR DESCRIPTION
…nt channel mutations

Concurrent mutations of different notification channels within the same organization can both succeed while one mutation is lost from the effective Alertmanager configuration. This is a race condition caused by reading the configuration outside the transaction, allowing concurrent requests to get stale snapshots.

This fix implements optimistic concurrency control using the existing hash field:

1. Added SetIfHash method to ConfigStore that verifies the hash hasn't changed before writing, returning ErrCodeAlertmanagerConfigConflict if a concurrent modification is detected.

2. Updated all channel mutation methods (CreateChannel, CreateNotificationChannel, UpdateNotificationChannel, DeleteChannelByID, UpdateChannelByReceiverAndID) to use retry logic with optimistic locking.

3. Each retry reads the latest config, captures its hash, performs the modification, and writes only if the hash matches. On conflict, the operation retries with the fresh config.

Fixes #12825

<!--A few plain bullets saying what changed and why, for a reviewer skimming it - not a wall of text, not a restatement of the diff, not generated boilerplate.-->
#### Description

<!--Reference issues using `Closes #issue-number` to enable automatic closure on merge. -->
#### Issues closed by this PR

<!--If applicable, include screenshots or screen recordings that clearly show the behavior before the change and the result after the change. -->
#### Screenshots / Screen Recordings

<!--Anything reviewers should keep in mind while reviewing -->
#### Additional Information

<!--Please delete paragraphs that you did not use before submitting.-->
