### PR TITLE
fix(contextlinks): carry every builder query into the explorer link

### DIFF
--- a/pkg/contextlinks/alert_link_visitor.go
+++ b/pkg/contextlinks/alert_link_visitor.go
@@ -42,6 +42,21 @@ type WhereClauseRewriter struct {
 // by clause, in which case we replace it with the actual value for the notification
 // i.e Severity text = WARN
 // If the Severity text is not part of the group by clause, then we add it as it is.
+// PrepareFilterExpressions returns one filter expression per builder query. A
+// caller whose rule has no builder query for the signal passes none and gets a
+// single expression built from the labels alone.
+func PrepareFilterExpressions(labels map[string]string, builderQueries []BuilderQuery) []string {
+	if len(builderQueries) == 0 {
+		return []string{PrepareFilterExpression(labels, "", nil)}
+	}
+
+	expressions := make([]string, 0, len(builderQueries))
+	for _, builderQuery := range builderQueries {
+		expressions = append(expressions, PrepareFilterExpression(labels, builderQuery.Filter, builderQuery.GroupBy))
+	}
+	return expressions
+}
+
 func PrepareFilterExpression(labels map[string]string, whereClause string, groupByItems []qbtypes.GroupByKey) string {
 	if whereClause == "" && len(labels) == 0 {
 		return ""

--- a/pkg/contextlinks/links.go
+++ b/pkg/contextlinks/links.go
@@ -11,34 +11,47 @@ import (
 )
 
 // PrepareParamsForTracesV5 returns the traces explorer query params for the
-// given range and filter; the traces explorer writes its time params in
-// nanoseconds. queryType is builder_ai_query for the AI observability explorer.
-func PrepareParamsForTracesV5(start, end time.Time, whereClause string, queryType qbtypes.QueryType) url.Values {
-	return prepareExplorerParams("traces", queryType, start.UnixNano(), end.UnixNano(), whereClause)
+// given range and filters, one explorer query per filter; the traces explorer
+// writes its time params in nanoseconds. queryType is builder_ai_query for the
+// AI observability explorer.
+func PrepareParamsForTracesV5(start, end time.Time, whereClauses []string, queryType qbtypes.QueryType) url.Values {
+	return prepareExplorerParams("traces", queryType, start.UnixNano(), end.UnixNano(), whereClauses)
 }
 
 // PrepareParamsForLogsV5 returns the logs explorer query params for the given
-// range and filter; the logs explorer writes its time params in milliseconds.
-func PrepareParamsForLogsV5(start, end time.Time, whereClause string) url.Values {
-	return prepareExplorerParams("logs", qbtypes.QueryTypeBuilder, start.UnixMilli(), end.UnixMilli(), whereClause)
+// range and filters, one explorer query per filter; the logs explorer writes
+// its time params in milliseconds.
+func PrepareParamsForLogsV5(start, end time.Time, whereClauses []string) url.Values {
+	return prepareExplorerParams("logs", qbtypes.QueryTypeBuilder, start.UnixMilli(), end.UnixMilli(), whereClauses)
 }
 
 // The end link is double encoded because otherwise a filter expression with `%` somewhere in it breaks.
-func prepareExplorerParams(dataSource string, queryType qbtypes.QueryType, start, end int64, whereClause string) url.Values {
+func prepareExplorerParams(dataSource string, queryType qbtypes.QueryType, start, end int64, whereClauses []string) url.Values {
 	// builder_query is the explorer default, so it is left out to keep existing links unchanged
 	builderQueryType := ""
 	if queryType != qbtypes.QueryTypeBuilder {
 		builderQueryType = queryType.StringValue()
 	}
 
+	// the explorer needs a query to render; an unfiltered one is the meaningful
+	// fallback when the caller has no filter to carry over
+	if len(whereClauses) == 0 {
+		whereClauses = []string{""}
+	}
+
+	queryData := make([]LinkQuery, 0, len(whereClauses))
+	for _, whereClause := range whereClauses {
+		queryData = append(queryData, LinkQuery{
+			DataSource:       dataSource,
+			BuilderQueryType: builderQueryType,
+			Filter:           &FilterExpression{Expression: whereClause},
+		})
+	}
+
 	urlData := URLShareableCompositeQuery{
 		QueryType: "builder",
 		Builder: URLShareableBuilderQuery{
-			QueryData: []LinkQuery{{
-				DataSource:       dataSource,
-				BuilderQueryType: builderQueryType,
-				Filter:           &FilterExpression{Expression: whereClause},
-			}},
+			QueryData:     queryData,
 			QueryFormulas: make([]string, 0),
 		},
 	}
@@ -52,40 +65,40 @@ func prepareExplorerParams(dataSource string, queryType qbtypes.QueryType, start
 	return params
 }
 
-// BuilderQueryForSignal returns the filter expression and group-by keys of the
-// builder query for the given signal, or found=false when the composite query
-// has no builder query for it (e.g. PromQL or ClickHouse SQL alerts). AI trace
-// queries (builder_ai_query) count as trace builder queries.
-// TODO(srikanthccv): re-visit this and support multiple queries.
-func BuilderQueryForSignal(queries []qbtypes.QueryEnvelope, signal telemetrytypes.Signal) (string, []qbtypes.GroupByKey, bool) {
+// BuilderQueriesForSignal returns the filter expression and group-by keys of
+// every builder query for the given signal, in the order they appear in the
+// composite query, or found=false when it has none (e.g. PromQL or ClickHouse
+// SQL alerts). AI trace queries (builder_ai_query) count as trace builder
+// queries.
+func BuilderQueriesForSignal(queries []qbtypes.QueryEnvelope, signal telemetrytypes.Signal) ([]BuilderQuery, bool) {
 	switch signal {
 	case telemetrytypes.SignalLogs:
-		return builderQueryForSignal[qbtypes.LogAggregation](queries, signal)
+		return builderQueriesForSignal[qbtypes.LogAggregation](queries, signal)
 	case telemetrytypes.SignalTraces:
-		return builderQueryForSignal[qbtypes.TraceAggregation](queries, signal)
+		return builderQueriesForSignal[qbtypes.TraceAggregation](queries, signal)
 	}
-	return "", nil, false
+	return nil, false
 }
 
-func builderQueryForSignal[T any](queries []qbtypes.QueryEnvelope, signal telemetrytypes.Signal) (string, []qbtypes.GroupByKey, bool) {
-	var q qbtypes.QueryBuilderQuery[T]
-	found := false
+func builderQueriesForSignal[T any](queries []qbtypes.QueryEnvelope, signal telemetrytypes.Signal) ([]BuilderQuery, bool) {
+	matches := make([]BuilderQuery, 0, len(queries))
 	for _, query := range queries {
 		if query.Type != qbtypes.QueryTypeBuilder && query.Type != qbtypes.QueryTypeBuilderAI {
 			continue
 		}
-		if spec, ok := query.Spec.(qbtypes.QueryBuilderQuery[T]); ok {
-			q = spec
-			found = true
+		spec, ok := query.Spec.(qbtypes.QueryBuilderQuery[T])
+		if !ok || spec.Signal != signal {
+			continue
 		}
-	}
-	if !found || q.Signal != signal {
-		return "", nil, false
-	}
 
-	filterExpr := ""
-	if q.Filter != nil {
-		filterExpr = q.Filter.Expression
+		filterExpr := ""
+		if spec.Filter != nil {
+			filterExpr = spec.Filter.Expression
+		}
+		matches = append(matches, BuilderQuery{Filter: filterExpr, GroupBy: spec.GroupBy})
 	}
-	return filterExpr, q.GroupBy, true
+	if len(matches) == 0 {
+		return nil, false
+	}
+	return matches, true
 }

--- a/pkg/contextlinks/links_test.go
+++ b/pkg/contextlinks/links_test.go
@@ -1,7 +1,10 @@
 package contextlinks
 
 import (
+	"encoding/json"
+	"net/url"
 	"testing"
+	"time"
 
 	qbtypes "github.com/SigNoz/signoz/pkg/types/querybuildertypes/querybuildertypesv5"
 	"github.com/SigNoz/signoz/pkg/types/telemetrytypes"
@@ -9,7 +12,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestBuilderQueryForSignal(t *testing.T) {
+func TestBuilderQueriesForSignal(t *testing.T) {
 	logQuery := qbtypes.QueryEnvelope{
 		Type: qbtypes.QueryTypeBuilder,
 		Spec: qbtypes.QueryBuilderQuery[qbtypes.LogAggregation]{
@@ -19,11 +22,28 @@ func TestBuilderQueryForSignal(t *testing.T) {
 			GroupBy: []qbtypes.GroupByKey{{TelemetryFieldKey: telemetrytypes.TelemetryFieldKey{Name: "service.name"}}},
 		},
 	}
+	secondLogQuery := qbtypes.QueryEnvelope{
+		Type: qbtypes.QueryTypeBuilder,
+		Spec: qbtypes.QueryBuilderQuery[qbtypes.LogAggregation]{
+			Name:    "B",
+			Signal:  telemetrytypes.SignalLogs,
+			Filter:  &qbtypes.Filter{Expression: "severity_text = 'WARN'"},
+			GroupBy: []qbtypes.GroupByKey{{TelemetryFieldKey: telemetrytypes.TelemetryFieldKey{Name: "host.name"}}},
+		},
+	}
 	traceQuery := qbtypes.QueryEnvelope{
 		Type: qbtypes.QueryTypeBuilder,
 		Spec: qbtypes.QueryBuilderQuery[qbtypes.TraceAggregation]{
 			Name:   "B",
 			Signal: telemetrytypes.SignalTraces,
+		},
+	}
+	secondTraceQuery := qbtypes.QueryEnvelope{
+		Type: qbtypes.QueryTypeBuilder,
+		Spec: qbtypes.QueryBuilderQuery[qbtypes.TraceAggregation]{
+			Name:   "C",
+			Signal: telemetrytypes.SignalTraces,
+			Filter: &qbtypes.Filter{Expression: "http.status_code >= 500"},
 		},
 	}
 	promQuery := qbtypes.QueryEnvelope{
@@ -41,40 +61,135 @@ func TestBuilderQueryForSignal(t *testing.T) {
 	}
 
 	t.Run("logs query among mixed queries", func(t *testing.T) {
-		filterExpr, groupBy, found := BuilderQueryForSignal([]qbtypes.QueryEnvelope{promQuery, logQuery, traceQuery}, telemetrytypes.SignalLogs)
+		builderQueries, found := BuilderQueriesForSignal([]qbtypes.QueryEnvelope{promQuery, logQuery, traceQuery}, telemetrytypes.SignalLogs)
 		require.True(t, found)
-		assert.Equal(t, "severity_text = 'ERROR'", filterExpr)
-		require.Len(t, groupBy, 1)
-		assert.Equal(t, "service.name", groupBy[0].Name)
+		require.Len(t, builderQueries, 1)
+		assert.Equal(t, "severity_text = 'ERROR'", builderQueries[0].Filter)
+		require.Len(t, builderQueries[0].GroupBy, 1)
+		assert.Equal(t, "service.name", builderQueries[0].GroupBy[0].Name)
+	})
+
+	t.Run("every logs query is returned in composite query order", func(t *testing.T) {
+		builderQueries, found := BuilderQueriesForSignal([]qbtypes.QueryEnvelope{promQuery, logQuery, secondLogQuery, traceQuery}, telemetrytypes.SignalLogs)
+		require.True(t, found)
+		require.Len(t, builderQueries, 2)
+		assert.Equal(t, "severity_text = 'ERROR'", builderQueries[0].Filter)
+		assert.Equal(t, "severity_text = 'WARN'", builderQueries[1].Filter)
+		require.Len(t, builderQueries[1].GroupBy, 1)
+		assert.Equal(t, "host.name", builderQueries[1].GroupBy[0].Name)
+	})
+
+	t.Run("every traces query is returned in composite query order", func(t *testing.T) {
+		builderQueries, found := BuilderQueriesForSignal([]qbtypes.QueryEnvelope{traceQuery, secondTraceQuery}, telemetrytypes.SignalTraces)
+		require.True(t, found)
+		require.Len(t, builderQueries, 2)
+		assert.Empty(t, builderQueries[0].Filter)
+		assert.Equal(t, "http.status_code >= 500", builderQueries[1].Filter)
 	})
 
 	t.Run("traces query without filter", func(t *testing.T) {
-		filterExpr, groupBy, found := BuilderQueryForSignal([]qbtypes.QueryEnvelope{logQuery, traceQuery}, telemetrytypes.SignalTraces)
+		builderQueries, found := BuilderQueriesForSignal([]qbtypes.QueryEnvelope{logQuery, traceQuery}, telemetrytypes.SignalTraces)
 		require.True(t, found)
-		assert.Empty(t, filterExpr)
-		assert.Empty(t, groupBy)
+		require.Len(t, builderQueries, 1)
+		assert.Empty(t, builderQueries[0].Filter)
+		assert.Empty(t, builderQueries[0].GroupBy)
 	})
 
 	t.Run("ai trace query counts as traces", func(t *testing.T) {
-		filterExpr, groupBy, found := BuilderQueryForSignal([]qbtypes.QueryEnvelope{logQuery, aiTraceQuery}, telemetrytypes.SignalTraces)
+		builderQueries, found := BuilderQueriesForSignal([]qbtypes.QueryEnvelope{logQuery, aiTraceQuery}, telemetrytypes.SignalTraces)
 		require.True(t, found)
-		assert.Equal(t, "trace.input_tokens > 1000", filterExpr)
-		require.Len(t, groupBy, 1)
-		assert.Equal(t, "session.id", groupBy[0].Name)
+		require.Len(t, builderQueries, 1)
+		assert.Equal(t, "trace.input_tokens > 1000", builderQueries[0].Filter)
+		require.Len(t, builderQueries[0].GroupBy, 1)
+		assert.Equal(t, "session.id", builderQueries[0].GroupBy[0].Name)
 	})
 
 	t.Run("no builder query for signal", func(t *testing.T) {
-		_, _, found := BuilderQueryForSignal([]qbtypes.QueryEnvelope{traceQuery}, telemetrytypes.SignalLogs)
+		_, found := BuilderQueriesForSignal([]qbtypes.QueryEnvelope{traceQuery}, telemetrytypes.SignalLogs)
 		assert.False(t, found)
 	})
 
 	t.Run("no builder queries at all", func(t *testing.T) {
-		_, _, found := BuilderQueryForSignal([]qbtypes.QueryEnvelope{promQuery}, telemetrytypes.SignalLogs)
+		_, found := BuilderQueriesForSignal([]qbtypes.QueryEnvelope{promQuery}, telemetrytypes.SignalLogs)
 		assert.False(t, found)
 	})
 
 	t.Run("unsupported signal", func(t *testing.T) {
-		_, _, found := BuilderQueryForSignal([]qbtypes.QueryEnvelope{logQuery}, telemetrytypes.SignalMetrics)
+		_, found := BuilderQueriesForSignal([]qbtypes.QueryEnvelope{logQuery}, telemetrytypes.SignalMetrics)
 		assert.False(t, found)
 	})
+}
+
+func TestPrepareFilterExpressions(t *testing.T) {
+	labels := map[string]string{"service.name": "checkout"}
+
+	t.Run("one expression per builder query", func(t *testing.T) {
+		expressions := PrepareFilterExpressions(labels, []BuilderQuery{
+			{Filter: "severity_text = 'ERROR'"},
+			{Filter: "severity_text = 'WARN'"},
+		})
+		require.Len(t, expressions, 2)
+		assert.Contains(t, expressions[0], "severity_text='ERROR'")
+		assert.Contains(t, expressions[1], "severity_text='WARN'")
+	})
+
+	t.Run("no builder query still yields a labels only expression", func(t *testing.T) {
+		expressions := PrepareFilterExpressions(map[string]string{"host.name": "web-1"}, nil)
+		require.Len(t, expressions, 1)
+		assert.Equal(t, "host.name='web-1'", expressions[0])
+	})
+}
+
+func TestPrepareParamsQueryData(t *testing.T) {
+	start := time.UnixMilli(1700000000000)
+	end := time.UnixMilli(1700000600000)
+
+	t.Run("one logs explorer query per filter", func(t *testing.T) {
+		params := PrepareParamsForLogsV5(start, end, []string{"severity_text='ERROR'", "severity_text='WARN'"})
+		queryData := decodeQueryData(t, params)
+
+		require.Len(t, queryData, 2)
+		assert.Equal(t, "logs", queryData[0].DataSource)
+		assert.Equal(t, "severity_text='ERROR'", queryData[0].Filter.Expression)
+		assert.Equal(t, "severity_text='WARN'", queryData[1].Filter.Expression)
+	})
+
+	t.Run("one traces explorer query per filter", func(t *testing.T) {
+		params := PrepareParamsForTracesV5(start, end, []string{"name='GET /a'", "name='GET /b'"}, qbtypes.QueryTypeBuilder)
+		queryData := decodeQueryData(t, params)
+
+		require.Len(t, queryData, 2)
+		assert.Equal(t, "traces", queryData[0].DataSource)
+		assert.Equal(t, "name='GET /a'", queryData[0].Filter.Expression)
+		assert.Equal(t, "name='GET /b'", queryData[1].Filter.Expression)
+	})
+
+	t.Run("ai trace query type is carried on every query", func(t *testing.T) {
+		params := PrepareParamsForTracesV5(start, end, []string{"a='1'", "b='2'"}, qbtypes.QueryTypeBuilderAI)
+		queryData := decodeQueryData(t, params)
+
+		require.Len(t, queryData, 2)
+		for _, query := range queryData {
+			assert.Equal(t, qbtypes.QueryTypeBuilderAI.StringValue(), query.BuilderQueryType)
+		}
+	})
+
+	t.Run("no filter still yields one explorer query", func(t *testing.T) {
+		params := PrepareParamsForLogsV5(start, end, nil)
+		queryData := decodeQueryData(t, params)
+
+		require.Len(t, queryData, 1)
+		assert.Empty(t, queryData[0].Filter.Expression)
+	})
+}
+
+func decodeQueryData(t *testing.T, params url.Values) []LinkQuery {
+	t.Helper()
+
+	raw, err := url.QueryUnescape(params.Get("compositeQuery"))
+	require.NoError(t, err)
+
+	var composite URLShareableCompositeQuery
+	require.NoError(t, json.Unmarshal([]byte(raw), &composite))
+	return composite.Builder.QueryData
 }

--- a/pkg/contextlinks/types.go
+++ b/pkg/contextlinks/types.go
@@ -1,6 +1,7 @@
 package contextlinks
 
 import (
+	qbtypes "github.com/SigNoz/signoz/pkg/types/querybuildertypes/querybuildertypesv5"
 	"github.com/SigNoz/signoz/pkg/types/ruletypes"
 )
 
@@ -8,6 +9,13 @@ import (
 
 type FilterExpression struct {
 	Expression string `json:"expression,omitempty"`
+}
+
+// BuilderQuery is the part of an alert's builder query that carries over into
+// an explorer link.
+type BuilderQuery struct {
+	Filter  string
+	GroupBy []qbtypes.GroupByKey
 }
 
 // LinkQuery carries the only fields the explorer pages read from a shared

--- a/pkg/modules/rulestatehistory/implrulestatehistory/links.go
+++ b/pkg/modules/rulestatehistory/implrulestatehistory/links.go
@@ -17,10 +17,9 @@ import (
 // filter and the entry's labels, so a history entry can be opened in the
 // explorer with the context that produced it.
 type relatedLinkBuilder struct {
-	alertType  ruletypes.AlertType
-	evaluation ruletypes.Evaluation
-	filterExpr string
-	groupBy    []qbtypes.GroupByKey
+	alertType      ruletypes.AlertType
+	evaluation     ruletypes.Evaluation
+	builderQueries []contextlinks.BuilderQuery
 }
 
 // relatedLinkBuilderForRule returns nil when the rule cannot be loaded or is
@@ -65,7 +64,7 @@ func (m *module) relatedLinkBuilderForRule(ctx context.Context, orgID valuer.UUI
 
 	// links are still built from the labels alone when the rule has no builder
 	// query for the signal (e.g. ClickHouse SQL alerts)
-	builder.filterExpr, builder.groupBy, _ = contextlinks.BuilderQueryForSignal(rule.RuleCondition.CompositeQuery.Queries, signal)
+	builder.builderQueries, _ = contextlinks.BuilderQueriesForSignal(rule.RuleCondition.CompositeQuery.Queries, signal)
 
 	return builder
 }
@@ -89,15 +88,15 @@ func (b *relatedLinkBuilder) links(labels rulestatehistorytypes.LabelsString, st
 		return rulestatehistorytypes.RelatedLinks{}
 	}
 
-	whereClause := contextlinks.PrepareFilterExpression(lbls, b.filterExpr, b.groupBy)
+	whereClauses := contextlinks.PrepareFilterExpressions(lbls, b.builderQueries)
 
 	switch b.alertType {
 	case ruletypes.AlertTypeLogs:
-		return rulestatehistorytypes.RelatedLinks{RelatedLogsLink: contextlinks.PrepareParamsForLogsV5(start, end, whereClause).Encode()}
+		return rulestatehistorytypes.RelatedLinks{RelatedLogsLink: contextlinks.PrepareParamsForLogsV5(start, end, whereClauses).Encode()}
 	case ruletypes.AlertTypeTraces:
-		return rulestatehistorytypes.RelatedLinks{RelatedTracesLink: contextlinks.PrepareParamsForTracesV5(start, end, whereClause, qbtypes.QueryTypeBuilder).Encode()}
+		return rulestatehistorytypes.RelatedLinks{RelatedTracesLink: contextlinks.PrepareParamsForTracesV5(start, end, whereClauses, qbtypes.QueryTypeBuilder).Encode()}
 	case ruletypes.AlertTypeAITraces:
-		return rulestatehistorytypes.RelatedLinks{RelatedAITracesLink: contextlinks.PrepareParamsForTracesV5(start, end, whereClause, qbtypes.QueryTypeBuilderAI).Encode()}
+		return rulestatehistorytypes.RelatedLinks{RelatedAITracesLink: contextlinks.PrepareParamsForTracesV5(start, end, whereClauses, qbtypes.QueryTypeBuilderAI).Encode()}
 	}
 	return rulestatehistorytypes.RelatedLinks{}
 }

--- a/pkg/query-service/app/http_handler.go
+++ b/pkg/query-service/app/http_handler.go
@@ -66,6 +66,7 @@ import (
 	"github.com/SigNoz/signoz/pkg/types/pipelinetypes"
 	qbtypes "github.com/SigNoz/signoz/pkg/types/querybuildertypes/querybuildertypesv5"
 	"github.com/SigNoz/signoz/pkg/types/ruletypes"
+	"github.com/SigNoz/signoz/pkg/types/telemetrytypes"
 	traceFunnels "github.com/SigNoz/signoz/pkg/types/tracefunneltypes"
 
 	"github.com/SigNoz/signoz/pkg/query-service/app/integrations/messagingQueues/kafka"
@@ -810,46 +811,15 @@ func (aH *APIHandler) getRuleStateHistory(w http.ResponseWriter, r *http.Request
 			// to get the correct query range
 			start := end.Add(-rule.EvalWindow.Duration() - 3*time.Minute)
 			if rule.AlertType == ruletypes.AlertTypeLogs {
-				// TODO(srikanthccv): re-visit this and support multiple queries
-				var q qbtypes.QueryBuilderQuery[qbtypes.LogAggregation]
+				builderQueries, _ := contextlinks.BuilderQueriesForSignal(rule.RuleCondition.CompositeQuery.Queries, telemetrytypes.SignalLogs)
+				whereClauses := contextlinks.PrepareFilterExpressions(lbls, builderQueries)
 
-				for _, query := range rule.RuleCondition.CompositeQuery.Queries {
-					if query.Type == qbtypes.QueryTypeBuilder {
-						switch spec := query.Spec.(type) {
-						case qbtypes.QueryBuilderQuery[qbtypes.LogAggregation]:
-							q = spec
-						}
-					}
-				}
-
-				filterExpr := ""
-				if q.Filter != nil && q.Filter.Expression != "" {
-					filterExpr = q.Filter.Expression
-				}
-
-				whereClause := contextlinks.PrepareFilterExpression(lbls, filterExpr, q.GroupBy)
-
-				res.Items[idx].RelatedLogsLink = contextlinks.PrepareParamsForLogsV5(start, end, whereClause).Encode()
+				res.Items[idx].RelatedLogsLink = contextlinks.PrepareParamsForLogsV5(start, end, whereClauses).Encode()
 			} else if rule.AlertType == ruletypes.AlertTypeTraces || rule.AlertType == ruletypes.AlertTypeAITraces {
-				// TODO(srikanthccv): re-visit this and support multiple queries
-				var q qbtypes.QueryBuilderQuery[qbtypes.TraceAggregation]
+				builderQueries, _ := contextlinks.BuilderQueriesForSignal(rule.RuleCondition.CompositeQuery.Queries, telemetrytypes.SignalTraces)
+				whereClauses := contextlinks.PrepareFilterExpressions(lbls, builderQueries)
 
-				for _, query := range rule.RuleCondition.CompositeQuery.Queries {
-					if query.Type == qbtypes.QueryTypeBuilder || query.Type == qbtypes.QueryTypeBuilderAI {
-						switch spec := query.Spec.(type) {
-						case qbtypes.QueryBuilderQuery[qbtypes.TraceAggregation]:
-							q = spec
-						}
-					}
-				}
-
-				filterExpr := ""
-				if q.Filter != nil && q.Filter.Expression != "" {
-					filterExpr = q.Filter.Expression
-				}
-
-				whereClause := contextlinks.PrepareFilterExpression(lbls, filterExpr, q.GroupBy)
-				res.Items[idx].RelatedTracesLink = contextlinks.PrepareParamsForTracesV5(start, end, whereClause, rule.AlertType.BuilderQueryType()).Encode()
+				res.Items[idx].RelatedTracesLink = contextlinks.PrepareParamsForTracesV5(start, end, whereClauses, rule.AlertType.BuilderQueryType()).Encode()
 			}
 		}
 	}

--- a/pkg/query-service/rules/threshold_rule.go
+++ b/pkg/query-service/rules/threshold_rule.go
@@ -100,14 +100,14 @@ func (r *ThresholdRule) prepareParamsForLogs(ctx context.Context, ts time.Time, 
 		return nil
 	}
 
-	filterExpr, groupBy, found := contextlinks.BuilderQueryForSignal(r.ruleCondition.CompositeQuery.Queries, telemetrytypes.SignalLogs)
+	builderQueries, found := contextlinks.BuilderQueriesForSignal(r.ruleCondition.CompositeQuery.Queries, telemetrytypes.SignalLogs)
 	if !found {
 		return nil
 	}
 
-	whereClause := contextlinks.PrepareFilterExpression(lbls.Map(), filterExpr, groupBy)
+	whereClauses := contextlinks.PrepareFilterExpressions(lbls.Map(), builderQueries)
 
-	return contextlinks.PrepareParamsForLogsV5(start, end, whereClause)
+	return contextlinks.PrepareParamsForLogsV5(start, end, whereClauses)
 }
 
 func (r *ThresholdRule) prepareParamsForTraces(ctx context.Context, ts time.Time, lbls ruletypes.Labels) url.Values {
@@ -125,14 +125,14 @@ func (r *ThresholdRule) prepareParamsForTraces(ctx context.Context, ts time.Time
 		return nil
 	}
 
-	filterExpr, groupBy, found := contextlinks.BuilderQueryForSignal(r.ruleCondition.CompositeQuery.Queries, telemetrytypes.SignalTraces)
+	builderQueries, found := contextlinks.BuilderQueriesForSignal(r.ruleCondition.CompositeQuery.Queries, telemetrytypes.SignalTraces)
 	if !found {
 		return nil
 	}
 
-	whereClause := contextlinks.PrepareFilterExpression(lbls.Map(), filterExpr, groupBy)
+	whereClauses := contextlinks.PrepareFilterExpressions(lbls.Map(), builderQueries)
 
-	return contextlinks.PrepareParamsForTracesV5(start, end, whereClause, r.typ.BuilderQueryType())
+	return contextlinks.PrepareParamsForTracesV5(start, end, whereClauses, r.typ.BuilderQueryType())
 }
 
 func (r *ThresholdRule) buildAndRunQuery(ctx context.Context, orgID valuer.UUID, ts time.Time) (ruletypes.Vector, error) {


### PR DESCRIPTION
#### Description

- An alert rule can hold more than one builder query for a signal, but the lookup behind the related logs/traces links only produced one. It overwrote its single match on each iteration, so a rule with two log queries carried the last one's filter and silently dropped the other — the click-through from a fired alert landed in the explorer with a filter the rule never had.
- `BuilderQueryForSignal` becomes `BuilderQueriesForSignal` and returns every match in composite-query order; `PrepareParamsForLogsV5` / `PrepareParamsForTracesV5` take a filter per query and emit one `LinkQuery` each. `Builder.QueryData` was already a list in the URL format, so nothing changes on the wire or in the frontend.
- The signal check now runs per query instead of against the last match only. Previously a trailing query for another signal could suppress an otherwise valid result.
- `getRuleStateHistory` in `http_handler.go` carried an inlined copy of the same lookup with the same defect, under the same TODO. It now calls the shared helper, which removes the duplication along with the bug.
- Rule state history links go through the same path, so they pick this up too. When a rule has no builder query for the signal (ClickHouse SQL alerts) the link is still built from the labels alone, as before.

#### Issues closed by this PR

Closes #12562

#### Additional Information

- New tests cover multi-query logs and traces, the per-query `LinkQuery` output for both explorers, and the no-builder-query fallback. The existing `BuilderQueryForSignal` cases are carried over unchanged apart from the new signature.
- `go vet` and `go test -race -count=1 -short` are clean on `./pkg/contextlinks/...`, `./pkg/query-service/rules/...`, `./pkg/query-service/app/...` and `./pkg/modules/rulestatehistory/...`.
